### PR TITLE
Removes arrows from number fields for moz and webkit

### DIFF
--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -1039,4 +1039,12 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     @include variable(fill, --accent, $accent);
   }
 
+  input[type=number] {
+    -moz-appearance: textfield !important;
+  }
+
+  input[type=number]::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+  }
+
 } // end of ix theme


### PR DESCRIPTION
Ticket: #35272
Uses CSS to remove up/down arrows on number input fields