### PR TITLE
Fix 27929

### DIFF
--- a/src/app/components/common/lineChart/lineChart.service.ts
+++ b/src/app/components/common/lineChart/lineChart.service.ts
@@ -96,6 +96,9 @@ export class LineChartService {
       });
 
       dataHandlerInterface.handleDataFunc(linechartData);
+    }, (error)=>{
+      console.error("Application got error in LineChart.service.ts calling data for list observce objects in log ->", dataList, error);
+      return false;
     });
   }
 


### PR DESCRIPTION
Special request erin.

Ive removed dialogService from the WebsocketService.

Reason being that it comes up at a time in my case. .I didn't want to display it...

It can be invoked again.. Using hte subscription error method.. For example..

websocketservice.call("someapi", {}).subscrit((response)=>{
                   // Normal code we all use now... Handles the resposne
}, (error)=> {
           // A method that I dont' see many of us using.. but is here and where I think 
           // the dialog service invoke should be.. So.. The UI comnponents.. Can customize
           // whats done with the error.
            this.dialogService.error(....);
});

as opposed to having the error being internal.. and un overrideable.. in the bowels of websocektservice.onmessage(...).... If that makes sense... 


So... Lets see if you agree...  

the original bug

https://redmine.ixsystems.com/issues/27929


Is not reporoducable.. I thought it might be on a totally fresh... But I took nightly from today.. Made sure it's updated by trying an update (It said it was already updated)...

And the UI works fine.. DOn't get the missing aggreation-cpu-sum path error.

However.. I did put this in.. To protect against it.. And in the chart cases... Log the error instead of showing a dialog.. Whhen a dataset isn't found ;)