### PR TITLE
Make dynamic instructions for console dialog

### DIFF
--- a/src/app/components/common/dialog/consolepanel/consolepanel-dialog.component.html
+++ b/src/app/components/common/dialog/consolepanel/consolepanel-dialog.component.html
@@ -1,7 +1,7 @@
 <div mat-dialog-content>
   <pre #footerBarScroll class="message">{{consoleMsg}}</pre>
   <div mat-dialog-content class="overflow-hide">
-    <mat-checkbox (change)="onStopRefresh($event)">Stop refresh</mat-checkbox>
+    <mat-checkbox (change)="onStopRefresh($event)">{{refreshMsg}}</mat-checkbox>
   </div>
 </div>
 <div mat-dialog-actions>

--- a/src/app/components/common/dialog/consolepanel/consolepanel-dialog.component.scss
+++ b/src/app/components/common/dialog/consolepanel/consolepanel-dialog.component.scss
@@ -1,5 +1,5 @@
 .message {
-	max-width: 900px;
+	max-width: 500px;
   max-height: 340px;
   width: 100vw;
   height: 100vh;

--- a/src/app/components/common/dialog/consolepanel/consolepanel-dialog.component.ts
+++ b/src/app/components/common/dialog/consolepanel/consolepanel-dialog.component.ts
@@ -8,7 +8,8 @@ import { WebSocketService } from '../../../../services/';
   templateUrl: './consolepanel-dialog.component.html'
 })
 export class ConsolePanelModalDialog {
-
+  
+  public refreshMsg: String = "Check to stop refresh";
   public intervalPing;
   public consoleMsg: String = "Loading...";
   @ViewChild('footerBarScroll') private footerBarScroll: ElementRef;
@@ -58,9 +59,11 @@ export class ConsolePanelModalDialog {
   onStopRefresh(data) {
     if(data.checked) {
       clearInterval(this.intervalPing);
+      this.refreshMsg = 'Uncheck to restart refresh';
     }
     else {
       this.getLogConsoleMsg();
+      this.refreshMsg = "Check to stop refresh";
     }    
   }
 }


### PR DESCRIPTION
Ticket: #31380
Instructions for console are on the tooltip where it is launched, but since the console is active throughout the app, I added dynamic instructions to the console.