### PR TITLE
Make filter function case insensitive

### DIFF
--- a/src/app/pages/common/entity/entity-table/entity-table.component.ts
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.ts
@@ -138,9 +138,10 @@ export class EntityTableComponent implements OnInit, AfterViewInit {
               let value: any = dataElement[dataElementProp.prop];
               
               if( typeof(value) === "boolean" || typeof(value) === "number") {
-                value = String(value);
+                value = String(value).toLowerCase();
               }
-              if (typeof (value) === "string" && value.length > 0 && (<string>value).indexOf(filterValue) >= 0) {
+              if (typeof (value) === "string" && value.length > 0 && 
+                (<string>value.toLowerCase()).indexOf(filterValue.toLowerCase()) >= 0) {
                 newData.push(dataElement);
                 break;
               }


### PR DESCRIPTION
Ticket: #33954
I think the filter works great - a few keystrokes usually gets you down to just a result or two. One improvement is that it should be case insensitive. We could easily make the filter ignore booleans, but I think this might cause more headaches than it solves.