### PR TITLE
Bug: 33567 Add regex to not allow invalid characters in Jail Names

### DIFF
--- a/src/app/pages/jails/jail-wizard/jail-wizard.component.ts
+++ b/src/app/pages/jails/jail-wizard/jail-wizard.component.ts
@@ -35,9 +35,9 @@ export class JailWizardComponent {
           placeholder: T('Jail Name'),
           tooltip: T('Mandatory. Can only contain alphanumeric characters,\
  dashes (-), or underscores (_).'),
-          validation: [ Validators.required ],
-        },
-        {
+          validation: [ regexValidator(/^[a-zA-Z0-9-_]+$/) ],
+      },
+                    {
           type: 'select',
           name: 'release',
           required: true,

--- a/src/app/pages/jails/jail-wizard/jail-wizard.component.ts
+++ b/src/app/pages/jails/jail-wizard/jail-wizard.component.ts
@@ -37,7 +37,7 @@ export class JailWizardComponent {
  dashes (-), or underscores (_).'),
           validation: [ regexValidator(/^[a-zA-Z0-9-_]+$/) ],
       },
-                    {
+        {
           type: 'select',
           name: 'release',
           required: true,

--- a/src/app/pages/jails/jail-wizard/jail-wizard.component.ts
+++ b/src/app/pages/jails/jail-wizard/jail-wizard.component.ts
@@ -36,7 +36,7 @@ export class JailWizardComponent {
           tooltip: T('Mandatory. Can only contain alphanumeric characters,\
  dashes (-), or underscores (_).'),
           validation: [ regexValidator(/^[a-zA-Z0-9-_]+$/) ],
-      },
+        },
         {
           type: 'select',
           name: 'release',


### PR DESCRIPTION
Only Aa-Zz, 0-9, -, and _ are allowed in Jail names
The Jail Wizard allowed all characters
Added the regex /^[a-zA-Z0-9-_]+$/ to only allow valid chars

This closes bug 33567