### PR TITLE
Faeture 28712 sunday

### DIFF
--- a/src/app/pages/storage/disks/disks-list/disks-list.component.html
+++ b/src/app/pages/storage/disks/disks-list/disks-list.component.html
@@ -1,4 +1,4 @@
-<div id="disks-list.component_html" class="material mat-card mat-card-table" *ngIf="repaintIt === true">
+<div id="disks-list.component_html" class="material mat-card mat-card-table" *ngIf="repaintIt === true && lockRefCount === 0">
   <div class="mat-toolbar mat-card-toolbar">
     <div class="mat-card-title-text">{{title}}</div>
   </div>
@@ -14,14 +14,16 @@
     </mat-button-toggle-group>
   </mat-card>
   
- 
+ <!-- Note the strange group.value.. That's being set abov in mat-button-toggle-group #group where the name "group" can be any name
+      then becomes a global variable seen in the template as Im doing below... It's the selected button basically.. In the button-toggle-group 
+    -->
   <div *ngIf="zfsPoolRows.length > 0 && group.value === conf.title">
     <entity-table [conf]="conf" [title]="conf.title"></entity-table>
   </div>
 
   <div *ngFor="let row of zfsPoolRows">
     <div *ngIf="group.value === row.name">
-      <entity-table *ngIf="row.isReady" [conf]="row.disksListConfig"></entity-table>
+      <entity-table [conf]="row.disksListConfig"></entity-table>
     </div>
   </div>
 
@@ -29,22 +31,5 @@
   <div>
     <br/>
   </div>
-
-  <!--
-  <div>
-    <mat-tab-group (selectChange)="tabSelectChangeHandler($event)">
-      <mat-tab label="ALL_DISKS" *ngIf="zfsPoolRows.length > 0">
-        <div>
-          <entity-table [conf]="conf" [title]="conf.title"></entity-table>
-        </div>
-      </mat-tab>
-      <mat-tab *ngFor="let row of zfsPoolRows" label="{{row.name}}">
-        <div *ngIf="selectedKeyName === row.name">
-          <entity-table *ngIf="row.isReady" [conf]="row.disksListConfig"></entity-table>
-        </div>
-      </mat-tab>
-    </mat-tab-group>
-  </div>
--->
 
 </div>

--- a/src/app/pages/storage/disks/disks-list/disks-list.component.ts
+++ b/src/app/pages/storage/disks/disks-list/disks-list.component.ts
@@ -234,9 +234,9 @@ export class DisksListComponent extends EntityTableComponent implements OnInit, 
 
 
         this.rest.get("storage/volume/" + volumeId + "/status", {}).subscribe((volumeStatusResponse) => {
-          console.log("volumeStatusResponse: " + volumeId, volumeStatusResponse);
           volume.driveStatusdata = volumeStatusResponse.data[0];
           volume.driveStatusdata.children = new EntityUtils().flattenData(volume.driveStatusdata.children);
+          console.log("volume:" + volume.name, volume);
         });
 
 

--- a/src/app/pages/storage/disks/disks-list/disks-list.component.ts
+++ b/src/app/pages/storage/disks/disks-list/disks-list.component.ts
@@ -232,13 +232,16 @@ export class DisksListComponent extends EntityTableComponent implements OnInit, 
 
         this.zfsPoolRows.push(volume);
 
+        if( volume.name !== DisksListConfig.BOOT_POOL) {
 
-        this.rest.get("storage/volume/" + volumeId + "/status", {}).subscribe((volumeStatusResponse) => {
-          volume.driveStatusdata = volumeStatusResponse.data[0];
-          volume.driveStatusdata.children = new EntityUtils().flattenData(volume.driveStatusdata.children);
-          console.log("volume:" + volume.name, volume);
-        });
-
+          this.rest.get("storage/volume/" + volumeId + "/status", {}).subscribe((volumeStatusResponse) => {
+            volume.driveStatusdata = volumeStatusResponse.data[0];
+            volume.driveStatusdata.children = new EntityUtils().flattenData(volume.driveStatusdata.children);
+            console.log("volume:" + volume.name, volume);
+          });
+  
+        }
+        
 
         let callQuery = (DisksListConfig.BOOT_POOL === volume.id) ? DisksListConfig.getRootPoolDisksQueryCall : "pool.get_disks";
         let args = (DisksListConfig.BOOT_POOL === volume.id) ? [] : [volumeId];

--- a/src/app/pages/storage/disks/disks-list/disks-list.component.ts
+++ b/src/app/pages/storage/disks/disks-list/disks-list.component.ts
@@ -246,6 +246,14 @@ export class DisksListComponent extends EntityTableComponent implements OnInit, 
 
       });
 
+      // For debug.. Seems to return the same fields as rest api.
+      // I need a way to detech offline vs online status of a disk in a pool?
+     // this.ws.call("disk.query", []).subscribe((resp)=>{
+     //   console.log("response", resp);
+     // }, (errorReport)=>{
+     //   console.log("errorReport", errorReport);
+     // });
+
       
     });
 

--- a/src/app/pages/storage/disks/disks-list/disks-list.component.ts
+++ b/src/app/pages/storage/disks/disks-list/disks-list.component.ts
@@ -104,8 +104,8 @@ export class DisksListConfig implements InputTableConf {
         label : T("Detach From Pool"),
         onClick : (row1) => {
           this.loader.open();
-
-          this.rest.post("storage/disk/" +  row1.id + "/detach", { body: JSON.stringify({}) }).subscribe((restPostResp) => {
+          let data = { label: row1.disk_name};
+          this.rest.post("storage/volume/" +  row1.poolName + "/detach", { body: JSON.stringify(data) }).subscribe((restPostResp) => {
             this.loader.close();
             this.diskPoolMapParent.repaintMe();
           }, (res) => {

--- a/src/app/pages/storage/volumes/volume-unencryptimports/volume-unencryptimport.component.ts
+++ b/src/app/pages/storage/volumes/volume-unencryptimports/volume-unencryptimport.component.ts
@@ -27,7 +27,6 @@ import { T } from '../../../../translate-marker';
  * 
  */
 export class VolumeUnencryptImportListComponent implements Formconfiguration {
-  public resource_name: string = 'storage/volume_unencrypt';
   public route_success: string[] = ['storage', 'pools'];
   public isEntity = true;
   public isNew = true;
@@ -44,9 +43,12 @@ export class VolumeUnencryptImportListComponent implements Formconfiguration {
     this.fieldConfig = [
       {
         type: 'upload',
-        name: 'encryption_key_file',
+        name: 'key',
         placeholder: T('Encryption Key File'),
         tooltip: T('Encryption key used to decrypt pools to be imported.'),
+        acceptedFiles: ',.key',
+        fileLocation: '',
+        validation : [  ],
       },
       {
         type: 'input',
@@ -84,10 +86,10 @@ export class VolumeUnencryptImportListComponent implements Formconfiguration {
   customSubmit(value) {
     this.loader.open();
     console.log("VALUE", value);
-    return this.rest.post(this.resource_name, { body: JSON.stringify({ volume_id: value.volume_id, is_decrypted: value.is_decrypted }) }).subscribe((restPostResp) => {
+    return this.rest.post("_upload", { body: JSON.stringify(value) }, false ).subscribe((restPostResp) => {
       console.log("restPostResp", restPostResp);
       this.loader.close();
-      this.dialogService.Info(T("Imported Pool"), T("Successfully decrypted pool ") + value.volume_id);
+      this.dialogService.Info(T("Uploaded key"), T("Uploaded Key"));
 
       this.router.navigate(new Array('/').concat(
         this.route_success));

--- a/src/app/pages/storage/volumes/volumes-list/volumes-list.component.html
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list.component.html
@@ -35,8 +35,16 @@
           <br/>
         </div>
         <div>
-          <dx-tree-list keyExpr="nodePath" parentIdExpr="parentPath" [dataSource]="row.volumesListTableConfig.rowData" [showRowLines]="true" [allowColumnResizing]="true" [columnAutoWidth]="true" [columnResizingMode]="'widget'" [columnMinWidth]="50" [expandedRowKeys]="['1']">
+          <dx-tree-list keyExpr="nodePath" 
+                        parentIdExpr="parentPath"
+                        [dataSource]="row.volumesListTableConfig.rowData" 
+                        [showRowLines]="true" [allowColumnResizing]="true" 
+                        [columnAutoWidth]="true" 
+                        [columnResizingMode]="'widget'" 
+                        [columnMinWidth]="50" [expandedRowKeys]="['1']">
             
+            <dxo-selection mode="single"></dxo-selection>
+
             <dxi-column dataField='name' cellTemplate="cellTemplateName"></dxi-column>
             <div *dxTemplate="let rowData of 'cellTemplateName'">
               <div class="panel_container" id="row_name_{{rowData.data.name}}">

--- a/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
@@ -314,6 +314,18 @@ export class VolumesListTableConfig implements InputTableConf {
           ]));
         }
       });
+      if (rowDataPathSplit[1] !== "iocage") {
+        actions.push({
+          label: T("Edit Permissions"),
+          onClick: (row1) => {
+            this._router.navigate(new Array('/').concat([
+              "storage", "pools", "id", row1.path.split('/')[0], "dataset",
+              "permissions", row1.path
+            ]));
+          }
+        });
+      }
+
       if (rowData.path.indexOf('/') !== -1) {
         actions.push({
           label: T("Delete Dataset"),
@@ -338,23 +350,12 @@ export class VolumesListTableConfig implements InputTableConf {
 
                 }
               });
-
           }
         });
-        if (rowDataPathSplit.length > 1 && rowDataPathSplit[1] !== "iocage") {
-          actions.push({
-            label: T("Edit Permissions"),
-            onClick: (row1) => {
-              this._router.navigate(new Array('/').concat([
-                "storage", "pools", "id", row1.path.split('/')[0], "dataset",
-                "permissions", row1.path
-              ]));
-            }
-          });
-        }
+
       }
 
-      let rowDataset = _.find(this.datasetData, {id:rowData.path});
+      let rowDataset = _.find(this.datasetData, { id: rowData.path });
       if (rowDataset && rowDataset['origin'] && !!rowDataset['origin'].parsed) {
         actions.push({
           label: T("Promote Dataset"),
@@ -384,7 +385,7 @@ export class VolumesListTableConfig implements InputTableConf {
           this.dialogService.confirm(T("Delete zvol:" + row1.path), T("Please confirm the deletion of zvol:" + row1.path), false).subscribe((confirmed) => {
             if (confirmed === true) {
               this.loader.open();
-              
+
               this.rest.delete('storage/volume/' + this._classId + '/zvols/' + row1.name, {}).subscribe((wsResp) => {
                 this.loader.close();
                 this.parentVolumesListComponent.repaintMe();

--- a/src/app/pages/storage/volumes/volumeunlock-form/volumeunlock-form.component.ts
+++ b/src/app/pages/storage/volumes/volumeunlock-form/volumeunlock-form.component.ts
@@ -87,7 +87,6 @@ export class VolumeUnlockFormComponent  implements Formconfiguration {
     return this.rest.post(this.resource_name + "/" + value.name + "/unlock/", { body: JSON.stringify({passphrase: value.passphrase}) }).subscribe((restPostResp) => {
       console.log("restPostResp", restPostResp);
       this.loader.close();
-      this.dialogService.Info(T("Unlock Pool"), T("Successfully unlocked pool ") + value.name);
       
       this.router.navigate(new Array('/').concat(
         this.route_success));


### PR DESCRIPTION
Got the API volume/id/detach    body:  JSON.stringify( {  label:  disk.disk_name } )

This works.  the api retuns and says "Disk successfully detached"

But.. I see no way to then detect this.. The getting disks by pool.. The disk I detached still comes up?

I notice in disks.query There's no status in da1 vs da2 (I detached da2 in my pool).  Same is true of v1.0/storage/disks

So.. How do you detech the status that this api toggled?


OH.. I removed the uneeded Succesfully Un locked volume blah blah.. because you can see the difference in the parent list when itupdates (Not locked)