### PR TITLE
Simple form width adjustment via css

### DIFF
--- a/src/app/pages/common/entity/entity-form/entity-form.component.scss
+++ b/src/app/pages/common/entity/entity-form/entity-form.component.scss
@@ -1,7 +1,7 @@
-.mat-card{
+/*.mat-card{
   max-width:960px;
   margin:0 auto;
-}
+}*/
 
 .form-wrap {
 	display: flex;

--- a/src/app/pages/common/entity/entity-task/entity-task.component.html
+++ b/src/app/pages/common/entity/entity-task/entity-task.component.html
@@ -1,5 +1,5 @@
 <p *ngIf="error" type="danger"><span [innerHTML]="error"></span></p>
-<mat-card>
+<mat-card class="form-card">
   <form (ngSubmit)="onSubmit($event)" [formGroup]="formGroup" #entityForm="ngForm">
     <ng-container *ngFor="let field of conf.fieldConfig; let i = index">
     	<div [ngClass]="field.class == 'inline' ? 'form-inline' : 'form-line'" id="{{i}}">
@@ -8,8 +8,8 @@
         </div>
     </ng-container>
     <mat-card-actions class="buttons">
-      <button class="btn btn-block btn-warning" type="submit" mat-raised-button color="primary" [disabled]="!entityForm.form.valid">{{ "Save" | translate }}</button>
-      <button *ngIf="conf.route_success" (click)="goBack()" type="button" mat-raised-button color="accent">{{ "Cancel" | translate }}</button>
+      <button class="btn btn-block btn-warning" type="submit" mat-button color="primary" [disabled]="!entityForm.form.valid">{{ "Save" | translate }}</button>
+      <button *ngIf="conf.route_success" (click)="goBack()" type="button" mat-button color="accent">{{ "Cancel" | translate }}</button>
     </mat-card-actions>
   </form>
 </mat-card>

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -412,6 +412,18 @@ tr.dx-row:nth-child(odd){
 
 // END Treelist styles
 
+//Entity Module Overrides
+
+entity-task .form-card.mat-card,
+entity-form .form-card.mat-card{
+  max-width:960px;
+  margin:0 auto;
+}
+
+.form-card.mat-card{
+  font-size:12px;
+}
+
 .fieldset-label{
   min-width:100%;
   margin-bottom:16px;


### PR DESCRIPTION
Moved entity-forms .mat-card.form-card max-width rule to global css files. Added .form-card class to entity-task's mat-card element so both form types will have the same layout property.