### PR TITLE
Fix/defaults show before data 33858

### DIFF
--- a/src/app/pages/common/entity/entity-form/entity-form.component.html
+++ b/src/app/pages/common/entity/entity-form/entity-form.component.html
@@ -4,7 +4,7 @@
 </p>
 <mat-card class="form-card">
     <div class="mat-content">
-        <form (ngSubmit)="onSubmit($event)" [formGroup]="formGroup" class="form-wrap" #entityForm="ngForm">
+        <form (ngSubmit)="onSubmit($event)" [formGroup]="formGroup" class="form-wrap" #entityForm="ngForm" *ngIf="showDefaults">
            <!-- <ng-container *ngFor="let field of fieldConfig; let i = index">
                 <div [ngClass]="field.class == 'inline' ? 'form-inline' : 'form-line'" id="{{i}}">
                     <div id="dynamicField_{{field.name}}" dynamicField [config]="field" [group]="formGroup" [fieldShow]="isShow(field.name) ? 'show' :'hide'">

--- a/src/app/pages/common/entity/entity-form/entity-form.component.ts
+++ b/src/app/pages/common/entity/entity-form/entity-form.component.ts
@@ -313,6 +313,7 @@ export class EntityFormComponent implements OnInit, OnDestroy, OnChanges, AfterV
           if (this.conf.initial) {
             this.conf.initial.bind(this.conf)(this);
           }
+          // Gets called on most entity forms after ws data returns
           this.showDefaults = true;
         });
       }
@@ -320,6 +321,13 @@ export class EntityFormComponent implements OnInit, OnDestroy, OnChanges, AfterV
     if (this.conf.afterInit) {
       this.conf.afterInit(this);
     }
+    // Stop-gap measure for forms that don't cooperate with the above including
+    // System/Support and Storage/Import Disk
+    // setTimeout(() => { this.setShowDefaults(); }, 500);
+  }
+
+  setShowDefaults() {
+    this.showDefaults = true;
   }
 
   ngOnChanges() {

--- a/src/app/pages/common/entity/entity-form/entity-form.component.ts
+++ b/src/app/pages/common/entity/entity-form/entity-form.component.ts
@@ -323,7 +323,7 @@ export class EntityFormComponent implements OnInit, OnDestroy, OnChanges, AfterV
     }
     // Stop-gap measure for forms that don't cooperate with the above including
     // System/Support and Storage/Import Disk
-    // setTimeout(() => { this.setShowDefaults(); }, 500);
+    setTimeout(() => { this.setShowDefaults(); }, 500);
   }
 
   setShowDefaults() {

--- a/src/app/pages/common/entity/entity-form/entity-form.component.ts
+++ b/src/app/pages/common/entity/entity-form/entity-form.component.ts
@@ -313,7 +313,8 @@ export class EntityFormComponent implements OnInit, OnDestroy, OnChanges, AfterV
           if (this.conf.initial) {
             this.conf.initial.bind(this.conf)(this);
           }
-          // Gets called on most entity forms after ws data returns
+          // Gets called on most entity forms after ws data returns, 
+          // thus hiding messages like 'no data'
           this.showDefaults = true;
         });
       }
@@ -321,8 +322,7 @@ export class EntityFormComponent implements OnInit, OnDestroy, OnChanges, AfterV
     if (this.conf.afterInit) {
       this.conf.afterInit(this);
     }
-    // Stop-gap measure for forms that don't cooperate with the above including
-    // System/Support and Storage/Import Disk
+    // ...but for entity forms that don't make a data request, this kicks in 
     setTimeout(() => { this.setShowDefaults(); }, 500);
   }
 

--- a/src/app/pages/common/entity/entity-form/entity-form.component.ts
+++ b/src/app/pages/common/entity/entity-form/entity-form.component.ts
@@ -131,6 +131,7 @@ export class EntityFormComponent implements OnInit, OnDestroy, OnChanges, AfterV
   public error: string;
   public success = false;
   public data: Object = {};
+  public showDefaults: boolean = false;
 
   constructor(protected router: Router, protected route: ActivatedRoute,
               protected rest: RestService, protected ws: WebSocketService,
@@ -312,6 +313,7 @@ export class EntityFormComponent implements OnInit, OnDestroy, OnChanges, AfterV
           if (this.conf.initial) {
             this.conf.initial.bind(this.conf)(this);
           }
+          this.showDefaults = true;
         });
       }
     });

--- a/src/app/pages/common/entity/entity-table/entity-table.component.html
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.html
@@ -36,7 +36,7 @@
   </div>
 
   <div>
-    <ngx-datatable class='material' 
+    <ngx-datatable *ngIf="showDefaults" class='material' 
       [rows]='seenRows' 
       [columns]="conf.columns" 
       [columnMode]="'force'" 

--- a/src/app/pages/common/entity/entity-table/entity-table.component.ts
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.ts
@@ -154,7 +154,13 @@ export class EntityTableComponent implements OnInit, AfterViewInit {
         this.paginationPageIndex  = 0;
         this.setPaginationInfo();
       });
+
+      setTimeout(() => { this.setShowDefaults(); }, 1000);
     
+  }
+
+  setShowDefaults() {
+    this.showDefaults = true;
   }
   
 

--- a/src/app/pages/common/entity/entity-table/entity-table.component.ts
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.ts
@@ -94,6 +94,7 @@ export class EntityTableComponent implements OnInit, AfterViewInit {
     paging: true,
     sorting: { columns: this.columns },
   };
+  public showDefaults: boolean = false;
 
   protected loaderOpen = false;
   public selected = [];
@@ -153,6 +154,7 @@ export class EntityTableComponent implements OnInit, AfterViewInit {
         this.paginationPageIndex  = 0;
         this.setPaginationInfo();
       });
+    
   }
   
 
@@ -193,6 +195,7 @@ export class EntityTableComponent implements OnInit, AfterViewInit {
       this.getFunction.subscribe((res)=>{
         this.handleData(res);
       });
+
   }
 
   handleData(res): any {
@@ -249,6 +252,7 @@ export class EntityTableComponent implements OnInit, AfterViewInit {
     this.currentRows = this.rows;
     this.paginationPageIndex  = 0;
     this.setPaginationInfo();
+    this.showDefaults = true;
     return res;
 
   }

--- a/src/app/pages/common/entity/entity-task/entity-task.component.ts
+++ b/src/app/pages/common/entity/entity-task/entity-task.component.ts
@@ -37,6 +37,7 @@ export class EntityTaskComponent implements OnInit {
   protected pk: any;
   public isNew: boolean = false;
   protected data: any;
+  public showDefaults: boolean = false;
 
   protected preTaskName: string = '';
 
@@ -215,11 +216,18 @@ export class EntityTaskComponent implements OnInit {
           }
         }
       });
+      this.showDefaults = true;
     }
 
     if (this.conf.afterInit) {
       this.conf.afterInit(this);
     }
+
+    setTimeout(() => { this.setShowDefaults(); }, 500);
+  }
+
+  setShowDefaults() {
+    this.showDefaults = true;
   }
 
   isShow(name: any): any {

--- a/src/app/pages/storage/volumes/volumes-list/volumes-list.component.html
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list.component.html
@@ -120,7 +120,7 @@
       </mat-expansion-panel>
     </mat-accordion>
   </div>
-  <div *ngIf="zfsPoolRows.length < 1">
+  <div *ngIf="zfsPoolRows.length < 1 && showDefaults">
     <mat-card>
       <mat-card-content name="no_pools">
         {{"No pools" | translate}}

--- a/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
@@ -497,7 +497,7 @@ export class VolumesListComponent extends EntityTableComponent implements OnInit
     protected mdDialog: MatDialog, protected erdService: ErdService, protected translate: TranslateService) {
     super(rest, router, ws, _eRef, dialogService, loader, erdService, translate);
   }
-
+  public showDefaults: boolean = false;
   public repaintMe() {
     this.paintMe = false;
     this.ngOnInit();
@@ -509,6 +509,7 @@ export class VolumesListComponent extends EntityTableComponent implements OnInit
     }
 
     this.ws.call('pool.dataset.query', []).subscribe((datasetData) => {
+      this.loader.open();
       this.rest.get("storage/volume", {}).subscribe((res) => {
         res.data.forEach((volume: ZfsPoolData) => {
           volume.volumesListTableConfig = new VolumesListTableConfig(this, this.router, volume.id, volume.name, datasetData, this.mdDialog, this.rest, this.ws, this.dialogService, this.loader, this.translate);
@@ -533,7 +534,10 @@ export class VolumesListComponent extends EntityTableComponent implements OnInit
           this.expanded = true;
         }
 
-        this.paintMe = true;
+        this.paintMe = true; 
+        this.showDefaults = true;
+        this.loader.close();
+        
       }, (res) => {
         this.dialogService.errorReport(T("Error getting pool data"), res.message, res.stack);
       });

--- a/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
@@ -539,9 +539,11 @@ export class VolumesListComponent extends EntityTableComponent implements OnInit
         this.loader.close();
         
       }, (res) => {
+        this.loader.close();
         this.dialogService.errorReport(T("Error getting pool data"), res.message, res.stack);
       });
     }, (res) => {
+      this.loader.close();
       this.dialogService.errorReport(T("Error getting pool data"), res.message, res.stack);
     });
 


### PR DESCRIPTION
Current behavior for tables and forms is to show defaults (such as "No data" or empty fields) until data loads and is filled in.This can be misleading. So this branch...
- Hides defaults until data requests complete - for entity tables, forms, tasks and also Pools list page
- Includes a brief timeout for the entity docs after which the defaults load even if the data isn't back. This timeout is the max. time the display will wait. If data comes back quicker, the page loads quicker. 
- Adds a loader (spinner) on the pools page, since it often takes noticeable time to load.