### PR TITLE
Added an example for the authorized hosts and ip addresses field.

### DIFF
--- a/src/app/pages/sharing/nfs/nfs-form/nfs-form.component.ts
+++ b/src/app/pages/sharing/nfs/nfs-form/nfs-form.component.ts
@@ -93,7 +93,8 @@ export class NFSFormComponent {
       name: 'nfs_hosts',
       placeholder: T('Authorized Hosts and IP addresses'),
       tooltip: T('Space-delimited list of allowed IP addresses or\
-                  hostnames. Leave empty to allow all.'),
+                  hostnames. Example: <i>1.2.3.0</i>.\
+                  Leave empty to allow all.'),
       blurStatus : true,
       blurEvent: this.nfs_hosts_event,
       parent: this,

--- a/src/app/pages/sharing/nfs/nfs-form/nfs-form.component.ts
+++ b/src/app/pages/sharing/nfs/nfs-form/nfs-form.component.ts
@@ -92,9 +92,9 @@ export class NFSFormComponent {
       type: 'textarea',
       name: 'nfs_hosts',
       placeholder: T('Authorized Hosts and IP addresses'),
-      tooltip: T('Space-delimited list of allowed IP addresses or\
-                  hostnames. Example: <i>1.2.3.0</i>.\
-                  Leave empty to allow all.'),
+      tooltip: T('Space-delimited list of allowed IP addresses\
+                  <i>(192.168.1.10)</i> or hostnames\
+                  <i>(www.freenas.com)</i>. Leave empty to allow all.'),
       blurStatus : true,
       blurEvent: this.nfs_hosts_event,
       parent: this,


### PR DESCRIPTION
Passed build test with no issues.
Related to: https://redmine.ixsystems.com/issues/23923#change-362826.
Added a correct example of an IP address/hostname to the Authorized Hosts and IP addresses field in response to a customer adding an incorrect address  (192.168.2.1/24). 

