### PR TITLE
restyle app-confirm dialog

### DIFF
--- a/src/app/pages/services/services.component.ts
+++ b/src/app/pages/services/services.component.ts
@@ -129,7 +129,7 @@ export class Services implements OnInit {
     }
 
     if (rpc === 'service.stop') {
-      let confirm = this.confirmService.confirm('Alert', 'Stop this service?', 'Stop');
+      let confirm = this.confirmService.confirm(T('Alert'), T('Stop this service?'), T('Stop'));
       confirm.subscribe(res => {
         if (res) {
           this.updateService(rpc, service);

--- a/src/app/pages/services/services.component.ts
+++ b/src/app/pages/services/services.component.ts
@@ -129,7 +129,7 @@ export class Services implements OnInit {
     }
 
     if (rpc === 'service.stop') {
-      let confirm = this.confirmService.confirm('Alert', 'Stop this service?');
+      let confirm = this.confirmService.confirm('Alert', 'Stop this service?', 'Stop');
       confirm.subscribe(res => {
         if (res) {
           this.updateService(rpc, service);

--- a/src/app/pages/system/alertservice/alert-service/alert-service.component.html
+++ b/src/app/pages/system/alertservice/alert-service/alert-service.component.html
@@ -67,7 +67,7 @@
       <mat-card-actions class="buttons">
         <button id="save_button" class="btn btn-block btn-warning" type="submit" mat-button color="primary" [disabled]="!entityForm.form.valid">{{"Save" | translate}}</button>
         <button id="goback_button" *ngIf="route_success" class="btn  btn-block btn-lg btn-primary" type="button" (click)="goBack()" mat-button color="accent">{{"Cancel" | translate}}</button>
-        <button type="button" (click)="sendTestAlet()" mat-button [disabled]="!entityForm.form.valid">{{"Send Test Alert" | translate}}</button>
+        <button id="test-alert" type="button" (click)="sendTestAlet()" mat-button [disabled]="!entityForm.form.valid">{{"Send Test Alert" | translate}}</button>
         <button type="button" (click)="settingEnabled = !settingEnabled" mat-button>{{ settingEnabled ? "Hide Settings" : "Show Settings" | translate }}</button>
       </mat-card-actions>
     </div>

--- a/src/app/services/app-confirm/app-confirm.component.ts
+++ b/src/app/services/app-confirm/app-confirm.component.ts
@@ -5,25 +5,24 @@ import { Component } from '@angular/core';
   selector: 'app-confirm',
   template: `<h1 mat-dialog-title>{{ title }}</h1>
     <div mat-dialog-content>{{ message }}</div>
-    <div mat-dialog-actions>
-    <button 
-    type="button" 
-    mat-button
-    color="primary" 
-    (click)="dialogRef.close(true)">OK</button>
-    &nbsp;
-    <span fxFlex></span>
+    <div mat-dialog-actions style='justify-content:flex-end'>
     <button 
     type="button"
     color="accent"
     mat-button 
     (click)="dialogRef.close(false)">Cancel</button>
+    <button 
+    type="button" 
+    mat-button
+    color="primary" 
+    (click)="dialogRef.close(true)">{{customButton}}</button>
     </div>`,
 })
 export class AppComfirmComponent {
 
   public title: string;
   public message: string;
+  public customButton: string;
 
   constructor(public dialogRef: MatDialogRef<AppComfirmComponent>) {
 

--- a/src/app/services/app-confirm/app-confirm.component.ts
+++ b/src/app/services/app-confirm/app-confirm.component.ts
@@ -10,7 +10,7 @@ import { Component } from '@angular/core';
     type="button"
     color="accent"
     mat-button 
-    (click)="dialogRef.close(false)">Cancel</button>
+    (click)="dialogRef.close(false)">{{'Cancel'}}</button>
     <button 
     type="button" 
     mat-button

--- a/src/app/services/app-confirm/app-confirm.service.ts
+++ b/src/app/services/app-confirm/app-confirm.service.ts
@@ -9,12 +9,13 @@ export class AppConfirmService {
 
   constructor(private dialog: MatDialog) { }
 
-  public confirm(title: string, message: string): Observable<boolean> {
+  public confirm(title: string, message: string, customButton: string): Observable<boolean> {
     let dialogRef: MatDialogRef<AppComfirmComponent>;
     dialogRef = this.dialog.open(AppComfirmComponent, {disableClose: true});
     dialogRef.updateSize('380px');
     dialogRef.componentInstance.title = title;
     dialogRef.componentInstance.message = message;
+    dialogRef.componentInstance.customButton = customButton;
     return dialogRef.afterClosed();
   }
 }

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -369,6 +369,10 @@ div.hopscotch-bubble .hopscotch-nav-button.next,
   opacity: .38;
 }
 
+#test-alert {
+  @include variable(color, --fg2, $fg2);
+}
+
 .mat-form-field-ripple{
   @include variable(background-color, --primary, $primary);
 }

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -872,12 +872,6 @@ iscsi .mat-ink-bar {
   overflow-y: hidden !important;
 }
 
-// pw show button on entity tables
-// #show-pw {
-//   @include variable(background-color, --primary, $primary);
-//   color: white;
-// }
-
 // Define logo via CSS properties
 .logo{
  /*   @include variable(background-image, --logo, $logo !important); //url(assets/images/logo.svg);
@@ -898,4 +892,13 @@ iscsi .mat-ink-bar {
     background-size: contain;
     background-repeat: no-repeat;
     background-position: 2px 0;*/
+}
+
+.ix-blue .mat-progress-bar-fill::after {
+  @include variable(background-color, --primary, $primary);
+}
+
+.ix-blue .mat-progress-bar-buffer {
+  @include variable(background-color, --primary, $primary);
+  opacity: 0.5;
 }

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -960,11 +960,11 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
   //     background-position: 2px 0;*/
   // }
 
-  .ix-blue .mat-progress-bar-fill::after {
+  .mat-progress-bar-fill::after {
     @include variable(background-color, --primary, $primary);
   }
 
-  .ix-blue .mat-progress-bar-buffer {
+  .mat-progress-bar-buffer {
     @include variable(background-color, --primary, $primary);
     opacity: 0.5;
   }


### PR DESCRIPTION
Ticket: #42845
Formats dialog that pops up from service-stop button - conforms it to material standards
Fixes a button on Alert Service page that is way too transparent when disabled
Brings theme colors to progress bars