### PR TITLE
Using inputType='password' in storage form configruaitons when ever t…

### DIFF
--- a/src/app/pages/storage/volumes/volume-unencryptimports/volume-unencryptimport.component.ts
+++ b/src/app/pages/storage/volumes/volume-unencryptimports/volume-unencryptimport.component.ts
@@ -50,6 +50,7 @@ export class VolumeUnencryptImportListComponent implements Formconfiguration {
       },
       {
         type: 'input',
+        inputType: 'password',
         name: 'passphrase',
         label: T('Passphrase'),
         placeholder: T('Passphrase'),

--- a/src/app/pages/storage/volumes/volumeaddkey-form/volumeaddkey-form.component.ts
+++ b/src/app/pages/storage/volumes/volumeaddkey-form/volumeaddkey-form.component.ts
@@ -48,6 +48,7 @@ export class VolumeAddkeyFormComponent implements Formconfiguration {
       isHidden: true
     },{
       type : 'input',
+      inputType: 'password',
       name : 'passphrase',
       label : T('Passphrase'),
       placeholder: T('Passphrase'),

--- a/src/app/pages/storage/volumes/volumecreatekey-form/volumecreatekey-form.component.ts
+++ b/src/app/pages/storage/volumes/volumecreatekey-form/volumecreatekey-form.component.ts
@@ -48,12 +48,14 @@ export class VolumeCreatekeyFormComponent implements Formconfiguration {
       isHidden: true
     },{
       type : 'input',
+      inputType: 'password',
       name : 'passphrase',
       label: T("passphrase"),
       placeholder: T('Passphrase'),
       tooltip: T('Geli Passphrase')
     },{
       type : 'input',
+      inputType: 'password',
       name : 'passphrase2',
       label : T('Passphrase2'),
       placeholder: T('Passphrase2 must match above'),

--- a/src/app/pages/storage/volumes/volumerekey-form/volumerekey-form.component.ts
+++ b/src/app/pages/storage/volumes/volumerekey-form/volumerekey-form.component.ts
@@ -48,6 +48,7 @@ export class VolumeRekeyFormComponent  implements Formconfiguration {
       isHidden: true
     },{
       type : 'input',
+      inputType: 'password',
       name : 'passphrase',
       label : T('Passphrase'),
       placeholder: T('Passphrase'),

--- a/src/app/pages/storage/volumes/volumeunlock-form/volumeunlock-form.component.ts
+++ b/src/app/pages/storage/volumes/volumeunlock-form/volumeunlock-form.component.ts
@@ -47,11 +47,13 @@ export class VolumeUnlockFormComponent  implements Formconfiguration {
       isHidden: true
     },{
       type : 'input',
+      inputType: 'password',
       name : 'name',
       placeholder: T('Passphrase'),
       isHidden: true
     },{
       type : 'input',
+      inputType: 'password',
       name : 'passphrase',
       placeholder: T('Passphrase'),
       tooltip: 'Geli Passphrase'


### PR DESCRIPTION
Used the inputType password on all passphrase input within the storage section.

To see them...  Create an encrypted volume.

Then try stuff like.. Create Passphrase
                                Lock/Unlock

etc..  Under volumes section.  Password INPUTS should look like  "****"  instead of seeing the characters.