### PR TITLE
Fix css in top bar, breadcrumb area, on VM page

### DIFF
--- a/src/app/components/common/breadcrumb/breadcrumb.component.css
+++ b/src/app/components/common/breadcrumb/breadcrumb.component.css
@@ -31,3 +31,15 @@
   position: absolute;
   right: 4px;
 }
+
+@media screen and (max-width: 400px) {
+  .copyright-txt {
+    font-size: 75%;
+  }
+}
+
+@media screen and (max-width: 348px) {
+  .copyright-txt {
+    font-size: 65%;
+  }
+}

--- a/src/app/components/common/topbar/topbar.template.html
+++ b/src/app/components/common/topbar/topbar.template.html
@@ -1,7 +1,7 @@
 <mat-toolbar class="topbar lola">
   <mat-toolbar-row>
     <!-- Sidenav toggle button -->
-    <button mat-icon-button id="sidenavToggle" (click)="toggleSidenav()" matTooltip="Toggle Hide/Open">
+    <button mat-icon-button id="sidenavToggle" (click)="toggleSidenav()" matTooltip="Toggle Hide/Open" matTooltipPosition="right">
       <mat-icon>menu</mat-icon>
     </button>
     <!-- Sidenav toggle collapse -->

--- a/src/app/pages/vm/vm-cards/vm-cards.component.css
+++ b/src/app/pages/vm/vm-cards/vm-cards.component.css
@@ -35,7 +35,7 @@ mat-card.card-filter .view-controls{
   width:22%;
   position:relative;
 /*  text-align:right;*/
-  min-width: 274px;
+  min-width: 285px;
   margin-right: 16px;
   margin-top:10px;
 }
@@ -208,4 +208,34 @@ mat-chip.vm-state-on,
   bottom: 90px;
   left: 116px;
   position: fixed;
+}
+
+/* Fix layout on Ffx, adujst on Webkit */
+#add-vm-button {
+  vertical-align: text-top;
+  transform: none;
+  -moz-transform:translateY(-20px);
+}
+
+/* Change VM header layout at smaller sizes*/
+@media screen and (max-width: 650px) {
+  #filter-control-card {
+    max-width: 483px;
+    min-width: 400px;
+  }
+  .filter-field {
+    margin-left: -15px;
+  }
+  #vm-header {
+    display: inline-block;
+    margin: 3% 17%; 
+  }
+  #search-icon {
+    margin-top: 12px;
+  }
+
+  .view-controls {
+    margin-top: -15px !important;
+  }
+  
 }

--- a/src/app/pages/vm/vm-cards/vm-cards.component.html
+++ b/src/app/pages/vm/vm-cards/vm-cards.component.html
@@ -3,14 +3,14 @@
   It's role is management of data and creating/destroying
   views. 
 -->
-<mat-card class="card-filter">
-  <mat-card-header>
+<mat-card id="filter-control-card" class="card-filter">
+  <mat-card-header id="vm-header">
     <!--
       This is the filter bar which shares an mat-card 
       with the table view
     -->
     <div class="filter-field">
-      <mat-icon role="img">search</mat-icon>
+      <mat-icon id="search-icon" role="img">search</mat-icon>
       <div class="card-filter-field">
         <mat-input-container floatPlaceholder="Filter VMs">
           <input matInput #filter placeholder="Filter VM List" [ngModel]="searchTerm" (ngModelChange)="displayFilter('name',$event)">
@@ -30,7 +30,7 @@
             <button mat-fab><mat-icon>list</mat-icon></button>
         </smd-fab-trigger>
         <smd-fab-actions> -->
-          <button *ngFor="let action of actions" mat-mini-fab (click)="action.onClick()" matTooltip="{{action.label | translate}}">
+          <button id="add-vm-button" *ngFor="let action of actions" mat-mini-fab (click)="action.onClick()" matTooltip="{{action.label | translate}}">
             <mat-icon>{{action.icon}}</mat-icon>
           </button>
         <!-- </smd-fab-actions>


### PR DESCRIPTION
Ticket: #35281
Fix hamburger menu tooltip from going off screen when sidenav is closed
VM page - fixes broken alignment of fab button on firefox. adjusts on webkit
Makes VM header line up on smaller screens
Shrinks copyright text in breadcrumb area when screen gets small