### PR TITLE
Card table titles

### DIFF
--- a/src/app/pages/account/groups/group-list/group-list.component.ts
+++ b/src/app/pages/account/groups/group-list/group-list.component.ts
@@ -5,10 +5,11 @@ import {RestService} from '../../../../services/rest.service';
 
 @Component({
   selector : 'app-group-list',
-  template : `<entity-table [conf]="this"></entity-table>`
+  template : `<entity-table [title]="title" [conf]="this"></entity-table>`
 })
 export class GroupListComponent {
 
+  public title = "Groups";
   protected resource_name: string = 'account/groups/';
   protected route_add: string[] = ['account', 'groups', 'add' ];
   protected route_add_tooltip: string = "Add Group";

--- a/src/app/pages/account/users/user-list/user-list.component.ts
+++ b/src/app/pages/account/users/user-list/user-list.component.ts
@@ -5,10 +5,11 @@ import { TourService } from '../../../../services/tour.service';
 
 @Component({
   selector: 'app-user-list',
-  template: `<entity-table [conf]="this"></entity-table>`
+  template: `<entity-table [title]="title" [conf]="this"></entity-table>`
 })
 export class UserListComponent implements OnInit {
 
+  public title = "Users";
   protected resource_name: string = 'account/users';
   protected route_add: string[] = ['account', 'users', 'add'];
   protected route_add_tooltip: string = "Add User";

--- a/src/app/pages/common/entity/entity-table/entity-table.component.html
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.html
@@ -1,42 +1,45 @@
-  <ngx-datatable
-    [ngBusy]="busy"
-    class="material ml-1 mt-1 mb-1 mr-1 mat-box-shadow" 
-    id="ngx-datatable"
-    [rows]="rows" 
-    [columns]="conf.columns" 
-    [headerHeight]="50" 
-    [rowHeight]="50"
-    [footerHeight]="50" 
-    [columnMode]="'force'" 
-    [limit]="conf.config.pageLimit ? conf.config.pageLimit : 25" 
-    [selectionType]="conf.config.selectionType ? conf.config.selectionType : ''"
-  >
-  <ngx-datatable-column
-    [width]="conf.config.width ? conf.config.width : 50"
-    [sortable]="conf.config.sortable ? conf.config.sortable : false"
-    [canAutoResize]="conf.config.canAutoResize ? conf.config.canAutoResize : false"
-    [draggable]="conf.config.draggable ? conf.config.draggable : false"
-    [resizeable]="conf.config.resizeable ? conf.config : false"
-    [checkboxable]="conf.config.selectionType ? true : false">
-  </ngx-datatable-column>
+<div class="material mat-card mat-card-table">
+	<div class="mat-toolbar mat-card-toolbar">
+		<div class="mat-card-title-text">{{ title }}</div>
+		<app-entity-table-add-actions [entity]="this"></app-entity-table-add-actions>
+	</div>
 
-  <div *ngFor="let col of conf.columns">
-    <ngx-datatable-column 
-      prop="{{col.prop}}" 
-      name="{{col.name}}">
-    </ngx-datatable-column>
-  </div>
+	<ngx-datatable
+		 [ngBusy]="busy"
+		 class="material ml-1 mt-1 mb-1 mr-1 " 
+	 id="ngx-datatable"
+	[rows]="rows" 
+	[columns]="conf.columns" 
+	[headerHeight]="50" 
+	[rowHeight]="50"
+	[footerHeight]="50" 
+	[columnMode]="'force'" 
+	[limit]="conf.config.pageLimit ? conf.config.pageLimit : 25" 
+	[selectionType]="conf.config.selectionType ? conf.config.selectionType : ''"
+	>
+	<ngx-datatable-column
+	[width]="conf.config.width ? conf.config.width : 50"
+	[sortable]="conf.config.sortable ? conf.config.sortable : false"
+	[canAutoResize]="conf.config.canAutoResize ? conf.config.canAutoResize : false"
+	[draggable]="conf.config.draggable ? conf.config.draggable : false"
+	[resizeable]="conf.config.resizeable ? conf.config : false"
+	[checkboxable]="conf.config.selectionType ? true : false">
+	</ngx-datatable-column>
 
-  <ngx-datatable-column prop=" " [width]="25" >
-    <ng-template let-row="row" ngx-datatable-cell-template>
-    <app-entity-table-actions [entity]="this" [row]="row">
-    </app-entity-table-actions>
+		<div *ngFor="let col of conf.columns">
+			<ngx-datatable-column 
+	prop="{{col.prop}}" 
+ name="{{col.name}}">
+			</ngx-datatable-column>
+		</div>
 
-    </ng-template>
-  </ngx-datatable-column>
-  </ngx-datatable>
+		<ngx-datatable-column prop=" " [width]="25" >
+			<ng-template let-row="row" ngx-datatable-cell-template>
+				<app-entity-table-actions [entity]="this" [row]="row">
+				</app-entity-table-actions>
 
-<div>
+			</ng-template>
+		</ngx-datatable-column>
+	</ngx-datatable>
 
-  <app-entity-table-add-actions [entity]="this"></app-entity-table-add-actions>
 </div>

--- a/src/app/pages/common/entity/entity-table/entity-table.component.ts
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.ts
@@ -23,7 +23,8 @@ import { AppLoaderService } from '../../../../services/app-loader/app-loader.ser
   providers: [DialogService]
 })
 export class EntityTableComponent implements OnInit {
-
+  
+  @Input() title:string = '';
   @Input('conf') conf: any;
 
   public busy: Subscription;

--- a/src/app/pages/common/entity/fab-speed-dial/fab-speed-dial.scss
+++ b/src/app/pages/common/entity/fab-speed-dial/fab-speed-dial.scss
@@ -28,7 +28,7 @@ smd-fab-speed-dial {
   display: inline-block;
   position: absolute;
   right: 66px;
-  bottom: 6px;
+  top: 34px;
 
   &.smd-opened {
     .smd-fab-speed-dial-container {

--- a/src/app/pages/common/entity/fab-speed-dial/fab-speed-dial.scss
+++ b/src/app/pages/common/entity/fab-speed-dial/fab-speed-dial.scss
@@ -29,6 +29,7 @@ smd-fab-speed-dial {
   position: absolute;
   right: 66px;
   top: 34px;
+  z-index:2;
 
   &.smd-opened {
     .smd-fab-speed-dial-container {

--- a/src/app/pages/jails/jail-list/jail-list.component.ts
+++ b/src/app/pages/jails/jail-list/jail-list.component.ts
@@ -3,24 +3,14 @@ import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 
 @Component({
-<<<<<<< Updated upstream
   selector: 'app-jail-list',
-  template: `<entity-table [conf]="this"></entity-table>`
-})
-export class JailListComponent {
-
-  protected queryCall = 'jail.query';
-  protected route_add: string[] = ['jails', 'add'];
-=======
-  selector : 'app-jail-list',
-  template : `<entity-table [title]="title" [conf]="this"></entity-table>`
+  template: `<entity-table [title]="title" [conf]="this"></entity-table>`
 })
 export class JailListComponent {
 
   public title = "Instances";
-  protected resource_name = 'jails/jails';
-  protected route_add: string[] = [ 'jails', 'add' ];
->>>>>>> Stashed changes
+  protected queryCall = 'jail.query';
+  protected route_add: string[] = ['jails', 'add'];
   protected route_add_tooltip = "Add Jail";
   protected wsDelete = 'jail.do_delete';
   protected entityList: any;

--- a/src/app/pages/jails/jail-list/jail-list.component.ts
+++ b/src/app/pages/jails/jail-list/jail-list.component.ts
@@ -3,6 +3,7 @@ import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 
 @Component({
+<<<<<<< Updated upstream
   selector: 'app-jail-list',
   template: `<entity-table [conf]="this"></entity-table>`
 })
@@ -10,6 +11,16 @@ export class JailListComponent {
 
   protected queryCall = 'jail.query';
   protected route_add: string[] = ['jails', 'add'];
+=======
+  selector : 'app-jail-list',
+  template : `<entity-table [title]="title" [conf]="this"></entity-table>`
+})
+export class JailListComponent {
+
+  public title = "Instances";
+  protected resource_name = 'jails/jails';
+  protected route_add: string[] = [ 'jails', 'add' ];
+>>>>>>> Stashed changes
   protected route_add_tooltip = "Add Jail";
   protected wsDelete = 'jail.do_delete';
   protected entityList: any;

--- a/src/app/pages/jails/storages/storage-list/storage-list.component.ts
+++ b/src/app/pages/jails/storages/storage-list/storage-list.component.ts
@@ -3,10 +3,11 @@ import { Router } from '@angular/router';
 
 @Component({
   selector : 'app-storage-list',
-  template : `<entity-table [conf]="this"></entity-table>`
+  template : `<entity-table [title]="title" [conf]="this"></entity-table>`
 })
 export class StorageListComponent {
 
+  public title = "Storage";
   protected resource_name: string = 'jails/mountpoints';
   protected route_add: string[] = [ 'jails', 'storage', 'add' ];
   protected route_add_tooltip: string = "Add Storage";

--- a/src/app/pages/jails/templates/template-list/template-list.component.ts
+++ b/src/app/pages/jails/templates/template-list/template-list.component.ts
@@ -3,10 +3,11 @@ import { Router } from '@angular/router';
 
 @Component({
   selector : 'app-jail-template-list',
-  template : `<entity-table [conf]="this"></entity-table>`
+  template : `<entity-table [title]="title" [conf]="this"></entity-table>`
 })
 export class TemplateListComponent {
 
+  public title = "Templates";
   protected resource_name: string = 'jails/templates';
   protected route_add: string[] = [ 'jails', 'templates', 'add' ];
   protected route_add_tooltip: string = "Add Template";

--- a/src/app/pages/network/interfaces/interfaces-list/interfaces-list.component.ts
+++ b/src/app/pages/network/interfaces/interfaces-list/interfaces-list.component.ts
@@ -5,10 +5,11 @@ import {RestService} from '../../../../services/rest.service';
 
 @Component({
   selector : 'app-interfaces-list',
-  template : `<entity-table [conf]="this"></entity-table>`
+  template : `<entity-table [title]="title" [conf]="this"></entity-table>`
 })
 export class InterfacesListComponent {
 
+  public title = "Interfaces";
   protected resource_name: string = 'network/interface/';
   protected route_add: string[] = [ 'network', 'interfaces', 'add' ];
   protected route_add_tooltip: string = "Add Interface";

--- a/src/app/pages/network/laggs/lagg-list/lagg-list.component.ts
+++ b/src/app/pages/network/laggs/lagg-list/lagg-list.component.ts
@@ -7,10 +7,11 @@ import {EntityUtils} from '../../../common/entity/utils';
 
 @Component({
   selector : 'app-lagg-list',
-  template : `<entity-table [conf]="this"></entity-table>`
+  template : `<entity-table [title]="title" [conf]="this"></entity-table>`
 })
 export class LaggListComponent {
 
+  public title = "Link Aggregation";
   protected resource_name: string = 'network/lagg/';
   protected route_add: string[] = [ 'network', 'laggs', 'add' ];
   protected route_add_tooltip: string = "Add Link Aggregation";

--- a/src/app/pages/network/staticroutes/staticroute-list/staticroute-list.component.ts
+++ b/src/app/pages/network/staticroutes/staticroute-list/staticroute-list.component.ts
@@ -5,10 +5,11 @@ import {RestService} from '../../../../services/rest.service';
 
 @Component({
   selector : 'app-staticroute-list',
-  template : `<entity-table [conf]="this"></entity-table>`
+  template : `<entity-table [title]="title" [conf]="this"></entity-table>`
 })
 export class StaticRouteListComponent {
 
+  public title = "Static Routes";
   protected resource_name: string = 'network/staticroute/';
   protected route_add: string[] = [ 'network', 'staticroutes', 'add' ];
   protected route_add_tooltip: string = "Add Static Route";

--- a/src/app/pages/network/vlans/vlan-list/vlan-list.component.ts
+++ b/src/app/pages/network/vlans/vlan-list/vlan-list.component.ts
@@ -5,10 +5,11 @@ import {RestService} from '../../../../services/rest.service';
 
 @Component({
   selector : 'app-vlan-list',
-  template : `<entity-table [conf]="this"></entity-table>`
+  template : `<entity-table [title]="title" [conf]="this"></entity-table>`
 })
 export class VlanListComponent {
 
+  public title = "Vlans";
   protected resource_name: string = 'network/vlan/';
   protected route_add: string[] = [ 'network', 'vlans', 'add' ];
   protected route_add_tooltip: string = "Add VLAN";

--- a/src/app/pages/reportsdashboard/reportsdashboard.html
+++ b/src/app/pages/reportsdashboard/reportsdashboard.html
@@ -1,5 +1,5 @@
 <div id="dashboardcontainerdiv">
-	<md-tab-group *ngIf="drawTabs" (selectChange)="tabSelectChangeHandler($event)">
+	<md-tab-group class="tab-header-fixed" *ngIf="drawTabs" (selectChange)="tabSelectChangeHandler($event)">
 		<md-tab *ngFor="let tabChartsMappingDataItem of tabChartsMappingDataArray" label="{{ tabChartsMappingDataItem.keyName }}">
 			<div *ngIf="tabChartsMappingDataSelected.keyName === tabChartsMappingDataItem.keyName">
 				

--- a/src/app/pages/sharing/afp/afp-list/afp-list.component.ts
+++ b/src/app/pages/sharing/afp/afp-list/afp-list.component.ts
@@ -5,10 +5,11 @@ import {RestService} from '../../../../services/rest.service';
 
 @Component({
   selector : 'app-afp-list',
-  template : `<entity-table [conf]="this"></entity-table>`
+  template : `<entity-table [title]="title" [conf]="this"></entity-table>`
 })
 export class AFPListComponent {
 
+  public title = "AFP (Apple File Protocol)";
   protected resource_name: string = 'sharing/afp/';
   protected route_add: string[] = [ 'sharing', 'afp', 'add' ];
   protected route_add_tooltip: string = "Add Apple (AFP) Share";

--- a/src/app/pages/sharing/nfs/nfs-list/nfs-list.component.ts
+++ b/src/app/pages/sharing/nfs/nfs-list/nfs-list.component.ts
@@ -2,10 +2,11 @@ import { Component } from '@angular/core';
 
 @Component({
   selector : 'app-nfs-list',
-  template : `<entity-table [conf]="this"></entity-table>`
+  template : `<entity-table [title]="title" [conf]="this"></entity-table>`
 })
 export class NFSListComponent {
 
+  public title = "NFS";
   protected resource_name: string = 'sharing/nfs/';
   protected route_add: string[] = [ 'sharing', 'nfs', 'add' ];
   protected route_add_tooltip: string = "Add Unix (NFS) Share";

--- a/src/app/pages/sharing/smb/smb-list/smb-list.component.ts
+++ b/src/app/pages/sharing/smb/smb-list/smb-list.component.ts
@@ -3,10 +3,11 @@ import { Router } from '@angular/router';
  
 @Component({
   selector : 'app-smb-list',
-  template : `<entity-table [conf]="this"></entity-table>`
+  template : `<entity-table [title]="title" [conf]="this"></entity-table>`
 })
 export class SMBListComponent {
 
+  public title = "Samba";
   protected resource_name: string = 'sharing/cifs/';
   protected route_add: string[] = [ 'sharing', 'smb', 'add' ];
   protected route_add_tooltip: string = "Add Windows (SMB) Share";

--- a/src/app/pages/sharing/webdav/webdav-list/webdav-list.component.ts
+++ b/src/app/pages/sharing/webdav/webdav-list/webdav-list.component.ts
@@ -7,10 +7,12 @@ import { RestService } from '../../../../services/rest.service';
 
 @Component({
   selector : 'webdav-list',
-  template : `<entity-table [conf]="this"></entity-table>`
+  template : `<entity-table [title]="title" [conf]="this"></entity-table>`
 })
 
 export class WebdavListComponent {
+
+    public title = "WebDAV";
     protected resource_name: string = 'sharing/webdav';
     public busy: Subscription;
     public sub: Subscription;

--- a/src/app/pages/storage/snapshots/snapshot-list/snapshot-list.component.ts
+++ b/src/app/pages/storage/snapshots/snapshot-list/snapshot-list.component.ts
@@ -6,10 +6,11 @@ import {RestService} from '../../../../services/rest.service';
 
 @Component({
   selector : 'app-snapshot-list',
-  template : `<entity-table [conf]="this"></entity-table>`
+  template : `<entity-table [title]="title" [conf]="this"></entity-table>`
 })
 export class SnapshotListComponent {
 
+  public title = "Snapshots";
   protected resource_name: string = 'storage/snapshot';
   protected entityList: any;
 

--- a/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
@@ -6,10 +6,11 @@ import filesize from 'filesize';
 
 @Component({
   selector : 'app-volumes-list',
-  template : `<entity-table [conf]="this"></entity-table>`
+  template : `<entity-table [title]="title" [conf]="this"></entity-table>`
 })
 export class VolumesListComponent implements OnInit {
 
+  public title = "Volumes";
   protected resource_name: string = 'storage/volume/';
   protected route_add: string[] = [ 'storage', 'volumes', 'manager' ];
   protected route_add_tooltip: string = "Volume Manager";

--- a/src/app/pages/system/CloudCredentials/CloudCredentials-list/CloudCredentials-list.component.ts
+++ b/src/app/pages/system/CloudCredentials/CloudCredentials-list/CloudCredentials-list.component.ts
@@ -7,9 +7,11 @@ import { RestService, WebSocketService } from '../../../../services/';
 
 @Component({
   selector : 'app-cloudcredentials-list',
-  template: `<entity-table [conf]="this"></entity-table>`
+  template: `<entity-table [title]="title" [conf]="this"></entity-table>`
 })
 export class CloudCredentialsListComponent {
+
+  public title = "Cloud Credentials";
   protected queryCall = 'backup.credential.query';
   protected route_delete: string[] = [ 'system', 'ntpservers', 'delete' ];
   protected route_success: string[] = [ 'system', 'ntpservers' ];

--- a/src/app/pages/system/alertservice/alertservice-list/alertservice-list.component.ts
+++ b/src/app/pages/system/alertservice/alertservice-list/alertservice-list.component.ts
@@ -7,9 +7,11 @@ import { RestService, WebSocketService } from '../../../../services/';
 
 @Component({
   selector : 'app-alertservice-list',
-  template: `<entity-table [conf]="this"></entity-table>`
+  template: `<entity-table [title]="title" [conf]="this"></entity-table>`
 })
 export class AlertServiceListComponent {
+
+  public title = "Alert Service";
   protected resource_name = 'system/ntpserver';
   protected route_delete: string[] = [ 'system', 'ntpservers', 'delete' ];
   protected route_success: string[] = [ 'system', 'ntpservers' ];

--- a/src/app/pages/system/bootenv/bootenv-list/bootenv-list.component.ts
+++ b/src/app/pages/system/bootenv/bootenv-list/bootenv-list.component.ts
@@ -6,10 +6,11 @@ import {RestService} from '../../../../services/rest.service';
 
 @Component({
   selector : 'app-bootenv-list',
-  template : `<entity-table [conf]="this"></entity-table>`
+  template : `<entity-table [title]="title" [conf]="this"></entity-table>`
 })
 export class BootEnvironmentListComponent {
 
+  public title = "Boot Environments";
   protected resource_name: string = 'system/bootenv';
   protected route_delete: string[] = [ 'system', 'bootenv', 'delete' ];
   protected entityList: any;

--- a/src/app/pages/system/ca/ca-list/ca-list.component.ts
+++ b/src/app/pages/system/ca/ca-list/ca-list.component.ts
@@ -6,10 +6,12 @@ import { RestService, WebSocketService } from '../../../../services/';
 
 @Component({
   selector: 'ca-list',
-  template: `<entity-table [conf]="this"></entity-table>`
+  template: `<entity-table [title]="title" [conf]="this"></entity-table>`
 })
 
 export class CertificateAuthorityListComponent {
+
+  public title = "Certificate Authorities";
   protected resource_name: string = 'system/certificateauthority';
   protected route_delete: string[] = ['system', 'ca', 'delete'];
   protected route_edit: string[] = ['system', 'ca', 'edit'];

--- a/src/app/pages/system/certificates/certificate-list/certificate-list.component.ts
+++ b/src/app/pages/system/certificates/certificate-list/certificate-list.component.ts
@@ -7,11 +7,12 @@ import { RestService, WebSocketService } from '../../../../services/';
 
 @Component({
   selector: 'certificate-list',
-  template: `<entity-table [conf]="this"></entity-table>`
+  template: `<entity-table [title]="title" [conf]="this"></entity-table>`
 })
 
 export class CertificateListComponent {
 
+  public title = "Certificates";
   protected resource_name: string = 'system/certificate';
   protected route_delete: string[] = ['system', 'certificates', 'delete'];
   protected route_edit: string[] = ['system', 'certificates', 'edit'];

--- a/src/app/pages/system/ntpservers/ntpserver-list/ntpserver-list.component.ts
+++ b/src/app/pages/system/ntpservers/ntpserver-list/ntpserver-list.component.ts
@@ -2,10 +2,11 @@ import {Component} from '@angular/core';
 
 @Component({
   selector : 'app-ntpserver-list',
-  template: `<entity-table [conf]="this"></entity-table>`
+  template: `<entity-table [title]="title" [conf]="this"></entity-table>`
 })
 export class NTPServerListComponent {
 
+  public title = "NTP Servers";
   protected resource_name: string = 'system/ntpserver';
   protected route_add: string[] = [ 'system', 'ntpservers', 'add' ];
   protected route_edit: string[] = [ 'system', 'ntpservers', 'edit' ];

--- a/src/app/pages/system/tunable/tunable-list/tunable-list.component.ts
+++ b/src/app/pages/system/tunable/tunable-list/tunable-list.component.ts
@@ -6,11 +6,12 @@ import { RestService, WebSocketService } from '../../../../services/';
 
 @Component({
   selector: 'system-tunables-list',
-  template: `<entity-table [conf]="this"></entity-table>`
+  template: `<entity-table [title]="title" [conf]="this"></entity-table>`
 })
 
 export class TunableListComponent {
 
+  public title = "Tunables";
   protected resource_name: string = 'system/tunable';
   protected route_delete: string[] = ['system', 'tunable', 'delete'];
   protected route_edit: string[] = ['system', 'tunable', 'edit'];

--- a/src/app/pages/task-calendar/cron/cron-list/cron-list.component.ts
+++ b/src/app/pages/task-calendar/cron/cron-list/cron-list.component.ts
@@ -7,11 +7,12 @@ import { TaskService } from '../../../../services/';
 
 @Component({
   selector: 'app-cron-list',
-  template: `<entity-table [conf]="this"></entity-table>`,
+  template: `<entity-table [title]="title" [conf]="this"></entity-table>`,
   providers: [TaskService]
 })
 export class CronListComponent {
 
+  public title = "Cron Jobs";
   protected resource_name = 'tasks/cronjob';
   protected route_add: string[] = ['tasks', 'cron', 'add'];
   protected route_add_tooltip = "Add Cron Job";

--- a/src/app/pages/task-calendar/initshutdown/initshutdown-list/initshutdown-list.component.ts
+++ b/src/app/pages/task-calendar/initshutdown/initshutdown-list/initshutdown-list.component.ts
@@ -7,11 +7,12 @@ import { TaskService } from '../../../../services/';
 
 @Component({
   selector: 'app-initshutdown-list',
-  template: `<entity-table [conf]="this"></entity-table>`,
+  template: `<entity-table [title]="title" [conf]="this"></entity-table>`,
   providers: [TaskService]
 })
 export class InitshutdownListComponent {
 
+  public title = "Init/Shutdown Scripts"
   protected resource_name = 'tasks/initshutdown';
   protected route_add: string[] = ['tasks', 'initshutdown', 'add'];
   protected route_add_tooltip = "Add Init/Shutdown Scripts";

--- a/src/app/pages/task-calendar/snapshot/snapshot-list/snapshot-list.component.ts
+++ b/src/app/pages/task-calendar/snapshot/snapshot-list/snapshot-list.component.ts
@@ -7,11 +7,12 @@ import { TaskService } from '../../../../services/';
 
 @Component({
   selector: 'app-snapshot-task-list',
-  template: `<entity-table [conf]="this"></entity-table>`,
+  template: `<entity-table [title]="title" [conf]="this"></entity-table>`,
   providers: [TaskService]
 })
 export class SnapshotListComponent {
 
+  public title = "Snapshots";
   protected resource_name = 'storage/task';
   protected route_add: string[] = ['tasks', 'snapshot', 'add'];
   protected route_add_tooltip = "Add Periodic Snapshot Task";

--- a/src/app/pages/vm/vm-list/vm-list.component.html
+++ b/src/app/pages/vm/vm-list/vm-list.component.html
@@ -1,9 +1,9 @@
-<md-tab-group>
+<md-tab-group class="tab-header-fixed">
     <md-tab label="Card View">
         <entity-card [conf]="this"></entity-card>
     </md-tab>
     <md-tab label="Table View">
-        <entity-table [conf]="this"></entity-table>
+        <entity-table [title]="title" [conf]="this"></entity-table>
     </md-tab>
 
 </md-tab-group>

--- a/src/app/pages/vm/vm-list/vm-list.component.ts
+++ b/src/app/pages/vm/vm-list/vm-list.component.ts
@@ -25,6 +25,7 @@ export class VmListComponent {
 
   constructor(protected router: Router, protected rest: RestService,
               protected ws: WebSocketService) {}
+  public title = "Virtual Machines"
 
   public columns: Array<any> = [
     {name : 'Name', prop : 'name', card: true},

--- a/src/assets/styles/egret_overrides.css
+++ b/src/assets/styles/egret_overrides.css
@@ -28,7 +28,7 @@ app-breadcrumb{
 }
 
 /* Tabbed navigation is fixed too */
-.mat-tab-header{
+.tab-header-fixed .mat-tab-header{
     overflow: hidden;
     position: fixed !important;
     top:104px;
@@ -42,4 +42,23 @@ app-breadcrumb{
     padding:64px 16px 16px;
 }
 
+/* Cards & Tables */
+.mat-card{
+  margin:24px;/* This will be deprecated once Grid System is implemented*/
+}
 
+.mat-card-table{
+  padding:0 !important;
+}
+
+.mat-card-table .ngx-datatable{
+  margin:0 !important;
+}
+
+ngx-datatable .mat-box-shadow{
+  box-shadow:none;
+}
+
+.mat-card-title-text{
+  margin:16px;
+}


### PR DESCRIPTION
**CSS Conflict Resolution:**
I added some style rules to egret-overrides.css and a class selector to any page that uses entity-table selector and needs the tab header fixed to top of page.

**FAB Buttons (WIP):**
For now it is stuck to top right hand corner of parent element. For cards and tables, I added a title/toolbar area to the element. This branch gives FABs a home on cards, but FABS will still need more work in the following areas ...

- Not every control needs to be a FAB button. 
- FAB buttons with only a single action shouldn't require a hover or click to be presented to the user
- As per the material design spec, FAB buttons should also have different animations when sliding between tabs. Meaning the FAB should not slide with the tab.
