### PR TITLE
Hide collapsed toggle when sidenav is offscreen to keep it from getting out of sync

### DIFF
--- a/src/app/components/common/topbar/topbar.component.ts
+++ b/src/app/components/common/topbar/topbar.component.ts
@@ -138,7 +138,6 @@ export class TopbarComponent implements OnInit, OnDestroy {
     // Fix for sidebar
     if(!domHelper.hasClass(appBody, 'collapsed-menu')) {
       (<HTMLElement>document.querySelector('mat-sidenav-content')).style.marginLeft = '240px';
-      // this.toggleSidenav();
     }
   }
 

--- a/src/app/components/common/topbar/topbar.component.ts
+++ b/src/app/components/common/topbar/topbar.component.ts
@@ -134,6 +134,12 @@ export class TopbarComponent implements OnInit, OnDestroy {
 
     domHelper.toggleClass(appBody, 'collapsed-menu');
     domHelper.removeClass(document.getElementsByClassName('has-submenu'), 'open');
+
+    // Fix for sidebar
+    if(!domHelper.hasClass(appBody, 'collapsed-menu')) {
+      (<HTMLElement>document.querySelector('mat-sidenav-content')).style.marginLeft = '240px';
+      // this.toggleSidenav();
+    }
   }
 
   onShowAbout() {

--- a/src/app/components/common/topbar/topbar.template.html
+++ b/src/app/components/common/topbar/topbar.template.html
@@ -5,7 +5,7 @@
       <mat-icon>menu</mat-icon>
     </button>
     <!-- Sidenav toggle collapse -->
-    <button mat-icon-button id="collapseToggle" fxHide.lt-mat="true" (click)="toggleCollapse()" matTooltip="Toggle Collapse" class="toggle-collapsed">
+    <button *ngIf="sidenav.opened" mat-icon-button id="collapseToggle" fxHide.lt-mat="true" (click)="toggleCollapse()" matTooltip="Toggle Collapse" class="toggle-collapsed">
       <mat-icon>chevron_left</mat-icon>
     </button>
     <!-- Search form


### PR DESCRIPTION
Ticket: #39095
Fix for glitch in sidenav when it goes from collapsed state to full - the bug is that it covers up the main toggle button. This fixes that and also hides the little arrow button when it isn't useful, to keep it from getting the menu out of sync.