### PR TITLE
Add a rule to get checkboxes on SMART tests to pick up theme color

### DIFF
--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -799,3 +799,8 @@ iscsi .mat-ink-bar {
   @include variable(background-color, --yellow, $yellow);
   @include variable(color, --yellow-txt, $yellow-txt);
 }
+
+// Gets checkboxes in SMART tests to pick up theme color
+.ix-blue .mat-primary .mat-pseudo-checkbox-checked, .ix-blue .mat-primary .mat-pseudo-checkbox-indeterminate {
+  @include variable(background, --accent, $accent !important);
+}

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -803,12 +803,13 @@ iscsi .mat-ink-bar {
 // Gets checkboxes in SMART tests to pick up theme color
 .ix-blue .mat-primary .mat-pseudo-checkbox-checked, .ix-blue .mat-primary .mat-pseudo-checkbox-indeterminate {
   @include variable(background, --accent, $accent !important);
+}
 
 // Fix for overscrolling problem with sidenav
 .sidebar-panel.mat-sidenav .navigation-hold {
   position: static !important;
-
 }
+
 .mat-drawer {
   overflow-y: hidden !important;
 }


### PR DESCRIPTION
Ticket: #40206
Adds a CSS rule to color 'pseudo-checkboxes' which appear without the right theme color in SMART Tests