### PR TITLE
Fix/sort pool list 33801

### DIFF
--- a/src/app/pages/storage/volumes/manager/manager.component.ts
+++ b/src/app/pages/storage/volumes/manager/manager.component.ts
@@ -149,6 +149,9 @@ export class ManagerComponent implements OnInit, OnDestroy {
         res[i]['capacity'] = (<any>window).filesize(res[i]['capacity'], {standard : "iec"});
         this.disks.push(res[i]);
       }
+      
+     this.disks = this.sorter.mySorter(this.disks, 'devname');
+
 
       // assign disks for suggested layout
       let largest_capacity = 0;

--- a/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
@@ -19,7 +19,7 @@ import { Injectable } from '@angular/core';
 import { ErdService } from 'app/services/erd.service';
 import { T } from '../../../../translate-marker';
 import { EntityJobComponent } from '../../../common/entity/entity-job/entity-job.component';
-
+import { StorageService } from '../../../../services/storage.service'
 
 
 export interface ZfsPoolData {
@@ -494,7 +494,8 @@ export class VolumesListComponent extends EntityTableComponent implements OnInit
 
   constructor(protected rest: RestService, protected router: Router, protected ws: WebSocketService,
     protected _eRef: ElementRef, protected dialogService: DialogService, protected loader: AppLoaderService,
-    protected mdDialog: MatDialog, protected erdService: ErdService, protected translate: TranslateService) {
+    protected mdDialog: MatDialog, protected erdService: ErdService, protected translate: TranslateService,
+    public sorter: StorageService) {
     super(rest, router, ws, _eRef, dialogService, loader, erdService, translate);
   }
 
@@ -528,6 +529,8 @@ export class VolumesListComponent extends EntityTableComponent implements OnInit
           }
           this.zfsPoolRows.push(volume);
         });
+        
+        this.zfsPoolRows = this.sorter.mySorter(this.zfsPoolRows, 'name');
 
         if (this.zfsPoolRows.length === 1) {
           this.expanded = true;

--- a/src/app/services/storage.service.ts
+++ b/src/app/services/storage.service.ts
@@ -20,7 +20,7 @@ export class StorageService {
   mySorter(myArray, key) {
   let tempArr = [];
   myArray.forEach((item) => {
-    tempArr.push(item.devname);
+    tempArr.push(item[key]);
   })
   // The Intl Collator allows language-sensitive str comparison and can allow for numbers
   let myCollator = new Intl.Collator(undefined, {numeric: true, sensitivity: 'base'});


### PR DESCRIPTION
Used the natural sorting function in storage service to sort pool list. Also, noticed that pools in the manager weren't sorted on page- load and fixed this. Tested this before upload but unable to do final test because of trouble running the current build.