### PR TITLE
Fixes/datatable and swatches etc

### DIFF
--- a/src/app/pages/preferences/page/forms/customtheme/customtheme.component.ts
+++ b/src/app/pages/preferences/page/forms/customtheme/customtheme.component.ts
@@ -400,7 +400,8 @@ export class CustomThemeComponent implements OnInit, OnChanges, OnDestroy {
         switch(evt.name){
           case "FormSubmitted":
             let valid:boolean = this.validateForm(evt.data);
-            if(valid){
+             if(valid){
+              evt.data.labelSwatch = evt.data.labelSwatch.slice(6, -1);
               evt.data.accentColors = ['blue', 'orange','green', 'violet','cyan', 'magenta', 'yellow','red'];
               this.core.emit({name:"AddCustomThemePreference",data:evt.data});
               this.globalPreview = false;

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -598,3 +598,8 @@ entity-form .form-card.mat-card{
 .datatable-scroll {
   min-width: 100%;
 }
+
+// Removes extra space at the bottom of datatables
+.ngx-datatable .datatable-body {
+  margin-bottom: -6px;
+}

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -603,3 +603,8 @@ entity-form .form-card.mat-card{
 .ngx-datatable .datatable-body {
   margin-bottom: -6px;
 }
+
+// ...with an exception for the vm table
+vm-table .ngx-datatable .datatable-body {
+  margin-bottom: 0px;
+}


### PR DESCRIPTION
- Currently, if you create a custom theme, the swatch doesn't appear in the menu. The fix is that, in customtheme.component.ts, the object returns with a labelSwatch property of something like `var(--bg1)` or `var(--red)`, but what works for the menu is simply `bg1` or `red` so the fix is to slice out the rest.

- The other fix is getting rid of a space above the footer of data tables (especially noticeable on a dark theme) with an exception for the VM table. 