### PR TITLE
Fix 41450

### DIFF
--- a/src/app/core/components/widgets/widgetchart/widgetchart.component.ts
+++ b/src/app/core/components/widgets/widgetchart/widgetchart.component.ts
@@ -70,6 +70,7 @@ export class WidgetChartComponent extends WidgetComponent implements AfterViewIn
   }
 
   ngOnDestroy(){
+    this.core.unregister({observerClass:this});
   }
 
   ngAfterViewInit(){ 

--- a/src/app/core/components/widgets/widgetcpuhistory/widgetcpuhistory.component.ts
+++ b/src/app/core/components/widgets/widgetcpuhistory/widgetcpuhistory.component.ts
@@ -36,6 +36,7 @@ export class WidgetCpuHistoryComponent extends WidgetChartComponent implements A
 
   ngOnDestroy(){
     this.core.emit({name:"StatsRemoveListener", data:{name:"CpuAggregate", obj:this}});
+    this.core.unregister({observerClass:this});
   }
 
   ngAfterViewInit(){

--- a/src/app/core/components/widgets/widgetcputemps/widgetcputemps.component.ts
+++ b/src/app/core/components/widgets/widgetcputemps/widgetcputemps.component.ts
@@ -54,6 +54,7 @@ export class WidgetCpuTempsComponent extends WidgetChartComponent implements Aft
 
   ngOnDestroy(){
     this.core.emit({name:"StatsRemoveListener", data:{name:"CpuTemp", obj:this}});
+    this.core.unregister({observerClass:this});
   }
 
   ngAfterViewInit(){

--- a/src/app/core/components/widgets/widgetload/widgetload.component.ts
+++ b/src/app/core/components/widgets/widgetload/widgetload.component.ts
@@ -33,6 +33,7 @@ export class WidgetLoadComponent extends WidgetChartComponent implements AfterVi
 
   ngOnDestroy(){
     this.core.emit({name:"StatsRemoveListener", data:{name:"Load", obj:this}});
+    this.core.unregister({observerClass:this});
   }
 
   ngAfterViewInit(){

--- a/src/app/core/components/widgets/widgetloadhistory/widgetloadhistory.component.ts
+++ b/src/app/core/components/widgets/widgetloadhistory/widgetloadhistory.component.ts
@@ -30,6 +30,7 @@ export class WidgetLoadHistoryComponent extends WidgetComponent implements After
 
   ngOnDestroy(){
     this.core.emit({name:"StatsRemoveListener", data:{name:"Processes",obj:this}});
+    this.core.unregister({observerClass:this});
   }
 
   ngAfterViewInit(){

--- a/src/app/core/components/widgets/widgetmemoryhistory/widgetmemoryhistory.component.ts
+++ b/src/app/core/components/widgets/widgetmemoryhistory/widgetmemoryhistory.component.ts
@@ -44,6 +44,7 @@ export class WidgetMemoryHistoryComponent extends WidgetChartComponent implement
 
   ngOnDestroy(){
     this.core.emit({name:"StatsRemoveListener", data:{name:"Memory", obj:this}});
+    this.core.unregister({observerClass:this});
   }
 
   ngAfterViewInit(){

--- a/src/app/core/components/widgets/widgetnetinfo/widgetnetinfo.component.ts
+++ b/src/app/core/components/widgets/widgetnetinfo/widgetnetinfo.component.ts
@@ -70,6 +70,7 @@ export class WidgetNetInfoComponent extends WidgetComponent implements OnInit, A
 
   ngOnDestroy(){
     this.core.emit({name:"StatsRemoveListener", data:{name:"NIC", obj:this}});
+    this.core.unregister({observerClass:this});
   }
 
   ngOnInit(){

--- a/src/app/core/components/widgets/widgetpool/widgetpool.component.ts
+++ b/src/app/core/components/widgets/widgetpool/widgetpool.component.ts
@@ -93,6 +93,7 @@ export class WidgetPoolComponent extends WidgetComponent implements AfterViewIni
 
   ngOnDestroy(){
     //this.core.emit({name:"StatsRemoveListener", data:{name:"Pool",obj:this}});
+    this.core.unregister({observerClass:this});
   }
 
   ngAfterViewInit(){

--- a/src/app/core/components/widgets/widgetsysinfo/widgetsysinfo.component.ts
+++ b/src/app/core/components/widgets/widgetsysinfo/widgetsysinfo.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, AfterViewInit, Input, ViewChild, Renderer2, ElementRef } from '@angular/core';
+import { Component, OnInit, OnDestroy, AfterViewInit, Input, ViewChild, Renderer2, ElementRef } from '@angular/core';
 import { CoreServiceInjector } from 'app/core/services/coreserviceinjector';
 import { Router } from '@angular/router';
 import { CoreService, CoreEvent } from 'app/core/services/core.service';
@@ -21,7 +21,7 @@ import { T } from '../../../../translate-marker';
   templateUrl:'./widgetsysinfo.component.html',
   styleUrls: ['./widgetsysinfo.component.css']
 })
-export class WidgetSysInfoComponent extends WidgetComponent implements OnInit, AfterViewInit {
+export class WidgetSysInfoComponent extends WidgetComponent implements OnInit,OnDestroy, AfterViewInit {
   public title: string = T("System Info");
   public data: any;
   public memory:string;
@@ -91,6 +91,10 @@ export class WidgetSysInfoComponent extends WidgetComponent implements OnInit, A
   }
   
   ngOnInit(){
+  }
+
+  ngOnDestroy(){
+    this.core.unregister({observerClass:this});
   }
 
   getCardBg(){

--- a/src/app/core/services/core.service.ts
+++ b/src/app/core/services/core.service.ts
@@ -41,11 +41,13 @@ export class CoreService {
   private debug:boolean;
   debug_show_subscription_type:boolean;
   debug_show_dispatch_table:boolean;
+  debug_show_emit_logs:boolean;
   //private debug_show_data:boolean
   constructor() {
     /////////////////////////////
     //Set Debug options here
     this.debug = false;
+    this.debug_show_emit_logs = false;
     this.debug_show_subscription_type = false;
     this.debug_show_dispatch_table = false;
     /////////////////////////////
@@ -72,6 +74,10 @@ export class CoreService {
   }
 
   public unregister(reg: Registration){
+    if(this.debug){
+      console.log("CoreService: Unregistering the following ObserverClass...")
+      console.log(reg.observerClass);
+    }
     let clone = [];// New Dispatch Table
     if(!reg.eventName){
       for(var i = 0; i < this.dispatchTable.length; i++){
@@ -100,7 +106,7 @@ export class CoreService {
   }
 
   public emit(evt: CoreEvent){
-    if(this.debug){ 
+    if(this.debug && this.debug_show_emit_logs){ 
       console.log("*******************************************************");
       console.log("CORESERVICE: Emitting " + evt.name);
       if(this.debug_show_dispatch_table){
@@ -133,7 +139,7 @@ export class CoreService {
       }
 
       if(reg.eventName == evt.name && reg.sender == evt.sender && subscriptionType == "NameSender"){
-        if(this.debug){
+        if(this.debug && this.debug_show_emit_logs){
           console.log(">>>>>>>>");
           console.log("Matched name and sender");
           console.log(reg.observerClass);
@@ -142,7 +148,7 @@ export class CoreService {
         }
 	reg.observable.next(evt);
       } else if(evt.name && reg.eventName == evt.name && subscriptionType == "Name"){
-        if(this.debug){
+        if(this.debug && this.debug_show_emit_logs){
           console.log(">>>>>>>>");
           console.log("Matched name only");
           console.log(reg.observerClass);
@@ -151,7 +157,7 @@ export class CoreService {
         }
 	reg.observable.next(evt);
       } else if(evt.sender && reg.sender == evt.sender && subscriptionType == "Sender"){
-        if(this.debug){
+        if(this.debug && this.debug_show_emit_logs){
           console.log(">>>>>>>>");
           console.log("Matched sender only");
           console.log(reg.observerClass);
@@ -163,7 +169,7 @@ export class CoreService {
         //DEBUG: console.log("No match found");
       }
     }
-    if(this.debug){ 
+    if(this.debug && this.debug_show_emit_logs){ 
       console.log("*******************************************************");
     }
     return this;

--- a/src/app/pages/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/dashboard.component.ts
@@ -47,6 +47,7 @@ export class DashboardComponent implements OnInit,OnDestroy {
   }
 
   ngOnDestroy(){
+    this.core.unregister({observerClass:this});
   }
 
   init(){

--- a/src/app/pages/preferences/page/forms/custom-theme-manager-form.component.ts
+++ b/src/app/pages/preferences/page/forms/custom-theme-manager-form.component.ts
@@ -1,4 +1,4 @@
-import { ApplicationRef, Input, Output, EventEmitter, Component, Injector, OnInit, ViewContainerRef, OnChanges } from '@angular/core';
+import { ApplicationRef, Input, Output, EventEmitter, Component, Injector, OnInit, OnDestroy, ViewContainerRef, OnChanges } from '@angular/core';
 import { NgModel }   from '@angular/forms';
 import {Router} from '@angular/router';
 import * as _ from 'lodash';
@@ -14,7 +14,7 @@ import { Subject } from 'rxjs/Subject';
   selector : 'custom-theme-manager-form',
   template:`<entity-form-embedded fxFlex="100" fxFlex.gt-xs="350px" [target]="target" [data]="values" [conf]="this"></entity-form-embedded>`
 })
-export class CustomThemeManagerFormComponent implements OnInit, OnChanges {
+export class CustomThemeManagerFormComponent implements OnInit, OnChanges, OnDestroy {
 
   /*
    //Preferences Object Structure
@@ -81,6 +81,10 @@ export class CustomThemeManagerFormComponent implements OnInit, OnChanges {
         this.initForm();
       });
 
+    }
+
+    ngOnDestroy(){
+      this.core.unregister({observerClass:this});
     }
 
     ngOnChanges(changes){

--- a/src/app/pages/preferences/page/forms/general-preferences-form.component.ts
+++ b/src/app/pages/preferences/page/forms/general-preferences-form.component.ts
@@ -1,4 +1,4 @@
-import { ApplicationRef, Input, Output, EventEmitter, Component, Injector, OnInit, ViewContainerRef, OnChanges } from '@angular/core';
+import { ApplicationRef, Input, Output, EventEmitter, Component, Injector, OnInit, ViewContainerRef, OnChanges, OnDestroy } from '@angular/core';
 import { NgModel }   from '@angular/forms';
 import {Router} from '@angular/router';
 import * as _ from 'lodash';
@@ -15,7 +15,7 @@ import { Subject } from 'rxjs/Subject';
   selector : 'general-preferences-form',
   template:`<entity-form-embedded fxFlex="100" fxFlex.gt-xs="300px" [target]="target" [data]="values" [conf]="this"></entity-form-embedded>`
 })
-export class GeneralPreferencesFormComponent implements OnInit, OnChanges {
+export class GeneralPreferencesFormComponent implements OnInit, OnChanges, OnDestroy {
 
   /*
    //Preferences Object Structure
@@ -104,6 +104,10 @@ export class GeneralPreferencesFormComponent implements OnInit, OnChanges {
       if(changes.baseTheme){
         alert("baseTheme Changed!")
       }
+    }
+
+    ngOnDestroy(){
+      this.core.unregister({observerClass:this});
     }
 
     init(){

--- a/src/app/pages/preferences/page/preferences.component.ts
+++ b/src/app/pages/preferences/page/preferences.component.ts
@@ -1,4 +1,4 @@
-import { ApplicationRef, Input, Output, EventEmitter, Component, Injector, OnInit, ViewContainerRef, OnChanges } from '@angular/core';
+import { ApplicationRef, Input, Output, EventEmitter, Component, Injector, OnInit, ViewContainerRef, OnChanges, OnDestroy } from '@angular/core';
 import { NgModel }   from '@angular/forms';
 import {Router} from '@angular/router';
 import * as _ from 'lodash';
@@ -25,7 +25,7 @@ import { Subject } from 'rxjs/Subject';
   </mat-card>
   `
 })
-export class PreferencesPage implements OnInit {
+export class PreferencesPage implements OnInit, OnDestroy {
 
   /*
    //Preferences Object Structure
@@ -53,6 +53,10 @@ export class PreferencesPage implements OnInit {
 
     ngOnInit(){
       //this.init();
+    }
+
+    ngOnDestroy(){
+      this.core.unregister({observerClass:this});
     }
 
     /*ngOnChanges(changes){

--- a/src/app/pages/vm/vm-cards/vm-summary.component.ts
+++ b/src/app/pages/vm/vm-cards/vm-summary.component.ts
@@ -1,4 +1,4 @@
-import { Component, AfterViewInit, ViewChild, Input } from '@angular/core';
+import { Component,OnDestroy, AfterViewInit, ViewChild, Input } from '@angular/core';
 import { CoreService, CoreEvent } from 'app/core/services/core.service';
 import { ChartData } from 'app/core/components/viewchart/viewchart.component';
 import { ViewChartPieComponent } from 'app/core/components/viewchartpie/viewchartpie.component';
@@ -12,7 +12,7 @@ import { Subject } from 'rxjs/Subject';
   templateUrl: './vm-summary.component.html',
   styleUrls: ['./vm-summary.component.css']
 })
-export class VmSummaryComponent implements AfterViewInit {
+export class VmSummaryComponent implements AfterViewInit, OnDestroy {
 
   @ViewChild('cpu') cpuChart:ViewChartLineComponent;
   @ViewChild('zpool') zpoolChart:ViewChartDonutComponent;
@@ -28,23 +28,23 @@ export class VmSummaryComponent implements AfterViewInit {
   ngAfterViewInit() {
 
     this.core.register({observerClass:this,eventName:"PoolData"}).subscribe((evt:CoreEvent) => {
-      console.log(evt);
+      //console.log(evt);
       this.setPoolData(evt);
     });
 
     this.core.register({observerClass:this,eventName:"StatsCpuData"}).subscribe((evt:CoreEvent) => {
-      console.log(evt);
+      //console.log(evt);
       this.setCPUData(evt);
       //this.setNetData(evt);
     });
 
     this.core.register({observerClass:this,eventName:"StatsVmemoryUsage"}).subscribe((evt:CoreEvent) => {
-      console.log(evt);
+      //console.log(evt);
       this.setMemData(evt);
     });
 
     this.core.register({observerClass:this,eventName:"SysInfo"}).subscribe((evt:CoreEvent) => {
-      console.log(evt);
+      //console.log(evt);
       this.setMemTotal(evt);
     });
 
@@ -65,6 +65,10 @@ export class VmSummaryComponent implements AfterViewInit {
     this.core.emit({name:"StatsCpuRequest", data:[['user','interrupt','system'/*,'idle','nice'*/],{step:'10', start:'now-10m'}]});
 
    }
+
+  ngOnDestroy(){
+    this.core.unregister({observerClass:this});
+  }
 
   setMemData(evt:CoreEvent){
     this.memChart.title = "vMemory in Use";
@@ -119,14 +123,14 @@ export class VmSummaryComponent implements AfterViewInit {
     this.zpoolChart.units = 'GB';
     this.zpoolChart.title = 'Zpool';
     this.zpoolChart.data = [used,available];
-    console.log(this.zpoolChart.data);
+    //console.log(this.zpoolChart.data);
     this.zpoolChart.width = this.chartSize;
     this.zpoolChart.height = this.chartSize;
   }
 
   setCPUData(evt:CoreEvent){
-    console.log("SET CPU DATA");
-    console.log(evt.data);
+    //console.log("SET CPU DATA");
+    //console.log(evt.data);
     let cpuUserObj = evt.data;
 
     let parsedData = [];
@@ -147,7 +151,7 @@ export class VmSummaryComponent implements AfterViewInit {
     this.cpuChart.units = '%';
     this.cpuChart.timeSeries = true;
     this.cpuChart.timeFormat = '%H:%M';// eg. %m-%d-%Y %H:%M:%S.%L
-      this.cpuChart.timeData = evt.data.meta;
+    this.cpuChart.timeData = evt.data.meta;
     this.cpuChart.data = parsedData;//[cpuUser];
     this.cpuChart.width = this.chartSize;
     this.cpuChart.height = this.chartSize;

--- a/src/app/pages/vm/vm-cards/vm-table.component.ts
+++ b/src/app/pages/vm/vm-cards/vm-table.component.ts
@@ -71,24 +71,24 @@ export class VmTableComponent implements OnChanges{
 
   ngOnChanges(changes) {
     if(changes.data){
-      console.log("VM Table: DATA CHANGED!");
+      //console.log("VM Table: DATA CHANGED!");
       let newData = Object.assign(this.data,{});
       this.data = newData;
     }
-    console.log("******** VM-CARDS ********");
+    //console.log("******** VM-CARDS ********");
     this.datatable.limit = this.pageSize; // items per page
     this.datatable.pageSize = 8;//this.pageSize;
     this.datatable.recalculate();
-    console.log(this.datatable);
+    //console.log(this.datatable);
     this.setTableHeight(this.datatable);
   }
 
   setTableHeight(t){
-    console.log("Row: " + t.rowHeight);
-    console.log("Header: " + t.headerHeight);
-    console.log("Footer: " + t.footerHeight);
+    //console.log("Row: " + t.rowHeight);
+    //console.log("Header: " + t.headerHeight);
+    //console.log("Footer: " + t.footerHeight);
     let height = (50*this.pageSize) + 100;
-    console.log("******** New tableHeight = " + height);
+    //console.log("******** New tableHeight = " + height);
     //return String(height) + "px";
     this.tableHeight = height;
   }

--- a/src/app/services/stats.service.ts
+++ b/src/app/services/stats.service.ts
@@ -576,7 +576,7 @@ export class StatsService {
        }
      }
 
-     if(messageList.length == 0){
+     if(!messageList || messageList.length == 0){
        this.stopBroadcast(messageList);
      }
   }


### PR DESCRIPTION
Ensures all components and pages using message bus (core.service) use the OnDestroy lifecycle hook and properly unregister themselves to avoid unnecessary subscriptions lingering. Also added additional debug flags to core.service to eliminate unneeded logging in the browser. 

This should ensure that bugs like the one from ticket 41450, where the stat service keeps asking for data periodically even after dashboard is destroyed, won't happen any more. 