### PR TITLE
Fix 39253

### DIFF
--- a/src/app/components/common/layouts/admin-layout/admin-layout.component.ts
+++ b/src/app/components/common/layouts/admin-layout/admin-layout.component.ts
@@ -1,4 +1,5 @@
 import { RestService, WebSocketService } from '../../../../services';
+import { CoreService, CoreEvent } from 'app/core/services/core.service';
 import { Component, AfterViewChecked, OnInit, ViewChild, ElementRef } from '@angular/core';
 import { Router, NavigationEnd } from '@angular/router';
 import { Subscription } from "rxjs/Subscription";
@@ -26,6 +27,8 @@ export class AdminLayoutComponent implements OnInit, AfterViewChecked {
   consoleMsg: String = "";
   consoleMSgList: any[] = [];
   public is_freenas: Boolean = false;
+  public logoPath: string = 'assets/images/light-logo.svg';
+  public logoTextPath: string = 'assets/images/light-logo-text.svg';
   public currentTheme: string = "";
   // we will just have to add to this list as more languages are added
 
@@ -34,6 +37,7 @@ export class AdminLayoutComponent implements OnInit, AfterViewChecked {
   freenasThemes;
 
   constructor(private router: Router,
+    public core: CoreService,
     public themeService: ThemeService,
     private media: ObservableMedia,
     protected rest: RestService,
@@ -59,6 +63,17 @@ export class AdminLayoutComponent implements OnInit, AfterViewChecked {
 
     // Translator init
     language.getMiddlewareLanguage();
+
+    // Subscribe to Theme Changes
+    core.register({
+      observerClass:this, 
+      eventName:"ThemeChanged", 
+      sender:themeService
+    }).subscribe((evt:CoreEvent)=>{
+      let theme = evt.data;
+      this.logoPath = theme.logoPath;
+      this.logoTextPath = theme.logoTextPath;
+    });
   }
 
   ngOnInit() {

--- a/src/app/components/common/layouts/admin-layout/admin-layout.template.html
+++ b/src/app/components/common/layouts/admin-layout/admin-layout.template.html
@@ -17,8 +17,8 @@
           </div>
           <ng-template #lightLogo>
             <div class="branding mat-bg-primary" *ngIf="is_freenas; else isTruenasLight">
-                <a routerLink="/dashboard"><img src="assets/images/light-logo.svg" alt="FreeNAS icon" class="app-logo"></a>
-                <a routerLink="/dashboard"><img src="assets/images/light-logo-text.svg" alt="FreeNAS" class="app-logo-text"></a>
+              <a routerLink="/dashboard" class="logo"><img [src]="logoPath" alt="FreeNAS icon" class="app-logo"></a>
+              <a routerLink="/dashboard" class="logo-text"><img [src]="logoTextPath" alt="FreeNAS" class="app-logo-text"></a>
             </div>
             <ng-template #isTruenasLight>
               <div class="branding mat-bg-primary">

--- a/src/app/pages/preferences/page/forms/customtheme/customtheme.component.ts
+++ b/src/app/pages/preferences/page/forms/customtheme/customtheme.component.ts
@@ -37,7 +37,7 @@ export class CustomThemeComponent implements OnInit, OnChanges, OnDestroy {
 
   // EXAMPLE THEME
   public values:Theme = {
-    name:'',
+    name:'New Theme',
     description:'',
     label:'',
     labelSwatch:'',
@@ -476,7 +476,7 @@ export class CustomThemeComponent implements OnInit, OnChanges, OnDestroy {
       let palette = Object.keys(ct);
       palette.splice(0,6);
 
-      palette.forEach(function(color){
+      palette.forEach((color)=>{
         values[color] = ct[color];
       });
 
@@ -487,7 +487,7 @@ export class CustomThemeComponent implements OnInit, OnChanges, OnDestroy {
       let palette = Object.keys(theme);
       palette.splice(0,5);
 
-      palette.forEach(function(color){
+      palette.forEach((color)=>{
       let swatch = theme[color];
       (<any>document).querySelector('#theme-preview').style.setProperty("--" + color, theme[color]);
       });

--- a/src/app/pages/preferences/page/forms/customtheme/customtheme.component.ts
+++ b/src/app/pages/preferences/page/forms/customtheme/customtheme.component.ts
@@ -145,8 +145,8 @@ export class CustomThemeComponent implements OnInit, OnChanges, OnDestroy {
           type: 'checkbox',
           name: 'hasDarkLogo',
           width:'100%',
-          placeholder: 'Choose Logo Type',
-          tooltip: "Choose the logo type",
+          placeholder: 'Enable Dark Logo',
+          tooltip: `Enable this to give the FreeNAS Logo a dark fill color`,
           class:'inline'
         },
         {

--- a/src/app/services/theme/theme.service.ts
+++ b/src/app/services/theme/theme.service.ts
@@ -173,7 +173,7 @@ export class ThemeService {
         this.core.emit({ name:"UserDataRequest",data:[[["id", "=", 1]]] });
       } else {
         //console.warn("SETTING DEFAULT THEME");
-        this.setDefaultTheme();
+        this.resetToDefaultTheme();
       }
     });
 
@@ -196,13 +196,12 @@ export class ThemeService {
 
     this.core.register({observerClass:this,eventName:"UserPreferencesChanged"}).subscribe((evt:CoreEvent) => {
       if(evt.data.customThemes){
-        //console.log("Custom Themes Detected");
         this.customThemes = evt.data.customThemes;
       }
 
       //if(evt.data.userTheme !== this.activeTheme){
         this.activeTheme = evt.data.userTheme;
-        this.setCssVars(this.findTheme(this.activeTheme));
+        this.setCssVars(this.findTheme(this.activeTheme, true));
         this.core.emit({name:'ThemeChanged'});
       //}
 
@@ -214,7 +213,7 @@ export class ThemeService {
     });
   }
 
-  setDefaultTheme(){
+  resetToDefaultTheme(){
     this.activeTheme = "ix-blue";
     this.changeTheme(this.activeTheme);
   }
@@ -223,15 +222,20 @@ export class ThemeService {
     return this.findTheme(this.activeTheme);
   }
 
-  findTheme(name:string):Theme{
+  findTheme(name:string, reset?:boolean):Theme{
     for(let i in this.allThemes){
       let t = this.allThemes[i];
       if(t.name == name){ return t;}
     }
+    if(reset){
+      //Optionally reset if not found
+      this.resetToDefaultTheme();
+      return this.freenasThemes[this.freeThemeDefaultIndex];
+    }
   }
 
   changeTheme(theme:string) {
-    //console.log("THEME SERVICE THEMECHANGE: changing to " + theme + " theme");
+    console.log("THEME SERVICE THEMECHANGE: changing to " + theme + " theme");
     this.core.emit({name:"ChangeThemePreference", data:theme, sender:this});
     //this.core.emit({name:'ThemeChanged'});
     }

--- a/src/app/services/theme/theme.service.ts
+++ b/src/app/services/theme/theme.service.ts
@@ -12,6 +12,8 @@ export interface Theme {
   accentColors: string[];
   favorite:boolean;
   hasDarkLogo: boolean;
+  logoPath?:string;
+  logoTextPath?:string;
   primary:string;
   accent:string;
   bg1:string
@@ -51,6 +53,8 @@ export class ThemeService {
       labelSwatch:"blue",
       description:'iX System Colors',
       hasDarkLogo:false,
+      logoPath:'assets/images/light-logo.svg',
+      logoTextPath:'light-logo-text.svg',
       favorite:false,
       accentColors:['blue', 'orange','green', 'violet','cyan', 'magenta', 'yellow','red'],
       primary:"var(--blue)",
@@ -78,6 +82,8 @@ export class ThemeService {
       labelSwatch:"blue",
       description:'Dracula color theme',
       hasDarkLogo:false,
+      logoPath:'assets/images/light-logo.svg',
+      logoTextPath:'light-logo-text.svg',
       favorite:false,
       accentColors:['blue', 'green','violet', 'yellow', 'red', 'cyan', 'magenta', 'orange'],
       primary:"var(--blue)",
@@ -105,6 +111,8 @@ export class ThemeService {
       labelSwatch:"bg2",
       description:'Solarized dark color scheme',
       hasDarkLogo:false,
+      logoPath:'assets/images/light-logo.svg',
+      logoTextPath:'light-logo-text.svg',
       favorite:false,
       accentColors:['red', 'blue', 'magenta', 'cyan', 'violet', 'green', 'orange', 'yellow'],
       primary:"var(--fg1)",
@@ -132,6 +140,8 @@ export class ThemeService {
       labelSwatch:"bg2",
       description:'Based on Solarized light color scheme',
       hasDarkLogo:false,
+      logoPath:'assets/images/light-logo.svg',
+      logoTextPath:'light-logo-text.svg',
       favorite:false,
       accentColors:['orange', 'green', 'cyan', 'yellow', 'violet', 'magenta', 'red', 'blue'],
       primary:"var(--alt-bg2)",
@@ -168,6 +178,7 @@ export class ThemeService {
     this.themesMenu = this.freenasThemes;
 
     this.core.register({observerClass:this,eventName:"Authenticated", sender:this.api}).subscribe((evt:CoreEvent) => {
+      this.core.emit({name:"ThemeChanged", data:this.findTheme(this.activeTheme), sender:this});
       this.loggedIn = evt.data;
       if(this.loggedIn == true){
         this.core.emit({ name:"UserDataRequest",data:[[["id", "=", 1]]] });
@@ -202,7 +213,7 @@ export class ThemeService {
       //if(evt.data.userTheme !== this.activeTheme){
         this.activeTheme = evt.data.userTheme;
         this.setCssVars(this.findTheme(this.activeTheme, true));
-        this.core.emit({name:'ThemeChanged'});
+        this.core.emit({name:'ThemeChanged', data: this.findTheme(this.activeTheme), sender:this});
       //}
 
       if(evt.data.showTooltips){
@@ -235,7 +246,7 @@ export class ThemeService {
   }
 
   changeTheme(theme:string) {
-    console.log("THEME SERVICE THEMECHANGE: changing to " + theme + " theme");
+    //console.log("THEME SERVICE THEMECHANGE: changing to " + theme + " theme");
     this.core.emit({name:"ChangeThemePreference", data:theme, sender:this});
     //this.core.emit({name:'ThemeChanged'});
     }
@@ -248,6 +259,8 @@ export class ThemeService {
 
   setCssVars(theme:Theme){ 
     let palette = Object.keys(theme);
+
+    // Isolate palette colors
     palette.splice(0,7);
 
     palette.forEach((color) => {
@@ -261,11 +274,30 @@ export class ThemeService {
 
       (<any>document).documentElement.style.setProperty("--" + color, theme[color]);
     });
+
+    // Set Material palette colors
     (<any>document).documentElement.style.setProperty("--primary",theme["primary"]);
     (<any>document).documentElement.style.setProperty("--accent",theme["accent"]);
+
+    // Set Material aux. text styles
+    let primaryColor = this.colorFromMeta(theme["primary"]); // eg. blue
+    let accentColor = this.colorFromMeta(theme["accent"]); // eg. yellow
+    let primaryTextColor = this.textContrast(theme[primaryColor], theme["bg2"]);
+    let accentTextColor = this.textContrast(theme[accentColor], theme["bg2"]);
+    (<any>document).documentElement.style.setProperty("--primary-txt", /*'var(--' + primaryColor + '-txt)'*/primaryTextColor);
+    (<any>document).documentElement.style.setProperty("--accent-txt", /*'var(--' + accentColor + '-txt)'*/accentTextColor);
+
+    // Logo light/dark
+    if(theme["hasDarkLogo"]){
+      theme.logoPath = 'assets/images/logo.svg';
+      theme.logoTextPath = 'assets/images/logo-text.svg';
+    } else {
+      theme.logoPath = 'assets/images/light-logo.svg';
+      theme.logoTextPath = 'assets/images/light-logo-text.svg';
+    }
   }
 
-  textContrast(cssVar, bgVar){
+  public textContrast(cssVar, bgVar){
     let txtColor = '';
     // Convert hex value to RGB
     let props = this.hexToRGB(cssVar); 
@@ -315,6 +347,12 @@ export class ThemeService {
       hex:hex,
       rgb:rgb
     }
+  }
+  
+  public colorFromMeta(meta:string){
+    let trimFront = meta.replace('var(--','');
+    let trimmed = trimFront.replace(')','');
+    return trimmed;
   }
 
   get customThemes(){

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -35,11 +35,17 @@ $violet-txt:'#fff';
 $blue-txt:'#fff';
 $cyan-txt:'#333';
 $green-txt:'#fff';
+$primary-txt:'#fff';
+$accent-txt:'#333';
 
 $primary: $blue;
 $accent: $yellow;
 $warn: $red;
 $tooltip:'inline';//display property
+
+// Logo images
+$logo: url('assets/images/light-logo.svg');
+$logo-text: url('assets/images/light-logo-text.svg');
 
 $md-primary: (
     50 : #e0f2fa,
@@ -274,7 +280,9 @@ h4{
 .mat-step-header .mat-step-icon,
 div.hopscotch-bubble{
       @include variable(background, --primary, $primary, !important);
-      @include variable(color, #fff, #fff, !important);
+      //@include variable(color, #fff, #fff, !important);
+      @include variable(color, --primary-txt, $primary-txt, !important);
+
 }
 
 .mat-bg-accent,
@@ -839,3 +847,25 @@ iscsi .mat-ink-bar {
 //   @include variable(background-color, --primary, $primary);
 //   color: white;
 // }
+
+// Define logo via CSS properties
+.logo{
+ /*   @include variable(background-image, --logo, $logo !important); //url(assets/images/logo.svg);
+    background-size: contain;
+    width: 52px;
+    height: 48px;
+    background-repeat: no-repeat;
+    background-position: 0 4px;
+    left: -6px;
+    position: relative;*/
+}
+.logo-text{
+   /* @include variable(background-image, --logo-text, $logo-text !important); //url(assets/images/logo-text.svg);
+    width: 112px;
+    height: 40px;
+    position: relative;
+    top: 0;
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: 2px 0;*/
+}


### PR DESCRIPTION
Fixes logo configuration field label in custom theme tool. Also fixed a bug where theme would break if user deletes a custom theme when that theme is selected. In that scenario, the user's theme will revert to the default ix-blue theme. Switching the logo type between light and dark is now accomplished via css custom properties. Topbar also makes use of new custom css property --primary-txt which the theme service generates. 