### PR TITLE
Duplicate of PR 1309

### DIFF
--- a/src/app/core/components/viewchart/viewchart.component.ts
+++ b/src/app/core/components/viewchart/viewchart.component.ts
@@ -27,8 +27,10 @@ export const ViewChartMetadata = {
         <div class="legend-html" fxLayout="row wrap" fxLayoutAlign="space-between" fxLayoutGap="16px" >
           <ng-container *ngFor="let item of legend; let i=index ">
             <div fxFlex.xs="calc(33% - 16px)" class="legend-item" *ngIf="chartType != 'gauge'" (click)="focus(legend[i])" [ngClass]="{'legend-item-disabled':!legend[i].visible}">
-              <span class="legend-swatch" [style.background-color]="legend[i].swatch"></span>
-              <span class="legend-name">{{legend[i].name}}: </span>
+              <div>
+                <span class="legend-swatch" [style.background-color]="legend[i].swatch"></span>
+                <span class="legend-name">{{legend[i].name}}: </span>
+              </div>
               <div class="legend-value" [style.color]="legend[i].swatch"><span *ngIf="showLegendValues">{{legend[i].value | number : '1.2-2'}}{{units}}</span></div>
             </div>
           </ng-container>

--- a/src/app/core/components/viewchartdonut/viewchartdonut.component.ts
+++ b/src/app/core/components/viewchartdonut/viewchartdonut.component.ts
@@ -4,7 +4,41 @@ import { ViewChartComponent, ViewChartMetadata } from 'app/core/components/viewc
 
 @Component({
   selector: 'viewchartdonut',
-  template:ViewChartMetadata.template
+  template: `
+      <div class="viewchart-wrapper {{chartClass}}-wrapper" fxLayout="row wrap" fxLayoutAlign="space-around center">
+
+      <div *ngIf="chartLoaded && legendPosition == 'top'" class="legend-wrapper">
+        <div class="legend-x legend-item" *ngIf="chartConfig.data.x">Time: <span *ngIf="showLegendValues" class="legend-item-time">{{legend[0].x}}</span></div>
+        <div class="legend-html" fxLayout="row wrap" fxLayoutAlign="space-between" fxLayoutGap="16px" >
+          <ng-container *ngFor="let item of legend; let i=index ">
+            <div fxFlex.xs="calc(33% - 16px)" class="legend-item" *ngIf="legendPosition == 'top'" (click)="focus(legend[i])" [ngClass]="{'legend-item-disabled':!legend[i].visible}">
+              <span class="legend-swatch" [style.background-color]="legend[i].swatch"></span>
+              <span class="legend-name">{{legend[i].name}}: </span>
+              <div class="legend-value" [style.color]="legend[i].swatch"><span *ngIf="showLegendValues">{{legend[i].value | number : '1.2-2'}}{{units}}</span></div>
+            </div>
+
+          </ng-container>
+        </div>
+      </div>
+
+      <div id="{{chartId}}" [ngClass]="chartClass" fxFlex="50"></div>
+      
+      <div *ngIf="chartLoaded && legendPosition == 'right'"  class="legend-wrapper" fxFlex="50">
+        <div class="legend-x legend-item" *ngIf="chartConfig.data.x">Time: <span *ngIf="showLegendValues" class="legend-item-time">{{legend[0].x}}</span></div>
+        <div class="legend-html" fxLayout="row wrap" fxLayoutAlign="space-between" fxLayoutGap="16px" >
+          <ng-container *ngFor="let item of legend; let i=index ">
+            <div fxFlex="100%" class="legend-item" (click)="focus(legend[i])" [ngClass]="{'legend-item-disabled':!legend[i].visible}">
+              <span class="legend-swatch" [style.background-color]="legend[i].swatch"></span>
+              <span class="legend-name">{{legend[i].name}}: </span>
+              <div class="legend-value" [style.color]="legend[i].swatch"><span *ngIf="showLegendValues">{{legend[i].value | number : '1.2-2'}}{{units}}</span></div>
+            </div>
+          </ng-container>
+        </div>
+      </div>
+
+    </div>
+  `
+  //template:ViewChartMetadata.template
   //templateUrl: './viewchartpie.component.html',
   //styleUrls: ['./viewchartdonut.component.css']
   })
@@ -12,6 +46,7 @@ export class ViewChartDonutComponent extends ViewChartComponent implements OnIni
 
   public title:string = '';
   public chartType: string = 'donut';
+  public legendPosition:string = 'right'; // Valid positions are top or right
 
   constructor() { 
     super();

--- a/src/app/core/components/viewchartline/viewchartline.component.ts
+++ b/src/app/core/components/viewchartline/viewchartline.component.ts
@@ -99,7 +99,7 @@ export class ViewChartLineComponent extends ViewChartComponent implements OnInit
           }
         },
         y:{
-          inner:true,
+          inner:false,
           /*tick:{
             format: d3.format(this.units)
           }*/

--- a/src/app/pages/vm/vm-cards/vm-summary.component.css
+++ b/src/app/pages/vm/vm-cards/vm-summary.component.css
@@ -1,3 +1,4 @@
 .vm-summary h3{
   text-align:center;
+  margin:16px 0;
 }

--- a/src/app/pages/vm/vm-cards/vm-summary.component.html
+++ b/src/app/pages/vm/vm-cards/vm-summary.component.html
@@ -1,7 +1,7 @@
 <div class="vm-summary" fxLayout="row" fxLayoutWrap fxLayoutAlign="space-around center" fxLayoutGap="1%">
   <h3 fxFlex="98">Virtual Machines Summary</h3>
   <!--<viewchartline #cpu fxFlex="30" class="chart"></viewchartline>-->
-  <viewchartline #cpu fxFlex="30" class="chart"></viewchartline>
-  <viewchartdonut #zpool fxFlex="30" class="chart"></viewchartdonut>
-  <viewchartdonut #mem fxFlex="30" class="chart"></viewchartdonut>
+  <!--<viewchartline #cpu fxFlex="30" class="chart"></viewchartline>
+    <viewchartdonut #zpool fxFlex="30" class="chart"></viewchartdonut>-->
+  <viewchartdonut #mem fxFlex="60" class="chart"></viewchartdonut>
 </div>

--- a/src/app/pages/vm/vm-cards/vm-summary.component.ts
+++ b/src/app/pages/vm/vm-cards/vm-summary.component.ts
@@ -73,6 +73,7 @@ export class VmSummaryComponent implements AfterViewInit, OnDestroy {
   setMemData(evt:CoreEvent){
     this.memChart.title = "vMemory in Use";
     this.memChart.units="GiB";
+    this.memChart.legendPosition = "right";
 
     // Convert to GiB
     let RNP = (<any>window).filesize(evt.data.RNP, {output: "object", exponent:3});
@@ -80,9 +81,9 @@ export class VmSummaryComponent implements AfterViewInit, OnDestroy {
     let RPRD = (<any>window).filesize(evt.data.RPRD, {output: "object", exponent:3});
 
     let memData = [
-      {legend: 'RNP', data:[RNP.value]},
-      {legend: 'PRD', data:[PRD.value]},
-      {legend: 'RPRD', data:[RPRD.value]}
+      {legend: 'Running (unprovisioned)', data:[RNP.value]},
+      {legend: 'Stopped (provisioned)', data:[PRD.value]},
+      {legend: 'Running (provisioned)', data:[RPRD.value]}
     ];
     this.totalVmem = evt.data.RNP + evt.data.PRD + evt.data.RPRD;
     if(this.physmem){
@@ -109,7 +110,7 @@ export class VmSummaryComponent implements AfterViewInit, OnDestroy {
 
   setPoolData(evt:CoreEvent){
     let usedObj = (<any>window).filesize(evt.data[0].used, {output: "object", exponent:3});
-    let used: ChartData = {
+    /*let used: ChartData = {
       legend: 'Used',
       data: [usedObj.value]
     };
@@ -125,13 +126,13 @@ export class VmSummaryComponent implements AfterViewInit, OnDestroy {
     this.zpoolChart.data = [used,available];
     //console.log(this.zpoolChart.data);
     this.zpoolChart.width = this.chartSize;
-    this.zpoolChart.height = this.chartSize;
+    this.zpoolChart.height = this.chartSize;*/
   }
 
   setCPUData(evt:CoreEvent){
     //console.log("SET CPU DATA");
     //console.log(evt.data);
-    let cpuUserObj = evt.data;
+    /*let cpuUserObj = evt.data;
 
     let parsedData = [];
     let dataTypes = evt.data.meta.legend;
@@ -147,13 +148,13 @@ export class VmSummaryComponent implements AfterViewInit, OnDestroy {
       parsedData.push(chartData);
     }
 
-    this.cpuChart.chartType = 'area-spline';
+    this.cpuChart.chartType = 'line';
     this.cpuChart.units = '%';
     this.cpuChart.timeSeries = true;
     this.cpuChart.timeFormat = '%H:%M';// eg. %m-%d-%Y %H:%M:%S.%L
     this.cpuChart.timeData = evt.data.meta;
     this.cpuChart.data = parsedData;//[cpuUser];
     this.cpuChart.width = this.chartSize;
-    this.cpuChart.height = this.chartSize;
+    this.cpuChart.height = this.chartSize;*/
   }
 }


### PR DESCRIPTION
Fixed labels on virtual memory chart in vm-summary in table view. Also removed cpu uage and pool usage charts since they were not appropriate and there wasn't enough room to accommodate them anyway. Changed legend location in viewchartdonut. You can now set legendPosition property to place legend to top or to the right.