### PR TITLE
Entity table's spinner for all the things

### DIFF
--- a/src/app/pages/common/entity/entity-table/entity-table-add-actions.component.ts
+++ b/src/app/pages/common/entity/entity-table/entity-table-add-actions.component.ts
@@ -10,22 +10,12 @@ import {EntityTableComponent} from './entity-table.component';
 @Component({
   selector : 'app-entity-table-add-actions',
   template : `
-	<div *ngIf="this.entity.conf.route_add && this.actions.length < 2">
-	  <button class="mat-card-primary-action" id="add_action_button" *ngIf="this.entity.conf.route_add" mat-mini-fab (click)="this.entity.doAdd()" matTooltip="{{this.entity.conf.route_add_tooltip | translate}}">
-	    <mat-icon>add</mat-icon>
-          </button>
-	  <button mat-mini-fab class="mat-card-primary-action card-action" id="add_action_button_{{action?.label}}" *ngFor="let action of actions" (click)="action.onClick()" matTooltip="{{action.label | translate}}">
-	    <mat-icon>{{action.icon}}</mat-icon>
-          </button>
-              </div>
-        
-	<div *ngIf="this.actions.length > 1">
+  	<div *ngIf="this.entity.conf.route_add || this.actions.length > 0">
 		<smd-fab-speed-dial id="myFab" #myFab [direction]="direction" [animationMode]="animationMode"
 				(mouseenter)="myFab.open = true" (mouseleave)="myFab.open = false">
 			<smd-fab-trigger [spin]="spin">
 				<button mat-fab><mat-icon>list</mat-icon></button>
 			</smd-fab-trigger>
-
 			<smd-fab-actions>
 				<button id="add_action_button" *ngIf="this.entity.conf.route_add" mat-mini-fab (click)="this.entity.doAdd()" matTooltip="{{this.entity.conf.route_add_tooltip | translate}}">
 					<mat-icon>add</mat-icon>


### PR DESCRIPTION
Reverted template on entity-table-add-actions.component to previous state. Spinner is back for everything