### PR TITLE
Update the Shell tool tip to describe actual behaviour

### DIFF
--- a/src/app/pages/shell/shell.component.ts
+++ b/src/app/pages/shell/shell.component.ts
@@ -41,13 +41,15 @@ export class ShellComponent implements OnInit, OnChanges, OnDestroy {
   public resize_terminal = true;
   private shellSubscription: any;
 
-  public shell_tooltip = T('Copy/paste with <b>Ctrl + C/V</b> or\
-   <b>Command + C/V</b>.<br>\
-   Many utilities are built-in, including:<br>\
-   <b>Iperf</b>, <b>Netperf</b>, <b>IOzone</b>, <b>arcsat</b>,\
-   <b>tw_cli</b>, <b>MegaCli</b>,<b>freenas-debug</b>,<b>tmux</b>,\
-   and <b>Dmidecode</b>. See the <b>Guide > Command Line Utilities</b>\
-   chapter for more information.');
+public shell_tooltip = T('<b>Ctrl+C</b> kills a foreground process. <br> \
+                        Many utilities are built-in: <br>\
+                        <b>Iperf</b>, <b>Netperf</b>, <b>IOzone</b>, \
+                        <b>arcsat</b>, <b>tw_cli</b>, <br><b>MegaCli</b>, \
+                        <b>freenas-debug</b>, <b>tmux</b>, <b>Dmidecode</b>. \
+                        <br>\
+                        Refer to the <b>Command Line Utilities</b> chapter in\
+                        the <b>User Guide</b> for usage information and \
+                        examples.');
 
   clearLine = "\u001b[2K\r"
 


### PR DESCRIPTION
Ctrl+C and Ctrl+V do not Copy or Paste
Ctrl+C kills a forground process is possible.

When linking to a specific section of the user guide is possible
This tool tip should be updated to link to the Command Line Utilities
chapter instead of advising where the chapter is.