### PR TITLE
Fixes for update/shutdown/reboot/login pages

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -19,9 +19,9 @@ export const rootRouterConfig: Routes = [{
       data: { title: 'Session' }
     },
     {
-      path: 'reboot',
+      path: 'others',
       loadChildren: './views/others/others.module#OthersModule',
-      data: { title: 'System Rebooting', breadcrumb: 'System Rebooting'}
+      data: { title: 'Others', breadcrumb: 'Others'}
     }]
   },
   {

--- a/src/app/components/common/topbar/topbar.component.ts
+++ b/src/app/components/common/topbar/topbar.component.ts
@@ -174,7 +174,16 @@ export class TopbarComponent implements OnInit, OnDestroy {
   onShutdown() {
     this.dialogService.confirm("Shut Down", "Shut down the system?").subscribe((res) => {
       if (res) {
-        this.ws.call('system.shutdown', {}).subscribe(res => {});
+        this.ws.call('system.shutdown', {}).subscribe(
+        (res) => {
+        },
+        (res) => { // error on shutdown
+          this.dialogService.errorReport(res.error, res.reason, res.trace.formatted);
+        },
+        () => { // show reboot screen
+          this.ws.prepare_shutdown();
+          this.router.navigate(['/others/shutdown']);
+        });
       }
     });
   }
@@ -182,7 +191,16 @@ export class TopbarComponent implements OnInit, OnDestroy {
   onReboot() {
     this.dialogService.confirm("Reboot", "Reboot the system?").subscribe((res) => {
       if (res) {
-        this.ws.call('system.reboot', {}).subscribe(res => {});
+        this.ws.call('system.reboot', {}).subscribe(
+          (res) => {
+          },
+          (res) => { // error on reboot
+            this.dialogService.errorReport(res.error, res.reason, res.trace.formatted);
+          },
+          () => { // show reboot screen
+            this.ws.prepare_shutdown();
+            this.router.navigate(['/others/reboot']);
+          });
       }
     });
   }

--- a/src/app/services/ws.service.ts
+++ b/src/app/services/ws.service.ts
@@ -20,6 +20,7 @@ export class WebSocketService {
   @LocalStorage() username;
   @LocalStorage() password;
   redirectUrl: string = '';
+  shuttingdown = false;
 
   public subscriptions: Map<string, Array<any>> = new Map<string, Array<any>>();
 
@@ -45,6 +46,7 @@ export class WebSocketService {
   }
 
   onconnect() {
+    this.shuttingdown = false;
     while (this.pendingMessages.length > 0) {
       let payload = this.pendingMessages.pop();
       this.send(payload);
@@ -55,7 +57,9 @@ export class WebSocketService {
     this.connected = false;
     this.onCloseSubject.next(true);
     setTimeout(this.connect.bind(this), 5000);
-    this._router.navigate(['/sessions/signin']);
+    if (!this.shuttingdown) {
+      this._router.navigate(['/sessions/signin']);
+    }
   }
 
   ping() {
@@ -215,10 +219,19 @@ export class WebSocketService {
     });
   }
 
-  logout() {
+  clearCredentials() {
     this.loggedIn = false;
     this.username = '';
     this.password = '';
+  }
+
+  prepare_shutdown() {
+    this.shuttingdown = true;
+    this.clearCredentials();
+  }
+
+  logout() {
+    this.clearCredentials();
     this._router.navigate(['/sessions/signin']);
   }
 }

--- a/src/app/views/others/others.module.ts
+++ b/src/app/views/others/others.module.ts
@@ -15,6 +15,7 @@ import { FlexLayoutModule } from '@angular/flex-layout';
 import { AppBlankComponent } from './app-blank/app-blank.component';
 import { OthersRoutes } from "./others.routing";
 import { RebootComponent } from "./reboot/reboot.component";
+import { ShutdownComponent } from "./shutdown/shutdown.component";
 
 @NgModule({
   imports: [
@@ -30,6 +31,6 @@ import { RebootComponent } from "./reboot/reboot.component";
     FlexLayoutModule,
     RouterModule.forChild(OthersRoutes)
   ],
-  declarations: [AppBlankComponent, RebootComponent]
+  declarations: [AppBlankComponent, RebootComponent, ShutdownComponent]
 })
 export class OthersModule { }

--- a/src/app/views/others/others.routing.ts
+++ b/src/app/views/others/others.routing.ts
@@ -1,10 +1,19 @@
 import { Routes } from '@angular/router';
 import { AppBlankComponent } from './app-blank/app-blank.component';
 import { RebootComponent } from './reboot/reboot.component';
+import { ShutdownComponent } from './shutdown/shutdown.component';
 
 export const OthersRoutes: Routes = [
   {
     path: '',
-    component: RebootComponent
+    children: [{
+      path: 'reboot',
+      component: RebootComponent,
+      data: { title: 'Reboot', breadcrumb: 'Reboot' }
+    }, {
+      path: 'shutdown',
+      component: ShutdownComponent,
+      data: { title: 'Shutdown', breadcrumb: 'Shutdown' }
+    }]
   }
 ];

--- a/src/app/views/others/shutdown/shutdown.component.html
+++ b/src/app/views/others/shutdown/shutdown.component.html
@@ -1,0 +1,3 @@
+<md-card>
+	<md-card-content>System is shutting down...</md-card-content>
+</md-card>

--- a/src/app/views/others/shutdown/shutdown.component.ts
+++ b/src/app/views/others/shutdown/shutdown.component.ts
@@ -1,0 +1,18 @@
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { WebSocketService } from '../../../services/ws.service';
+import { AppLoaderService } from '../../../services/app-loader/app-loader.service';
+
+@Component({
+  selector: 'system-shutdown',
+  templateUrl: './shutdown.component.html',
+})
+export class ShutdownComponent implements OnInit {
+
+  constructor(protected ws: WebSocketService, protected router: Router, protected loader: AppLoaderService, ) {
+  }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/views/sessions/signin/signin.component.html
+++ b/src/app/views/sessions/signin/signin.component.html
@@ -3,6 +3,7 @@
     <md-progress-bar mode="determinate" class="session-progress"></md-progress-bar>
     <md-card>
       <md-card-content>
+        <div *ngIf="connected();else notconnected">
         <div class="text-center pb-1" *ngIf="logo_ready">
           <img *ngIf="is_freenas; else isTruenas" src="assets/images/logo-full.png" alt="freenas-log">
           <ng-template #isTruenas>
@@ -57,6 +58,10 @@
             <a [routerLink]="['/sessions/signup']" class="mat-primary text-center full-width">Create a new account</a>
           </div-->
         </form>
+        </div>
+        <ng-template #notconnected>
+          System is not yet available, please wait
+        </ng-template>
         <div>
           <a md-button color="primary" href="/legacy/">Back to the Old UI</a>
         </div>

--- a/src/app/views/sessions/signin/signin.component.ts
+++ b/src/app/views/sessions/signin/signin.component.ts
@@ -31,12 +31,20 @@ export class SigninComponent implements OnInit {
 
   ngOnInit() {
     if (this.ws.username && this.ws.password && this.ws.redirectUrl) {
-      this.submitButton.disabled = true;
-      this.progressBar.mode = 'indeterminate';
+      if (this.submitButton) {
+        this.submitButton.disabled = true;
+      }
+      if (this.progressBar) {
+        this.progressBar.mode = 'indeterminate';
+      }
 
       this.ws.login(this.ws.username, this.ws.password)
                        .subscribe((result) => { this.loginCallback(result); });
     }
+  }
+
+  connected() {
+    return this.ws.connected;
   }
 
   signin() {


### PR DESCRIPTION
Make reboot page show up on reboot events, add shutdown page for
shutting down, hide login page while websockets are not available and
add loader to update pages

Ticket: #27357
        #27453
        #27068
        #27444