### PR TITLE
increase height of info panel to make room for train err message

### DIFF
--- a/src/app/pages/common/info-dialog/info-dialog.component.scss
+++ b/src/app/pages/common/info-dialog/info-dialog.component.scss
@@ -1,0 +1,3 @@
+.info-panel {
+    max-height: 115px !important;
+}


### PR DESCRIPTION
Ticket: #38600
Add a bit of space on info dialog to allow for the update warning about switching trains, Tested on Ffx and Chromium on Ubuntu and TrueOS