### PR TITLE
Resolving Redmine issue #24593, Part 2:

### DIFF
--- a/src/app/pages/system/ca/ca-intermediate/ca-intermediate.component.ts
+++ b/src/app/pages/system/ca/ca-intermediate/ca-intermediate.component.ts
@@ -131,7 +131,7 @@ export class CertificateAuthorityIntermediateComponent {
       name : 'cert_common',
       placeholder : 'Common Name',
       tooltip: 'Enter the fully-qualified hostname (FQDN) of the\
- FreeNAS® system. This name **must** be unique within a certificate\
+ system. This name **must** be unique within a certificate\
  chain.',
     },
     {

--- a/src/app/pages/system/ca/ca-intermediate/ca-intermediate.component.ts
+++ b/src/app/pages/system/ca/ca-intermediate/ca-intermediate.component.ts
@@ -130,8 +130,9 @@ export class CertificateAuthorityIntermediateComponent {
       type : 'input',
       name : 'cert_common',
       placeholder : 'Common Name',
-      tooltip: 'Enter the fully-qualified hostname\
- (FQDN) of the FreeNAS® system.',
+      tooltip: 'Enter the fully-qualified hostname (FQDN) of the\
+ FreeNAS® system. This name **must** be unique within a certificate\
+ chain.',
     },
     {
       type : 'textarea',

--- a/src/app/pages/system/ca/ca-internal/ca-internal.component.ts
+++ b/src/app/pages/system/ca/ca-internal/ca-internal.component.ts
@@ -118,7 +118,7 @@ export class CertificateAuthorityInternalComponent {
       name : 'cert_common',
       placeholder : 'Common Name',
       tooltip: 'Enter the fully-qualified hostname (FQDN) of the\
- FreeNAS® system. This name **must** be unique within a certificate\
+ system. This name **must** be unique within a certificate\
  chain.',
     },
     {

--- a/src/app/pages/system/ca/ca-internal/ca-internal.component.ts
+++ b/src/app/pages/system/ca/ca-internal/ca-internal.component.ts
@@ -117,8 +117,9 @@ export class CertificateAuthorityInternalComponent {
       type : 'input',
       name : 'cert_common',
       placeholder : 'Common Name',
-      tooltip: 'Enter the fully-qualified hostname (FQDN)\
- of the FreeNAS® system.',
+      tooltip: 'Enter the fully-qualified hostname (FQDN) of the\
+ FreeNAS® system. This name **must** be unique within a certificate\
+ chain.',
     },
     {
       type : 'textarea',

--- a/src/app/pages/system/certificates/certificate-csr/certificate-csr.component.ts
+++ b/src/app/pages/system/certificates/certificate-csr/certificate-csr.component.ts
@@ -104,8 +104,9 @@ export class CertificateCSRComponent {
       type : 'input',
       name : 'cert_common',
       placeholder : 'Common Name',
-      tooltip: 'Enter the fully-qualified\
- hostname (FQDN) of the FreeNAS® system.',
+      tooltip: 'Enter the fully-qualified hostname (FQDN) of the\
+ FreeNAS® system. This name **must** be unique within a certificate\
+ chain.',
     },
     {
       type : 'textarea',

--- a/src/app/pages/system/certificates/certificate-csr/certificate-csr.component.ts
+++ b/src/app/pages/system/certificates/certificate-csr/certificate-csr.component.ts
@@ -105,7 +105,7 @@ export class CertificateCSRComponent {
       name : 'cert_common',
       placeholder : 'Common Name',
       tooltip: 'Enter the fully-qualified hostname (FQDN) of the\
- FreeNAS® system. This name **must** be unique within a certificate\
+ system. This name **must** be unique within a certificate\
  chain.',
     },
     {

--- a/src/app/pages/system/certificates/certificate-internal/certificate-internal.component.ts
+++ b/src/app/pages/system/certificates/certificate-internal/certificate-internal.component.ts
@@ -128,8 +128,9 @@ export class CertificateInternalComponent {
       type : 'input',
       name : 'cert_common',
       placeholder : 'Common Name',
-      tooltip: 'Enter the fully-qualified\
- hostname (FQDN) of the FreeNAS® system.',
+      tooltip: 'Enter the fully-qualified hostname (FQDN) of the\
+ FreeNAS® system. This name **must** be unique within a certificate\
+ chain.',
     },
     {
       type : 'textarea',

--- a/src/app/pages/system/certificates/certificate-internal/certificate-internal.component.ts
+++ b/src/app/pages/system/certificates/certificate-internal/certificate-internal.component.ts
@@ -129,7 +129,7 @@ export class CertificateInternalComponent {
       name : 'cert_common',
       placeholder : 'Common Name',
       tooltip: 'Enter the fully-qualified hostname (FQDN) of the\
- FreeNAS® system. This name **must** be unique within a certificate\
+ system. This name **must** be unique within a certificate\
  chain.',
     },
     {


### PR DESCRIPTION
Update `Common Name` tooltip for applicable System/CA and System/Certificates forms.
The tooltip now warns the user to use a unique common name for each "part" of a chain of certificates,
as per engineering feedback.
Build test: no compile errors.