### PR TITLE
Css fixes misc

### DIFF
--- a/src/app/pages/common/entity/entity-job/entity-job.component.html
+++ b/src/app/pages/common/entity/entity-job/entity-job.component.html
@@ -2,7 +2,7 @@
 <div mat-dialog-content class="entity-job-dialog">
 	<div *ngIf="job && job.state == 'RUNNING'">
 	    <mat-progress-bar class="example-margin"
-			color="primary"
+			
 			mode="indeterminate"
 			[value]="progressTotalPercent"
 			bufferValue="bufferValue">

--- a/src/app/pages/common/entity/entity-job/entity-job.component.html
+++ b/src/app/pages/common/entity/entity-job/entity-job.component.html
@@ -2,7 +2,7 @@
 <div mat-dialog-content class="entity-job-dialog">
 	<div *ngIf="job && job.state == 'RUNNING'">
 	    <mat-progress-bar class="example-margin"
-			
+			color: "primary";
 			mode="indeterminate"
 			[value]="progressTotalPercent"
 			bufferValue="bufferValue">

--- a/src/app/pages/common/entity/entity-job/entity-job.component.html
+++ b/src/app/pages/common/entity/entity-job/entity-job.component.html
@@ -2,7 +2,7 @@
 <div mat-dialog-content class="entity-job-dialog">
 	<div *ngIf="job && job.state == 'RUNNING'">
 	    <mat-progress-bar class="example-margin"
-			color="primary";
+			color="primary"
 			mode="indeterminate"
 			[value]="progressTotalPercent"
 			bufferValue="bufferValue">

--- a/src/app/pages/common/entity/entity-job/entity-job.component.html
+++ b/src/app/pages/common/entity/entity-job/entity-job.component.html
@@ -2,7 +2,7 @@
 <div mat-dialog-content class="entity-job-dialog">
 	<div *ngIf="job && job.state == 'RUNNING'">
 	    <mat-progress-bar class="example-margin"
-			color: "primary";
+			color="primary";
 			mode="indeterminate"
 			[value]="progressTotalPercent"
 			bufferValue="bufferValue">

--- a/src/app/pages/directoryservice/idmap/idmap.component.html
+++ b/src/app/pages/directoryservice/idmap/idmap.component.html
@@ -41,9 +41,9 @@
 	    <ng-container *ngFor="let tdb2Field of tdb2FieldConfig;" dynamicField [config]="tdb2Field" [group]="formGroup">
 	    </ng-container>
 	</div>
-    <mat-card-actions>
-      <button class="btn btn-block btn-warning" type="submit" mat-raised-button color="primary">Save</button>
-      <button *ngIf="route_success" (click)="goBack()" mat-raised-button color="accent" type="button">Cancel</button>
+    <mat-card-actions id="idmap-actions">
+      <button class="btn btn-block btn-warning" type="submit" mat-button color="primary">Save</button>
+      <button *ngIf="route_success" (click)="goBack()" mat-button color="accent" type="button">Cancel</button>
     </mat-card-actions>
   </form>
 </mat-card>

--- a/src/app/pages/task-calendar/cloudsync/cloudsync-form/cloudsync-form.component.html
+++ b/src/app/pages/task-calendar/cloudsync/cloudsync-form/cloudsync-form.component.html
@@ -4,8 +4,8 @@
     <ng-container *ngFor="let field of fieldConfig;" dynamicField [config]="field" [group]="formGroup" [fieldShow]="'show'">
     </ng-container>
     <mat-card-actions class="buttons">
-      <button class="btn btn-block btn-warning" type="submit" mat-raised-button color="primary" [disabled]="!formGroup.valid || !validCredential">{{ "Save" | translate }}</button>
-      <button *ngIf="route_success" (click)="goBack()" type="button" mat-raised-button color="accent">{{ "Cancel" | translate }}</button>
+      <button class="btn btn-block btn-warning" type="submit" mat-button color="primary" [disabled]="!formGroup.valid || !validCredential">{{ "Save" | translate }}</button>
+      <button *ngIf="route_success" (click)="goBack()" type="button" mat-button color="accent">{{ "Cancel" | translate }}</button>
     </mat-card-actions>
   </form>
 </mat-card>

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -599,15 +599,6 @@ entity-form .form-card.mat-card{
   min-width: 100%;
 }
 
-.mat-tab-label-active {
-  // @include variable(color, --primary, $primary, !important);
-  border-bottom: 2px solid map-get($md-primary, 500);
-}
-
-.mat-ink-bar {
-  @include variable(background-color, --primary, $primary, !important);
-}
-
 // Align button and tooltip on Add Replication form
 #repl_remote_hostkey button {
   left: 17px;
@@ -627,3 +618,22 @@ entity-form .form-card.mat-card{
   @include variable(background-color, --accent, $accent, !important);
 
 }
+
+// Fix a layout problem on Sharing/ISCSI page with ink-bar under active link...
+iscsi .mat-tab-label-active {
+  border-bottom: 2px solid;
+  @include variable(border-color, --primary, $primary);
+}
+//...by hiding ink bar, replacing it with a bottom border, above.
+iscsi .mat-ink-bar {
+  opacity: 0;
+}
+
+// .mat-button.mat-primary {
+//   @include variable(color, --primary, $primary, !important);
+// }
+
+
+// .mat-button.mat-primary:hover {
+//   @include variable(background-color, --primary, $primary, !important);
+// }

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -633,6 +633,7 @@ iscsi .mat-ink-bar {
 // Properly align buttons on Dir Services / Idmap
 #idmap-actions {
   margin-left: 0;
+}
   
 // Removes extra space at the bottom of datatables
 .ngx-datatable .datatable-body {

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -629,6 +629,7 @@ iscsi .mat-ink-bar {
   opacity: 0;
 }
 
+// Properly align buttons on Dir Services / Idmap
 #idmap-actions {
   margin-left: 0;
 }

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -629,11 +629,6 @@ iscsi .mat-ink-bar {
   opacity: 0;
 }
 
-// .mat-button.mat-primary {
-//   @include variable(color, --primary, $primary, !important);
-// }
-
-
-// .mat-button.mat-primary:hover {
-//   @include variable(background-color, --primary, $primary, !important);
-// }
+#idmap-actions {
+  margin-left: 0;
+}

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -599,9 +599,10 @@ entity-form .form-card.mat-card{
   min-width: 100%;
 }
 
-// .mat-tab-label-active {
-//   @include variable(color, --primary, $primary, !important);
-// }
+.mat-tab-label-active {
+  // @include variable(color, --primary, $primary, !important);
+  border-bottom: 2px solid map-get($md-primary, 500);
+}
 
 .mat-ink-bar {
   @include variable(background-color, --primary, $primary, !important);
@@ -615,4 +616,14 @@ entity-form .form-card.mat-card{
 #repl_remote_hostkey .tooltip {
   left: 135px;
   top: -55px
+}
+
+// Theme color for slider (Shell page and elsewhere)
+.mat-slider {
+  @include variable(color, --accent, $accent, !important);
+}
+
+.mat-slider-track-fill, .mat-slider-thumb {
+  @include variable(background-color, --accent, $accent, !important);
+
 }

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -598,3 +598,21 @@ entity-form .form-card.mat-card{
 .datatable-scroll {
   min-width: 100%;
 }
+
+// .mat-tab-label-active {
+//   @include variable(color, --primary, $primary, !important);
+// }
+
+.mat-ink-bar {
+  @include variable(background-color, --primary, $primary, !important);
+}
+
+// Align button and tooltip on Add Replication form
+#repl_remote_hostkey button {
+  left: 17px;
+}
+
+#repl_remote_hostkey .tooltip {
+  left: 135px;
+  top: -55px
+}


### PR DESCRIPTION
Ticket: #36828

- Buttons on idmap page - aligns and flattens
- Buttons on CloudSync page - flattens
- Button and tooltip on Add Replication form - fixes alignment
- Makes the slider on the Shell pick up theme color
- Replaces the ink-bar (highlight) for the tabs on the Sharing/ISCSI with bottom borders for each tab, since the ink-bar feature won't wrap for two rows of tabs