### PR TITLE
Fixed breakage with device-edit form

### DIFF
--- a/src/app/pages/vm/devices/device-edit/device-edit.component.html
+++ b/src/app/pages/vm/devices/device-edit/device-edit.component.html
@@ -1,0 +1,46 @@
+<ng-template [ngTemplateOutlet]="templateTop" [ngTemplateOutletContext]="this"></ng-template>
+<p *ngIf="!hasConf">
+    Please <button mat-raised-button color="primary" class="btn btn-link" type="button" (click)="goConf()">Click here</button> to setup configuration first.
+</p>
+<mat-card class="form-card">
+    <div class="mat-content">
+      <!--<form (ngSubmit)="onSubmit($event)" [formGroup]="formGroup" class="form-wrap" #entityForm="ngForm" *ngIf="showDefaults">-->
+        <form (ngSubmit)="onSubmit($event)" [formGroup]="formGroup" class="form-wrap" #entityForm="ngForm">
+           <!-- <ng-container *ngFor="let field of fieldConfig; let i = index">
+                <div [ngClass]="field.class == 'inline' ? 'form-inline' : 'form-line'" id="{{i}}">
+                    <div id="dynamicField_{{field.name}}" dynamicField [config]="field" [group]="formGroup" [fieldShow]="isShow(field.name) ? 'show' :'hide'">
+                    </div>
+                </div>
+                </ng-container>-->
+                <div class="fieldset-container fieldset-display-default" *ngIf="fieldSets">
+            <ng-container *ngFor="let fieldSet of fieldSets; let i = index">
+              <div [ngClass]="fieldSet.class" class="fieldset divider-{{fieldSet.divider}}"
+                  fxLayout="row wrap" fxLayoutAlign="start start" fxFlex="100%" fxFlex.gt-xs="calc({{fieldSets[i].width}} - 16px)">
+                <mat-divider *ngIf="fieldSets[i].divider && i > 0"></mat-divider>
+                <!--<ng-template>-->
+                  <h4 *ngIf="fieldSet.label" class="fieldset-label">{{fieldSet.name}}</h4>
+                  <div *ngFor="let field of fieldSet.config; let ii = index" fxFlex="100%" fxFlex.gt-xs="calc({{field.width}} - 16px)"
+                    [ngClass]="field.class == 'inline' ? 'form-inline' : 'form-line'" id="{{fieldSet.name}}-{{ii}}">
+                    <div id="form_field_{{field.name}}" dynamicField [config]="field" [group]="formGroup" [fieldShow]="isShow(field.name) ? 'show' :'hide'"></div>
+                  </div>
+                <!--</ng-template>-->
+              </div>
+            </ng-container>
+            <mat-card-actions class="buttons">
+                <button id="save_button" class="btn btn-block btn-warning" type="submit" mat-button color="primary" [disabled]="!entityForm.form.valid" >{{saveSubmitText | translate}}</button>
+                <button id="goback_button" *ngIf="conf.route_success" class="btn  btn-block btn-raised btn-lg btn-primary" type="button" (click)="goBack()" mat-button color="accent">{{"Cancel" | translate}}</button>
+                <!-- </div> -->
+                <!-- <div class="btn-group btn-group-justified btn-group-raised"> -->
+                <span *ngFor="let custBtn of conf.custActions">
+                  <button id="cust_button_{{custBtn.name}}" mat-button *ngIf="!conf.isCustActionVisible || conf.isCustActionVisible(custBtn.id)" type="button" (click)="custBtn['function']()">{{custBtn.name | translate}}</button>
+                </span>
+                <button mat-button *ngIf="conf.route_delete" class="btn btn-block btn-danger" type="button" (click)="gotoDelete()">{{"Delete" | translate}}</button>
+                <!-- </div> -->
+            </mat-card-actions>
+          </div>
+            <!-- <div class="btn-group btn-group-justified btn-group-raised"> -->
+        </form>
+        <p *ngIf="success" type="success" id="successfully_updated">{{"Successfully updated." | translate}}</p>
+        <p *ngIf="error" type="danger" id="error_message"><span [innerHTML]="error"></span></p>
+    </div>
+</mat-card>

--- a/src/app/pages/vm/devices/device-edit/device-edit.component.scss
+++ b/src/app/pages/vm/devices/device-edit/device-edit.component.scss
@@ -1,0 +1,94 @@
+/*.mat-card{
+  max-width:960px;
+  margin:0 auto;
+}*/
+
+.form-wrap {
+	display: flex;
+    flex-flow: row wrap;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+    box-sizing: border-box;
+}
+
+.form-line {
+	flex: 1 1 100%;
+    box-sizing: border-box;
+    -webkit-box-flex: 1;
+    max-width: 100%;
+}
+
+.form-inline {
+	flex: 1 1 33.33%;
+    box-sizing: border-box;
+    -webkit-box-flex: 1;
+    max-width: 33.33%;
+}
+
+.form-card {
+    z-index:2;
+}
+
+.buttons {
+    margin-left: 1px;
+}
+
+
+/* Imported from embedded */
+/* Embedded Form Styles */
+.mat-content {
+  padding:0 ;
+  width:100%;
+  height:100%;
+}
+
+.mat-card-actions{
+  width: 100%;
+  margin-bottom:0;
+  /*height: 10%;*/
+  /*text-align: center;*/
+  /*background-color: #fff;*/
+  /*margin: 5px 0px;*/
+  /*position: absolute;*/
+  /*bottom: 0; */
+}
+
+.fieldset-container{
+  /*position: fixed;*/
+  width:100%;
+  height: 85%;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+.fieldset-container .fieldset{
+  display:flex;
+  flex-flow:row wrap;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal; 
+}
+
+.fieldset.divider-true{
+  min-height:32px;
+  padding-top:16px;
+}
+
+.fieldset-container .fieldset .tooltip .material-icons{
+  font-size:12px;
+}
+
+/* Default View */
+.fieldset-container.fieldset-display-default{
+  /*padding: 3%;*/
+}
+.fieldset-container.fieldset-display-default .fieldset{
+  width:100%;
+  margin:24px 0;
+  /*height: 100%;*/
+  /*float: left;*/
+}
+
+/* No Margins*/
+.fieldset-container.fieldset-display-default .fieldset{
+  margin:0;
+}

--- a/src/app/pages/vm/devices/device-edit/device-edit.component.ts
+++ b/src/app/pages/vm/devices/device-edit/device-edit.component.ts
@@ -22,15 +22,17 @@ import {WebSocketService, NetworkService, SystemGeneralService} from '../../../.
 import {VmService} from '../../../../services/vm.service';
 import {EntityUtils} from '../../../common/entity/utils';
 import {EntityFormService} from '../../../../pages/common/entity/entity-form/services/entity-form.service';
-import { Formconfiguration } from 'app/pages/common/entity/entity-form/entity-form.component';
+import { EntityFormComponent, Formconfiguration } from 'app/pages/common/entity/entity-form/entity-form.component';
+import { FieldSet } from 'app/pages/common/entity/entity-form/models/fieldset.interface';
 import {EntityTemplateDirective} from '../../../common/entity/entity-template.directive';
 import {regexValidator} from '../../../common/entity/entity-form/validators/regex-validation';
 
 @Component({
   selector : 'device-edit',
-  // WTF?
   //templateUrl : '../../../common/entity/entity-form/entity-form.component.html',
-  template:'<entity-form [conf]="conf"></entity-form>',
+  //template:'<entity-form [conf]="conf"></entity-form>',
+  templateUrl : './device-edit.component.html',
+  styleUrls: ['./device-edit.component.scss'],
   providers : [ VmService ]
 })
 
@@ -51,7 +53,12 @@ export class DeviceEditComponent implements OnInit {
   public busy: Subscription;
   public DISK_zvol: any;
   public fieldConfig: FieldConfig[] = [];
-  public conf: any = {};
+  public fieldSets: FieldSet[] = [{
+    name: 'Config',
+    class: 'config',
+    config: []
+  }];
+  public conf: Formconfiguration = {};
   public hasConf = true;
   public success = false;
   private nic_attach: any;
@@ -86,7 +93,7 @@ export class DeviceEditComponent implements OnInit {
       this.pk = params['pk'];
     });
     if (this.dtype === "CDROM") {
-      this.fieldConfig = [
+      this.fieldSets[0].config = [
         {
           type : 'explorer',
           initial: '/mnt',
@@ -97,7 +104,7 @@ export class DeviceEditComponent implements OnInit {
         },
       ];
     } else if (this.dtype === "NIC") {
-      this.fieldConfig = [
+      this.fieldSets[0].config = [
         {
           name : 'NIC_type',
           placeholder : 'Adapter Type:',
@@ -136,7 +143,7 @@ export class DeviceEditComponent implements OnInit {
         },
       ];
     } else if (this.dtype === "VNC") {
-      this.fieldConfig = [
+      this.fieldSets[0].config = [
         {
           name : 'VNC_port',
           placeholder : 'Port',
@@ -192,7 +199,7 @@ export class DeviceEditComponent implements OnInit {
         },
       ];
     } else if (this.dtype === "DISK") {
-      this.fieldConfig = [
+      this.fieldSets[0].config = [
         {
           name : 'DISK_zvol',
           placeholder : 'Zvol',
@@ -228,7 +235,7 @@ export class DeviceEditComponent implements OnInit {
         },
       ];
     } else if (this.dtype === "RAW") {
-      this.fieldConfig = [
+      this.fieldSets[0].config = [
         {
           type : 'explorer',
           initial: '/mnt',
@@ -292,7 +299,8 @@ export class DeviceEditComponent implements OnInit {
 
   afterInit(){
     const self = this;
-    this.formGroup = this.entityFormService.createFormGroup(this.fieldConfig);
+    //this.formGroup = this.entityFormService.createFormGroup(this.fieldSets[0].config);
+    this.formGroup = this.entityFormService.createFormGroup(this.fieldSets[0].config);
     const vnc_lookup_table: Object = {
       'vnc_port' : 'VNC_port',
       'vnc_resolution' : 'VNC_resolution',
@@ -328,7 +336,8 @@ export class DeviceEditComponent implements OnInit {
       }
       else if(device[0].dtype === 'VNC'){
         this.systemGeneralService.getIPChoices().subscribe((ipchoices) => {
-          this.vnc_bind = _.find(this.fieldConfig, {'name' : 'vnc_bind'});
+          //this.vnc_bind = _.find(this.fieldSets[0].config, {'name' : 'vnc_bind'});
+          this.vnc_bind = _.find(this.fieldSets[0].config, {'name' : 'vnc_bind'});
           for(const ipchoice of ipchoices){
             this.vnc_bind.options.push({label : ipchoice[1], value : ipchoice[0]});
           }
@@ -361,9 +370,9 @@ export class DeviceEditComponent implements OnInit {
       }
       else {
         if (device[0].vm.vm_type==="Container Provider"){
-          this.RAW_boot = _.find(this.fieldConfig, {name:'RAW_boot'})
-          this.RAW_rootpwd = _.find(this.fieldConfig, {name:'RAW_rootpwd'})
-          this.RAW_size = _.find(this.fieldConfig, {name:'RAW_size'})
+          this.RAW_boot = _.find(this.fieldSets[0].config, {name:'RAW_boot'})
+          this.RAW_rootpwd = _.find(this.fieldSets[0].config, {name:'RAW_rootpwd'})
+          this.RAW_size = _.find(this.fieldSets[0].config, {name:'RAW_size'})
           this.RAW_boot.isHidden = false
           this.RAW_rootpwd.isHidden = false
           this.RAW_size.isHidden = false

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -415,6 +415,7 @@ tr.dx-row:nth-child(odd){
 //Entity Module Overrides
 
 entity-task .form-card.mat-card,
+device-edit .form-card.mat-card,
 entity-form .form-card.mat-card{
   max-width:960px;
   margin:0 auto;


### PR DESCRIPTION
The device-edit component was using only the template from entity-form and nothing else. When fieldsets were added to entity-form, this caused some breakage. Wasn't noticed since technically this component is not using entity-form, only the template. Copied scss and html files from entity-form so device-edit could safely have it's own modifications without causing trouble. Wrapped fieldConfig inside a fieldset so look and feel and features can be consistent with entity-form. At some point this and all other forms should be converted to entity-form.