### PR TITLE
Adding an error dialog component, Ticket: #24180

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -14,6 +14,7 @@ import { RoutePartsService } from './services/route-parts/route-parts.service';
 import { NavigationService } from "./services/navigation/navigation.service";
 import { AuthService } from './services/auth/auth.service';
 import { ConfirmDialog } from './pages/common/confirm-dialog/confirm-dialog.component';
+import { ErrorDialog } from './pages/common/error-dialog/error-dialog.component';
 import { AboutModalDialog } from './components/common/about/about-dialog.component';
 import { ConsolePanelModalDialog } from './components/common/consolepanel/consolepanel-dialog.component';
 import { WebSocketService } from './services/ws.service';
@@ -45,7 +46,7 @@ export function createTranslateLoader(http: Http) {
     MaterialModule,
     RouterModule.forRoot(rootRouterConfig, { useHash: false })
   ],
-  declarations: [AppComponent, ConfirmDialog, AboutModalDialog, ConsolePanelModalDialog],
+  declarations: [AppComponent, ConfirmDialog, ErrorDialog, AboutModalDialog, ConsolePanelModalDialog],
   providers: [
     RoutePartsService,
     NavigationService,
@@ -61,6 +62,7 @@ export function createTranslateLoader(http: Http) {
   entryComponents: [
     AppLoaderComponent,
     ConfirmDialog,
+    ErrorDialog,
     AboutModalDialog,
     ConsolePanelModalDialog
   ],

--- a/src/app/pages/common/error-dialog/error-dialog.component.html
+++ b/src/app/pages/common/error-dialog/error-dialog.component.html
@@ -1,0 +1,20 @@
+<h1 md-dialog-title>
+  <md-icon class="warning-icon">report_problem</md-icon>
+  {{ title }}
+</h1>
+<div md-dialog-content>
+  <p>{{message}}</p>
+  <div class="more-info" (click)="toggleOpen($event)">
+    <md-icon *ngIf="isCloseMoreInfo">add_circle_outline</md-icon>
+    <md-icon *ngIf="!isCloseMoreInfo">remove_circle_outline</md-icon>
+    <span>More info...</span>
+  </div>
+  <div class="backtrace-panel" [ngClass]="{'open':!isCloseMoreInfo}">
+    <textarea mdInput>{{backtrace}}</textarea>
+  </div>  
+</div>
+<div md-dialog-actions>
+  &nbsp;
+  <span fxFlex></span>
+  <button class="mat-raised-button mat-accent" (click)="dialogRef.close(true)">Close</button>
+</div>

--- a/src/app/pages/common/error-dialog/error-dialog.component.scss
+++ b/src/app/pages/common/error-dialog/error-dialog.component.scss
@@ -1,0 +1,49 @@
+.mat-dialog-title {
+  .warning-icon {
+    color: #ffc107;
+    position: relative;
+    top: 8px;
+    font-size: 35px;
+    margin-right: 10px;
+  }
+}
+
+.mat-dialog-content {
+  max-width: 600px;
+
+  .more-info {
+    cursor: pointer;
+    margin-bottom: 10px;
+
+    .mat-icon {
+      position: relative;
+      top: 7px;
+    }
+  }
+
+  .backtrace-panel {
+    max-height: 0;
+    padding: 0px;
+    border: 0px;
+    overflow: hidden;
+    -webkit-transition: max-height 0.3s linear;
+    -moz-transition: max-height 0.3s linear;
+    -o-transition: max-height 0.3s linear;
+    -ms-transition: max-height 0.3s linear;
+    transition: max-height 0.5s linear;
+
+    &.open {
+      max-height: calc( 100px + 2rem + 4px );
+      padding: 2px;
+    }
+
+    textarea {
+      overflow: auto;
+      background: #eee;
+      border: 1px solid #ddd;
+      min-height: 100px;
+      padding: 1rem;
+      width: calc( 100% - 2rem );
+    }
+  }
+}

--- a/src/app/pages/common/error-dialog/error-dialog.component.ts
+++ b/src/app/pages/common/error-dialog/error-dialog.component.ts
@@ -1,0 +1,24 @@
+import {MdDialog, MdDialogRef} from '@angular/material';
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'error-dialog',
+  templateUrl: './error-dialog.component.html',
+  styleUrls : [ './error-dialog.component.scss' ]
+})
+export class ErrorDialog {
+
+  public title: string;
+  public message: string;
+  public backtrace: string;
+  public isCloseMoreInfo: Boolean = true;
+
+  constructor(public dialogRef: MdDialogRef < ErrorDialog > ) {
+    
+  }
+
+  public toggleOpen (data) {
+    this.isCloseMoreInfo = !this.isCloseMoreInfo;
+  }
+
+}

--- a/src/app/services/dialog.service.ts
+++ b/src/app/services/dialog.service.ts
@@ -1,5 +1,6 @@
 import { Observable } from 'rxjs/Rx';
 import { ConfirmDialog } from '../pages/common/confirm-dialog/confirm-dialog.component';
+import { ErrorDialog } from '../pages/common/error-dialog/error-dialog.component';
 import { MdDialogRef, MdDialog, MdDialogConfig } from '@angular/material';
 import { Injectable } from '@angular/core';
 
@@ -19,4 +20,18 @@ export class DialogService {
 
         return dialogRef.afterClosed();
     }
+
+    public errorReport(title: string, message: string, backtrace: string): Observable<boolean> {
+
+        let dialogRef: MdDialogRef<ErrorDialog>;
+
+        dialogRef = this.dialog.open(ErrorDialog);
+
+        dialogRef.componentInstance.title = title;
+        dialogRef.componentInstance.message = message;
+        dialogRef.componentInstance.backtrace = backtrace;
+
+        return dialogRef.afterClosed();
+    }
+
 }

--- a/src/assets/styles/styles.css
+++ b/src/assets/styles/styles.css
@@ -270,7 +270,7 @@ code {
 
 .mat-card {
     margin: .333333rem;
-    overflow: hidden;
+    /*overflow: hidden;*/ /* Removed by Daisuke */
 }
 .mat-card .mat-card-title .mat-divider, .mat-divider.full-width {
     margin-left: -24px;


### PR DESCRIPTION
I completed https://bugs.freenas.org/issues/24180

For example, this error dialog modal can be called by the following code:
this.dialogService.errorReport("title", "description", "traceback -- error").subscribe((res) => { });