### PR TITLE
Fix entity table checkboxes 37690

### DIFF
--- a/src/app/pages/common/entity/entity-table/entity-table.component.html
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.html
@@ -37,13 +37,16 @@
   <ul>
     <li *ngFor="let col of allColumns">
       <div>
-        <mat-checkbox
-          type="checkbox"
-          class="colselect"
-          [id]="col.name"
-          (change)="toggle(col)"
-          [checked]="isChecked(col)"></mat-checkbox>
-        <label [attr.for]="col.name">{{col.name}}</label>
+        <label>
+          <mat-checkbox
+            type="checkbox"
+            class="colselect"
+            [id]="col.name"
+            (change)="toggle(col)"
+            [checked]="isChecked(col)">
+          </mat-checkbox>
+          {{col.name}}
+        </label>
       </div>
     </li>
   </ul>
@@ -84,7 +87,7 @@
       [offset]="paginationPageIndex"
       (page)='paginationUpdate($event)'
       (sort)='reorderEvent($event)'
-      [selectionType]="'multiClick'"
+      [selectionType]="'checkbox'"
       [selected]='selected'
       (select)='onSelect($event)'
       [scrollbarH]='true'

--- a/src/app/pages/common/entity/entity-table/entity-table.component.html
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.html
@@ -25,13 +25,14 @@
 <!-- Selected columns checkbox ----------------- -->
 <div id="col-select-box" class="selected-columns" *ngIf="allColumns.length > 10 ? true : false">
   <div id="select-all-checkbox-and-label">
-    Toggle
+    <label>Toggle
     <mat-checkbox
-      type="checkbox"
-      [id]="check-all"
-      [checked]="checkLength()"
-      (change)="checkAll()">
-    </mat-checkbox> 
+        type="checkbox"
+        [id]="check-all"
+        [checked]="checkLength()"
+        (change)="checkAll()">
+      </mat-checkbox> 
+    </label>
     
   </div>
   <ul>

--- a/src/app/pages/storage/volumes/manager/manager.component.html
+++ b/src/app/pages/storage/volumes/manager/manager.component.html
@@ -43,7 +43,7 @@
                 [columnMode]="'force'"
                 [limit]="10"
                 [selected] = "selected"
-                [selectionType]="'multiClick'"
+                [selectionType]="'checkbox'"
                 (select)='onSelect($event)'>
                 <ngx-datatable-column [width]="80" [sortable]="false" [canAutoResize]="false" [draggable]="false" [resizeable]="false">
                   <ng-template ngx-datatable-header-template let-value="value" let-allRowsSelected="allRowsSelected" let-selectFn="selectFn">

--- a/src/app/pages/storage/volumes/manager/vdev/vdev.component.html
+++ b/src/app/pages/storage/volumes/manager/vdev/vdev.component.html
@@ -13,7 +13,7 @@
         [footerHeight]="'auto'" 
         [limit]="10"
         [selected] = "selected"
-        [selectionType]="'multiClick'"
+        [selectionType]="'checkbox'"
         (select)='onSelect($event)'>
         <ngx-datatable-column [width]="80" [sortable]="false" [canAutoResize]="false" [draggable]="false" [resizeable]="false">
             <ng-template ngx-datatable-header-template let-value="value" let-allRowsSelected="allRowsSelected" let-selectFn="selectFn">


### PR DESCRIPTION
Ticket: #37690
- I reset the entity table selection method from check box to multi row last week (to make it possible to select by clicking anywhere on the row), but should have known better. It appears to work at first, but doesn't really. This rolls it back.
- This branch also adds the ability to click on the labels of the column-selecting check boxes (on the Users page, for example) to check the box.