### PR TITLE
Added to donaload dialog.   Error case that call loader.close();  als…

### DIFF
--- a/src/app/components/common/dialog/downloadkey/downloadkey-dialog.component.html
+++ b/src/app/components/common/dialog/downloadkey/downloadkey-dialog.component.html
@@ -9,5 +9,6 @@
 <div mat-dialog-actions>
   &nbsp;
   <span fxFlex></span>
+  <button class="mat-raised-button mat-primary" (click)="dialogRef.close(true)">Cancel</button>
   <button class="mat-raised-button mat-primary" [disabled]="!isDownloaded" (click)="dialogRef.close(true)">Done</button>
 </div>

--- a/src/app/components/common/dialog/downloadkey/downloadkey-dialog.component.ts
+++ b/src/app/components/common/dialog/downloadkey/downloadkey-dialog.component.ts
@@ -33,6 +33,10 @@ export class DownloadKeyModalDialog {
         window.open("http://" + environment.remote + res);
         this.isDownloaded = true;
       }
+    }, (resError)=>{
+      this.isDownloaded = true;
+      this.loader.close();
+    
     });
   }
 }

--- a/src/app/pages/storage/volumes/volumes-list/volumes-list.component.html
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list.component.html
@@ -7,7 +7,7 @@
     <br/>
   </div>
   <div *ngIf="zfsPoolRows.length > 0">
-    <mat-accordion>
+    <mat-accordion [multi]="true">
       <mat-expansion-panel *ngFor="let row of zfsPoolRows" [expanded]="expanded" id="epansionpanel_zfs_{{row.name}}" >
         <mat-expansion-panel-header>
           <mat-panel-title>


### PR DESCRIPTION
…o.. Gasve it a cancel button.. And in error case enabled done... NO big deal.. but stops a hang UI case if the user deleted their encryption key.  Also... Gave the volume panel the ability to [multi]='true' which allows for the control to accept multi panel expansion.. for viewing the volumes at the same time.


Very simple changes.. Don't think it needs a review.. But Ive added reviewers mostly for respect so the we all know what happened changed.... :)