### PR TITLE
force scrollbar to refresh on every menu click

### DIFF
--- a/src/app/components/common/navigation/navigation.component.ts
+++ b/src/app/components/common/navigation/navigation.component.ts
@@ -3,6 +3,7 @@ import { NavigationService } from "../../../services/navigation/navigation.servi
 import { WebSocketService } from "../../../services/";
 import {Router} from "@angular/router";
 import * as _ from 'lodash';
+import * as Ps from 'perfect-scrollbar';
 
 @Component({
   selector: 'navigation',
@@ -31,5 +32,13 @@ export class NavigationComponent {
       //Checks item list has any icon type.
       this.hasIconTypeMenuItem = !!this.menuItems.filter(item => item.type === 'icon').length;
     });
+  }
+
+  // Workaround to keep scrollbar displaying as needed
+  updateScroll() {
+    let navigationHold = document.getElementById('scroll-area');
+    setTimeout(() => {
+      Ps.update(navigationHold);
+    }, 500);
   }
 }

--- a/src/app/components/common/navigation/navigation.template.html
+++ b/src/app/components/common/navigation/navigation.template.html
@@ -14,7 +14,7 @@
     <!-- Regular menu items -->
     <div *ngFor="let item of menuItems; let i = index">
         <!-- if it's not disabled and not a separator and not icon -->
-        <mat-list-item sideNavAccordion class="sidebar-list-item" role="listitem" *ngIf="!item.disabled && item.type !== 'separator' && item.type !== 'icon'" [ngClass]="{'has-submenu': item.type === 'dropDown'}" routerLinkActive="open" id="nav-{{i}}">
+        <mat-list-item (click)="updateScroll()" sideNavAccordion class="sidebar-list-item" role="listitem" *ngIf="!item.disabled && item.type !== 'separator' && item.type !== 'icon'" [ngClass]="{'has-submenu': item.type === 'dropDown'}" routerLinkActive="open" id="nav-{{i}}">
             <a [routerLink]="['/', item.state]" *ngIf="item.type === 'link'" name="{{item.name.replace(' ', '_')}}-menu">
                 <span class="menu-item-tooltip" [matTooltip]="item.tooltip" id="{{item.name}}" matTooltipPosition="right"></span>
                 <mat-icon>{{item.icon}}</mat-icon>


### PR DESCRIPTION
Ticket: #41760
Causes the scrollbar on sidenav to update on every menu item click. Fixes a problem where, if he scrollbar isn't needed on page load, then it won't automatically appear when the menu expands and it is needed.