### PR TITLE
Fix/certs 47246

### DIFF
--- a/src/app/pages/system/ca/ca-add/ca-add.component.ts
+++ b/src/app/pages/system/ca/ca-add/ca-add.component.ts
@@ -26,9 +26,7 @@ export class CertificateAuthorityAddComponent {
       placeholder : T('Identifier'),
       tooltip: T('Enter a description of the CA.'),
       required: true,
-      validation : [ Validators.required, Validators.pattern('[A-Za-z0-9_-]+$') ],
-      hasErrors: false,
-      errors: 'Allowed characters: letters, numbers, underscore (_), and dash (-).'
+      validation : [ Validators.required]
     },
     {
       type : 'select',
@@ -314,19 +312,6 @@ export class CertificateAuthorityAddComponent {
         }
       }
     })
-
-    entity.formGroup.controls['name'].valueChanges.subscribe((res) => {
-      this.identifier = res;
-    })
-
-    entity.formGroup.controls['name'].statusChanges.subscribe((res) => {
-      if (this.identifier && res === 'INVALID') {
-        _.find(this.fieldConfig).hasErrors = true;
-      } else {
-        _.find(this.fieldConfig).hasErrors = false;
-      }
-    })
-
   }
 
   hideField(fieldName: any, show: boolean, entity: any) {

--- a/src/app/pages/system/ca/ca-add/ca-add.component.ts
+++ b/src/app/pages/system/ca/ca-add/ca-add.component.ts
@@ -194,17 +194,17 @@ export class CertificateAuthorityAddComponent {
     },
     {
       type : 'input',
-      name : 'Passphrase',
+      name : 'passphrase',
       placeholder : T('Passphrase'),
       tooltip : T('Enter the passphrase for the Private Key.'),
       inputType : 'password',
-      validation : [ matchOtherValidator('Passphrase2') ],
+      validation : [ matchOtherValidator('passphrase2') ],
       isHidden: true,
       togglePw : true
     },
     {
       type : 'input',
-      name : 'Passphrase2',
+      name : 'passphrase2',
       inputType : 'password',
       placeholder : T('Confirm Passphrase'),
       isHidden : true
@@ -239,8 +239,8 @@ export class CertificateAuthorityAddComponent {
   private importcaFields: Array<any> = [
     'certificate',
     'privatekey',
-    'Passphrase',
-    'Passphrase2',
+    'passphrase',
+    'passphrase2',
   ];
 
   private country: any;
@@ -346,8 +346,8 @@ export class CertificateAuthorityAddComponent {
     if (data.Passphrase == '') {
       data.Passphrase = undefined;
     }
-    if (data.Passphrase2 == '') {
-      data.Passphrase2 = undefined;
+    if (data.passphrase2) {
+      delete data.passphrase2;
     }
   }
 }

--- a/src/app/pages/system/ca/ca-add/ca-add.component.ts
+++ b/src/app/pages/system/ca/ca-add/ca-add.component.ts
@@ -341,6 +341,13 @@ export class CertificateAuthorityAddComponent {
     } else {
       data.san = _.split(data.san, ' ');
     }
-  }
 
+    // Addresses non-pristine field being mistaken for a passphrase of ''
+    if (data.Passphrase == '') {
+      data.Passphrase = undefined;
+    }
+    if (data.Passphrase2 == '') {
+      data.Passphrase2 = undefined;
+    }
+  }
 }

--- a/src/app/pages/system/ca/ca-add/ca-add.component.ts
+++ b/src/app/pages/system/ca/ca-add/ca-add.component.ts
@@ -343,8 +343,8 @@ export class CertificateAuthorityAddComponent {
     }
 
     // Addresses non-pristine field being mistaken for a passphrase of ''
-    if (data.Passphrase == '') {
-      data.Passphrase = undefined;
+    if (data.passphrase == '') {
+      data.passphrase = undefined;
     }
     if (data.passphrase2) {
       delete data.passphrase2;

--- a/src/app/pages/system/ca/ca-add/ca-add.component.ts
+++ b/src/app/pages/system/ca/ca-add/ca-add.component.ts
@@ -26,7 +26,9 @@ export class CertificateAuthorityAddComponent {
       placeholder : T('Identifier'),
       tooltip: T('Enter a description of the CA.'),
       required: true,
-      validation : [ Validators.required]
+      validation : [ Validators.required, Validators.pattern('[A-Za-z0-9_-]+$') ],
+      hasErrors: false,
+      errors: 'Allowed characters: letters, numbers, underscore (_), and dash (-).'
     },
     {
       type : 'select',
@@ -312,6 +314,19 @@ export class CertificateAuthorityAddComponent {
         }
       }
     })
+
+    entity.formGroup.controls['name'].valueChanges.subscribe((res) => {
+      this.identifier = res;
+    })
+
+    entity.formGroup.controls['name'].statusChanges.subscribe((res) => {
+      if (this.identifier && res === 'INVALID') {
+        _.find(this.fieldConfig).hasErrors = true;
+      } else {
+        _.find(this.fieldConfig).hasErrors = false;
+      }
+    })
+
   }
 
   hideField(fieldName: any, show: boolean, entity: any) {
@@ -326,13 +341,6 @@ export class CertificateAuthorityAddComponent {
     } else {
       data.san = _.split(data.san, ' ');
     }
-
-    // Addresses non-pristine field being mistaken for a passphrase of ''
-    if (data.passphrase == '') {
-      data.passphrase = undefined;
-    }
-    if (data.passphrase2) {
-      delete data.passphrase2;
-    }
   }
+
 }

--- a/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
+++ b/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
@@ -27,7 +27,7 @@ export class CertificateAddComponent {
       placeholder : T('Identifier'),
       tooltip: T('Enter a description of the CA.'),
       required: true,
-      validation : [ Validators.required]
+      validation : [ Validators.required ]
     },
     {
       type : 'select',
@@ -53,7 +53,7 @@ export class CertificateAddComponent {
       isHidden: true,
       disabled: true,
       required: true,
-      validation: [Validators.required ]
+      validation: [Validators.required]
     },
     {
       type : 'select',

--- a/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
+++ b/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
@@ -27,7 +27,9 @@ export class CertificateAddComponent {
       placeholder : T('Identifier'),
       tooltip: T('Enter a description of the CA.'),
       required: true,
-      validation : [ Validators.required]
+      validation : [ Validators.required, Validators.pattern('[A-Za-z0-9_-]+$') ],
+      hasErrors: false,
+      errors: 'Allowed characters: letters, numbers, underscore (_), and dash (-).'
     },
     {
       type : 'select',
@@ -343,11 +345,8 @@ export class CertificateAddComponent {
     if (data.passphrase == '') {
       data.passphrase = undefined;
     }
-
-    if (data.passphrase2) {
+      if (data.passphrase2) {
       delete data.passphrase2;
     }
   }
-
-
 }

--- a/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
+++ b/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
@@ -315,19 +315,6 @@ export class CertificateAddComponent {
       }
     })
 
-    entity.formGroup.controls['name'].valueChanges.subscribe((res) => {
-      this.identifier = res;
-    })
-  
-    entity.formGroup.controls['name'].statusChanges.subscribe((res) => {
-      if (this.identifier && res === 'INVALID') {
-        _.find(this.fieldConfig).hasErrors = true;
-      } else {
-        _.find(this.fieldConfig).hasErrors = false;
-      }
-    })
-  }
-
   hideField(fieldName: any, show: boolean, entity: any) {
     let target = _.find(this.fieldConfig, {'name' : fieldName});
     target.isHidden = show;

--- a/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
+++ b/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
@@ -195,17 +195,17 @@ export class CertificateAddComponent {
     },
     {
       type : 'input',
-      name : 'Passphrase',
+      name : 'passphrase',
       placeholder : T('Passphrase'),
       tooltip : T('Enter the passphrase for the Private Key.'),
       inputType : 'password',
-      validation : [ matchOtherValidator('Passphrase2') ],
+      validation : [ matchOtherValidator('passphrase2') ],
       isHidden: true,
       togglePw : true
     },
     {
       type : 'input',
-      name : 'Passphrase2',
+      name : 'passphrase2',
       inputType : 'password',
       placeholder : T('Confirm Passphrase'),
       isHidden : true
@@ -239,8 +239,8 @@ export class CertificateAddComponent {
   private importFields: Array<any> = [
     'certificate',
     'privatekey',
-    'Passphrase',
-    'Passphrase2',
+    'passphrase',
+    'passphrase2',
   ];
 
   private country: any;
@@ -342,12 +342,13 @@ export class CertificateAddComponent {
     }
 
     // Addresses non-pristine field being mistaken for a passphrase of ''
-    if (data.Passphrase == '') {
-      data.Passphrase = undefined;
+    if (data.passphrase == '') {
+      data.passphrase = undefined;
     }
-    if (data.Passphrase2 == '') {
-      data.Passphrase2 = undefined;
-    }    
+
+    if (data.passphrase2) {
+      delete data.passphrase2;
+    }
   }
 
 

--- a/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
+++ b/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
@@ -341,6 +341,7 @@ export class CertificateAddComponent {
       data.san = _.split(data.san, ' ');
     }
 
+    // Addresses non-pristine field being mistaken for a passphrase of ''
     if (data.Passphrase == '') {
       data.Passphrase = undefined;
     }

--- a/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
+++ b/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
@@ -340,6 +340,14 @@ export class CertificateAddComponent {
     } else {
       data.san = _.split(data.san, ' ');
     }
+
+    if (data.Passphrase == '') {
+      data.Passphrase = undefined;
+    }
+    if (data.Passphrase2 == '') {
+      data.Passphrase2 = undefined;
+    }    
+    console.log(data)
   }
 
 

--- a/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
+++ b/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
@@ -311,7 +311,7 @@ export class CertificateAddComponent {
         }
       }
     })
-
+  }
   hideField(fieldName: any, show: boolean, entity: any) {
     let target = _.find(this.fieldConfig, {'name' : fieldName});
     target.isHidden = show;

--- a/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
+++ b/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
@@ -348,7 +348,6 @@ export class CertificateAddComponent {
     if (data.Passphrase2 == '') {
       data.Passphrase2 = undefined;
     }    
-    console.log(data)
   }
 
 

--- a/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
+++ b/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
@@ -27,9 +27,7 @@ export class CertificateAddComponent {
       placeholder : T('Identifier'),
       tooltip: T('Enter a description of the CA.'),
       required: true,
-      validation : [ Validators.required, Validators.pattern('[A-Za-z0-9_-]+$') ],
-      hasErrors: false,
-      errors: 'Allowed characters: letters, numbers, underscore (_), and dash (-).'
+      validation : [ Validators.required]
     },
     {
       type : 'select',

--- a/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
+++ b/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
@@ -243,7 +243,6 @@ export class CertificateAddComponent {
 
   private country: any;
   private signedby: any;
-  public identifier: any;
 
   constructor(protected router: Router, protected route: ActivatedRoute,
               protected rest: RestService, protected ws: WebSocketService,

--- a/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
+++ b/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
@@ -53,7 +53,7 @@ export class CertificateAddComponent {
       isHidden: true,
       disabled: true,
       required: true,
-      validation: [Validators.required]
+      validation: [Validators.required ]
     },
     {
       type : 'select',


### PR DESCRIPTION
Ticket: 47246
Renames passphrase fields to match API, thus fixing inability to submit CAs and Certs with passphrases