### PR TITLE
Fill in gap above scroll bar with background color

### DIFF
--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -735,3 +735,8 @@ vm-table .ngx-datatable .datatable-body {
 .form-ex-flex-container {
   @include variable(background, --bg1, $bg1);
 }
+
+.datatable-body {
+  @include variable(background-color, --alt-bg1, $alt-bg1);
+
+}


### PR DESCRIPTION
Ticket: #38605
- Fix another gap in entity table, this one added by the horz scroll bar; fixed by filling in the background color