### PR TITLE
Fixed out of bounds problem with widget cards

### DIFF
--- a/src/app/core/components/viewchart/viewchart.component.ts
+++ b/src/app/core/components/viewchart/viewchart.component.ts
@@ -23,13 +23,13 @@ export const ViewChartMetadata = {
   template: `
     <div class="viewchart-wrapper {{chartClass}}-wrapper">
       <div *ngIf="chartLoaded" class="legend-wrapper">
-        <div class="legend-x legend-item" *ngIf="chartConfig.data.x">Time: <span *ngIf="showLegendValues">{{legend[0].x}}</span></div>
-        <div class="legend-html" fxLayout="row" fxLayoutAlign="space-between" fxLayoutGap="16px" >
+        <div class="legend-x legend-item" *ngIf="chartConfig.data.x">Time: <span *ngIf="showLegendValues" class="legend-item-time">{{legend[0].x}}</span></div>
+        <div class="legend-html" fxLayout="row wrap" fxLayoutAlign="space-between" fxLayoutGap="16px" >
           <ng-container *ngFor="let item of legend; let i=index ">
-            <div class="legend-item" *ngIf="chartType != 'gauge'" (click)="focus(legend[i])" [ngClass]="{'legend-item-disabled':!legend[i].visible}">
+            <div fxFlex.xs="calc(33% - 16px)" class="legend-item" *ngIf="chartType != 'gauge'" (click)="focus(legend[i])" [ngClass]="{'legend-item-disabled':!legend[i].visible}">
               <span class="legend-swatch" [style.background-color]="legend[i].swatch"></span>
               <span class="legend-name">{{legend[i].name}}: </span>
-              <div class="legend-value" [style.color]="legend[i].swatch"><span *ngIf="showLegendValues">{{legend[i].value}}{{units}}</span></div>
+              <div class="legend-value" [style.color]="legend[i].swatch"><span *ngIf="showLegendValues">{{legend[i].value | number : '1.2-2'}}{{units}}</span></div>
             </div>
           </ng-container>
         </div>

--- a/src/app/core/components/widgets/widget/widget.component.html
+++ b/src/app/core/components/widgets/widget/widget.component.html
@@ -1,5 +1,5 @@
-<div class="widget widget-{{widgetSize}}">
-  <div class="card-container {{flipDirection}} front" animate [animation]="flipAnimation">
+<div class="widget">
+  <div class="card-container front">
     <mat-card class="front" fxLayout="row" fxLayoutWrap fxLayoutAlign="space-between stretch">
       <mat-toolbar-row fxLayout="row" fxLayoutWrap fxLayoutAlign="space-between start" fxFlex="100" class="mat-card-toolbar">
         <h4 class="mat-card-title-text"><div class="card-title-text">{{title}}</div></h4>
@@ -13,7 +13,7 @@
           <span>Configure</span>
         </button>
       </mat-menu>
-      <mat-card-content fxLayout="row" fxLayoutWrap fxLayoutAlign="center start" fxFlex="100">
+      <mat-card-content fxLayout="row" fxLayoutAlign="center start" fxFlex="100">
         <viewchartdonut fxFlex="30" #chartDonut [width]="chartSize" [height]="chartSize" style="display:none;"></viewchartdonut>
         <viewchartline fxFlex="100" fxFlexAlign="end" #chartCpu [width]="chartSize" [height]="chartSize"></viewchartline>
       </mat-card-content>

--- a/src/app/core/components/widgets/widgetcpuhistory/widgetcpuhistory.component.html
+++ b/src/app/core/components/widgets/widgetcpuhistory/widgetcpuhistory.component.html
@@ -1,5 +1,5 @@
-<div class="widget widget-{{widgetSize}}">
-  <div class="card-container {{flipDirection}} front" animate [animation]="flipAnimation">
+<div class="widget">
+  <div class="card-container  front">
     <mat-card class="front" fxLayout="row" fxLayoutWrap fxLayoutAlign="space-between stretch">
       <mat-toolbar-row fxLayout="row" fxLayoutWrap fxLayoutAlign="space-between start" fxFlex="100" class="mat-card-toolbar">
         <h4 class="mat-card-title-text"><div class="card-title-text">{{title}}</div></h4>
@@ -12,20 +12,15 @@
       </mat-card-content>
       <!--<div class="widget-footer"><button md-raised-button color="primary" (click)="toggleConfig()">Flip</button></div>-->
     </mat-card>
+    <ng-template *ngIf="configurable">
     <mat-card class="back">
       <mat-card-content fxLayout="column" fxLayoutAlign="start stretch" fxFlex="100">
-        <!--<form (ngSubmit)="setPreferences(f)" #f="ngForm" id="preferences" *ngIf="chartCpu.legend.length > 0">
-          <ng-container *ngFor="let legend of chartCpu.legend; let i=index">
-            <mat-checkbox ngModel name="{{chartCpu.legend[i].name}}">
-              {{chartCpu.legend[i].name}}
-            </mat-checkbox><br>
-            </ng-container>
-            </form>-->
       </mat-card-content>
       <div class="widget-footer">
         <button mat-raised-button color="accent" (click)="toggleConfig()">Cancel</button>
         <button mat-raised-button color="primary" type="submit" form="preferences" (click)="toggleConfig()">Save</button>
       </div>
     </mat-card>
+    </ng-template>
   </div>
 </div>

--- a/src/app/core/components/widgets/widgetloadhistory/widgetloadhistory.component.html
+++ b/src/app/core/components/widgets/widgetloadhistory/widgetloadhistory.component.html
@@ -1,5 +1,5 @@
-<div class="widget widget-{{widgetSize}}">
-  <div class="card-container {{flipDirection}} front" animate [animation]="flipAnimation">
+<div class="widget">
+  <div class="card-container front">
     <mat-card class="front" fxLayout="row" fxLayoutWrap fxLayoutAlign="space-between stretch">
       <mat-toolbar-row fxLayout="row" fxLayoutWrap fxLayoutAlign="space-between start" fxFlex="100" class="mat-card-toolbar">
         <h4 class="mat-card-title-text"><div class="card-title-text">{{title}}</div></h4>
@@ -12,6 +12,7 @@
       </mat-card-content>
       <!--<div class="widget-footer"><button md-raised-button color="primary" (click)="toggleConfig()">Flip</button></div>-->
     </mat-card>
+    <ng-template *ngIf="configurable">
     <mat-card class="back">
       <mat-card-content fxLayout="column" fxLayoutAlign="start stretch" fxFlex="100">
         <form (ngSubmit)="setPreferences(f)" #f="ngForm" id="preferences" *ngIf="chartLoad.legend.length > 0">
@@ -27,5 +28,6 @@
         <button mat-raised-button color="primary" type="submit" form="preferences" (click)="toggleConfig()">Save</button>
       </div>
     </mat-card>
+    </ng-template>
   </div>
 </div>

--- a/src/app/core/components/widgets/widgetmemoryhistory/widgetmemoryhistory.component.html
+++ b/src/app/core/components/widgets/widgetmemoryhistory/widgetmemoryhistory.component.html
@@ -1,5 +1,5 @@
-<div class="widget widget-{{widgetSize}}">
-  <div class="card-container {{flipDirection}} front" animate [animation]="flipAnimation">
+<div class="widget">
+  <div class="card-container front">
     <mat-card class="front" fxLayout="row" fxLayoutWrap fxLayoutAlign="space-between stretch">
       <mat-toolbar-row fxLayout="row" fxLayoutWrap fxLayoutAlign="space-between start" fxFlex="100" class="mat-card-toolbar">
         <h4 class="mat-card-title-text"><div class="card-title-text">{{title}}</div></h4>
@@ -12,6 +12,7 @@
       </mat-card-content>
       <!--<div class="widget-footer"><button md-raised-button color="primary" (click)="toggleConfig()">Flip</button></div>-->
     </mat-card>
+    <ng-template *ngIf="configurable">
     <mat-card class="back">
       <mat-card-content fxLayout="column" fxLayoutAlign="start stretch" fxFlex="100">
         <form (ngSubmit)="setPreferences(f)" #f="ngForm" id="preferences" *ngIf="chartMem.legend.length > 0">
@@ -27,5 +28,6 @@
         <button mat-raised-button color="primary" type="submit" form="preferences" (click)="toggleConfig()">Save</button>
       </div>
     </mat-card>
+    </ng-template>
   </div>
 </div>

--- a/src/app/core/components/widgets/widgetpool/widgetpool.component.html
+++ b/src/app/core/components/widgets/widgetpool/widgetpool.component.html
@@ -1,7 +1,7 @@
 <div class="widget widget-{{widgetSize}}" ngClass.xs="double-height">
-  <div class="card-container {{flipDirection}} front" animate [animation]="flipAnimation">
+  <div class="card-container  front">
     <mat-card class="front" fxLayout="row" fxLayoutWrap fxLayoutAlign="space-between stretch">
-      <mat-toolbar-row fxLayout="row" fxLayoutWrap fxLayoutAlign="space-between stretch" fxFlex="100" class="mat-card-toolbar">
+      <mat-toolbar-row fxLayout="row" fxLayoutWrap fxLayoutAlign="space-between center" fxFlex="100" class="mat-card-toolbar">
         <span class="mat-card-title-text">
           <div class="card-title-text">
             <div class="card-title-items">
@@ -102,6 +102,7 @@
     </mat-card>
 
     <!-- Back Face -->
+    <ng-template *ngIf="configurable">
     <mat-card class="back">
       <mat-card-content fxLayout="column" fxLayoutAlign="start stretch" fxFlex="100">
         <form (ngSubmit)="setPreferences(f)" #f="ngForm" id="preferences" *ngIf="chartZvol.legend.length > 0">
@@ -117,5 +118,6 @@
         <button mat-raised-button color="primary" type="submit" form="preferences" (click)="toggleConfig()">Save</button>
       </div>
     </mat-card>
+    </ng-template>
   </div>
 </div>

--- a/src/app/pages/dashboard/dashboard.html
+++ b/src/app/pages/dashboard/dashboard.html
@@ -10,12 +10,12 @@
     <!--<widget-storage-collection style="display:none;" #storageCollection fxFlex="90" [widgetSize]="medium" [widgetFlex]="100" [collectionLayout]="'row'"></widget-storage-collection>-->
       <ng-container  *ngFor="let volume of volumes; let i=index">
         <widget-pool [volumeData]="volumes[i]" style="max-width:928px;"  fxFlex.xl="48" fxFlex.lt-xl="90" [widgetSize]="medium" animate [animation]="animation" [shake]="shake" configurable="false"></widget-pool>
-      </ng-container>
+        </ng-container>
     
 
     <widget-cpu-history fxFlex.xl="48" fxFlex.gt-sm="48" fxFlex.lt-md="90" [widgetSize]="medium" animate [animation]="animation" [shake]="shake" configurable="false"></widget-cpu-history>
     <widget-memory-history fxFlex.xl="48" fxFlex.gt-sm="48" fxFlex.lt-md="90" [widgetSize]="medium" animate [animation]="animation" [shake]="shake"configurable="false"></widget-memory-history>
-    <widget-load-history fxFlex.xl="48" fxFlex.gt-sm="48" fxFlex.lt-md="90" [widgetSize]="medium" animate [animation]="animation" [shake]="shake" configurable="false"></widget-load-history>
+      <widget-load-history fxFlex.xl="48" fxFlex.gt-sm="48" fxFlex.lt-md="90" [widgetSize]="medium" animate [animation]="animation" [shake]="shake" configurable="false"></widget-load-history>
 
 
     <!--<widget-notes-collection fxFlex="98" [widgetSize]="medium" [widgetFlex]="noteFlex" [collectionLayout]="'row'"></widget-notes-collection>-->

--- a/src/app/services/stats.service.ts
+++ b/src/app/services/stats.service.ts
@@ -174,8 +174,8 @@ export class StatsService {
   private listeners: any[] = [];
   private queue:any[] = [];
   private started:boolean = false;
-  private bufferSize:number = 10000;// milliseconds
-  private bufferSizeRealtime:number = 1000;// milliseconds
+  private bufferSize:number = 60000;// milliseconds
+  private bufferSizeRealtime:number = 15000;// milliseconds
   private broadcastId:number;
   private broadcastRealtimeId:number;
 

--- a/src/assets/styles/egret_overrides.css
+++ b/src/assets/styles/egret_overrides.css
@@ -215,7 +215,7 @@ body.collapsed-menu mat-sidenav-container.mat-drawer-opened mat-sidenav-content.
 }
 
 .widget .mat-card{
-  position:absolute;
+  /*position:absolute;*/
   left:0;
   right:0;
   width:100%;
@@ -265,3 +265,10 @@ body.collapsed-menu mat-sidenav-container.mat-drawer-opened mat-sidenav-content.
   font-size:20px;
 }
 
+.widget .mat-card.back{
+  display:none;
+}
+
+.legend-item-time{
+  height:82px;
+}


### PR DESCRIPTION
Fixed out of bounds problem with widget cards by disabling the back face of the flip card via ngIf. Also added a pipe to legend time to avoid numbers with more than 2 decimal places. Relaxed the frequency at which stats service was polling as it seems to have been a little bit too aggressive and was slowing the page down.