### PR TITLE
Remove ellipsis on overflow to allow data to show

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "angular-calendar": "0.23.2",
     "angular-draggable-droppable": "^2.0.0",
     "angular-resizable-element": "^2.0.0",
-    "angular-svg-icon": "^5.1.1",
+    "angular-svg-icon": "5.1.1",
     "angular-tree-component": "7.1.0",
     "angular2-markdown": "2.2.2",
     "angular2-moment": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "angular-calendar": "0.23.2",
     "angular-draggable-droppable": "^2.0.0",
     "angular-resizable-element": "^2.0.0",
-    "angular-svg-icon": "5.1.1",
+    "angular-svg-icon": "^5.1.1",
     "angular-tree-component": "7.1.0",
     "angular2-markdown": "2.2.2",
     "angular2-moment": "1.8.0",

--- a/src/assets/styles/fn-styles.css
+++ b/src/assets/styles/fn-styles.css
@@ -1379,8 +1379,3 @@ body.safari-platform .mat-raised-button {
     line-height: 1 !important;
     font-family: Consolas,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New, monospace !important;
 }
-
-ngx-datatable * { 
-    overflow: hidden; 
-    text-overflow: ellipsis; 
-} 


### PR DESCRIPTION
Ticket: #37666 (also addresses #37453). 

Removes ellipsis on text overflow for data tables.

With horizontal scroll bars on data tables, there are few reasons to keep the ellipsis on text overflow, and the ellipsis is causing a new problem - making data invisible until user scrolls over - on TrueOS, at least). 

Ticket 37453 reports shifting check boxes, which I haven't been able to duplicate but which the ticketer says is solved by removing the ellipsis (which was a known issue with the ellipsis in the past).