### PR TITLE
Adjust method for adding up capacity of striped array

### DIFF
--- a/src/app/pages/storage/volumes/manager/vdev/vdev.component.ts
+++ b/src/app/pages/storage/volumes/manager/vdev/vdev.component.ts
@@ -91,11 +91,13 @@ export class VdevComponent implements OnInit {
     this.error = null;
     this.firstdisksize = 0;
     let totalsize = 0;
+    let stripeSize = 0;
     let smallestdisk = 0;
     let estimate = 0;
     const swapsize = 2 * 1024 * 1024 * 1024;
     for (let i = 0; i < this.disks.length; i++) {
       const size = parseInt(this.disks[i].real_capacity, 10) - swapsize;
+      stripeSize += size;
       if (i === 0) {
         smallestdisk = size;
         this.firstdisksize = size;
@@ -117,7 +119,7 @@ export class VdevComponent implements OnInit {
     } else if (this.type === "raidz3") {
       estimate = totalsize - 3 * smallestdisk;
     } else {
-      estimate = totalsize; // stripe
+      estimate = stripeSize; // stripe
     }
 
     this.rawSize =estimate;


### PR DESCRIPTION
Ticket: #48966
Adjusts method for calculating capacity of stripe only, assuming that the stripe option means using the real capacity of all disks combined, unlike mirror or raidz.