### PR TITLE
Fix/certs 47246

### DIFF
--- a/src/app/pages/system/ca/ca-add/ca-add.component.ts
+++ b/src/app/pages/system/ca/ca-add/ca-add.component.ts
@@ -194,17 +194,17 @@ export class CertificateAuthorityAddComponent {
     },
     {
       type : 'input',
-      name : 'Passphrase',
+      name : 'passphrase',
       placeholder : T('Passphrase'),
       tooltip : T('Enter the passphrase for the Private Key.'),
       inputType : 'password',
-      validation : [ matchOtherValidator('Passphrase2') ],
+      validation : [ matchOtherValidator('passphrase2') ],
       isHidden: true,
       togglePw : true
     },
     {
       type : 'input',
-      name : 'Passphrase2',
+      name : 'passphrase2',
       inputType : 'password',
       placeholder : T('Confirm Passphrase'),
       isHidden : true
@@ -239,8 +239,8 @@ export class CertificateAuthorityAddComponent {
   private importcaFields: Array<any> = [
     'certificate',
     'privatekey',
-    'Passphrase',
-    'Passphrase2',
+    'passphrase',
+    'passphrase2',
   ];
 
   private country: any;
@@ -346,8 +346,8 @@ export class CertificateAuthorityAddComponent {
     if (data.Passphrase == '') {
       data.Passphrase = undefined;
     }
-    if (data.Passphrase2 == '') {
-      data.Passphrase2 = undefined;
+    if (data.passphrase2) {
+      delete data.passphrase2;
     }
   }
 }

--- a/src/app/pages/system/ca/ca-add/ca-add.component.ts
+++ b/src/app/pages/system/ca/ca-add/ca-add.component.ts
@@ -341,6 +341,13 @@ export class CertificateAuthorityAddComponent {
     } else {
       data.san = _.split(data.san, ' ');
     }
-  }
 
+    // Addresses non-pristine field being mistaken for a passphrase of ''
+    if (data.Passphrase == '') {
+      data.Passphrase = undefined;
+    }
+    if (data.Passphrase2 == '') {
+      data.Passphrase2 = undefined;
+    }
+  }
 }

--- a/src/app/pages/system/ca/ca-add/ca-add.component.ts
+++ b/src/app/pages/system/ca/ca-add/ca-add.component.ts
@@ -343,8 +343,8 @@ export class CertificateAuthorityAddComponent {
     }
 
     // Addresses non-pristine field being mistaken for a passphrase of ''
-    if (data.Passphrase == '') {
-      data.Passphrase = undefined;
+    if (data.passphrase == '') {
+      data.passphrase = undefined;
     }
     if (data.passphrase2) {
       delete data.passphrase2;

--- a/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
+++ b/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
@@ -195,17 +195,17 @@ export class CertificateAddComponent {
     },
     {
       type : 'input',
-      name : 'Passphrase',
+      name : 'passphrase',
       placeholder : T('Passphrase'),
       tooltip : T('Enter the passphrase for the Private Key.'),
       inputType : 'password',
-      validation : [ matchOtherValidator('Passphrase2') ],
+      validation : [ matchOtherValidator('passphrase2') ],
       isHidden: true,
       togglePw : true
     },
     {
       type : 'input',
-      name : 'Passphrase2',
+      name : 'passphrase2',
       inputType : 'password',
       placeholder : T('Confirm Passphrase'),
       isHidden : true
@@ -239,8 +239,8 @@ export class CertificateAddComponent {
   private importFields: Array<any> = [
     'certificate',
     'privatekey',
-    'Passphrase',
-    'Passphrase2',
+    'passphrase',
+    'passphrase2',
   ];
 
   private country: any;
@@ -342,12 +342,13 @@ export class CertificateAddComponent {
     }
 
     // Addresses non-pristine field being mistaken for a passphrase of ''
-    if (data.Passphrase == '') {
-      data.Passphrase = undefined;
+    if (data.passphrase == '') {
+      data.passphrase = undefined;
     }
-    if (data.Passphrase2 == '') {
-      data.Passphrase2 = undefined;
-    }    
+
+    if (data.passphrase2) {
+      delete data.passphrase2;
+    }
   }
 
 

--- a/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
+++ b/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
@@ -341,6 +341,7 @@ export class CertificateAddComponent {
       data.san = _.split(data.san, ' ');
     }
 
+    // Addresses non-pristine field being mistaken for a passphrase of ''
     if (data.Passphrase == '') {
       data.Passphrase = undefined;
     }

--- a/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
+++ b/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
@@ -340,6 +340,14 @@ export class CertificateAddComponent {
     } else {
       data.san = _.split(data.san, ' ');
     }
+
+    if (data.Passphrase == '') {
+      data.Passphrase = undefined;
+    }
+    if (data.Passphrase2 == '') {
+      data.Passphrase2 = undefined;
+    }    
+    console.log(data)
   }
 
 

--- a/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
+++ b/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
@@ -348,7 +348,6 @@ export class CertificateAddComponent {
     if (data.Passphrase2 == '') {
       data.Passphrase2 = undefined;
     }    
-    console.log(data)
   }
 
 


### PR DESCRIPTION
Ticket: 47246
Renames passphrase fields to match API, thus fixing inability to submit CAs and Certs with passphrases