### PR TITLE
Update text related to "Save System Configuration" dialog:

### DIFF
--- a/src/app/pages/common/entity/entity-dialog/dialog-form-configuration.interface.ts
+++ b/src/app/pages/common/entity/entity-dialog/dialog-form-configuration.interface.ts
@@ -12,6 +12,7 @@ export interface DialogFormConfiguration {
   isCustActionVisible?: any,
   hideButton?: boolean,
   message?: any,
+  warning?: any,
   preInit?: any,
   parent?: any
 }

--- a/src/app/pages/common/entity/entity-dialog/entity-dialog.component.html
+++ b/src/app/pages/common/entity/entity-dialog/entity-dialog.component.html
@@ -8,7 +8,8 @@
       <mat-icon *ngIf="!showPassword">visibility</mat-icon>
       <mat-icon *ngIf="showPassword">visibility_off</mat-icon>
   </button>
-  
+  <span [innerHTML]="conf.warning"></span>
+
   </ng-container>
 </div>
 <div>
@@ -19,10 +20,10 @@
   <span fxFlex></span>
   <span *ngFor="let custBtn of conf.custActions">
     <button id="cust_button_{{custBtn.id}}" mat-button class="mat-button"
-      *ngIf="!conf.isCustActionVisible || conf.isCustActionVisible(custBtn.id)" type="button" 
+      *ngIf="!conf.isCustActionVisible || conf.isCustActionVisible(custBtn.id)" type="button"
       (click)="custBtn['function']()" [name]="custBtn.name + '_button'">{{custBtn.name | translate}}</button>
   </span>
   <button mat-button class="mat-flat-button mat-accent" (click)="cancel()" [name]="cancelButtonText + '_button'">{{cancelButtonText | translate}}</button>
-  <button mat-button class="mat-flat-button mat-primary" (click)="submit()" [disabled]="!formGroup.valid" 
+  <button mat-button class="mat-flat-button mat-primary" (click)="submit()" [disabled]="!formGroup.valid"
     *ngIf="saveButtonText" [name]="saveButtonText + '_button'">{{saveButtonText | translate}}</button>
 </div>

--- a/src/app/pages/common/entity/entity-dialog/entity-dialog.component.ts
+++ b/src/app/pages/common/entity/entity-dialog/entity-dialog.component.ts
@@ -24,6 +24,7 @@ export class EntityDialogComponent implements OnInit {
   @Input('conf') conf: DialogFormConfiguration;
 
   public title: string;
+  public warning: string;
   public fieldConfig: Array < FieldConfig > ;
   public formGroup: FormGroup;
   public saveButtonText: string;

--- a/src/app/pages/preferences/page/forms/general-preferences-form.component.ts
+++ b/src/app/pages/preferences/page/forms/general-preferences-form.component.ts
@@ -77,22 +77,24 @@ export class GeneralPreferencesFormComponent implements OnInit, OnChanges, OnDes
             tooltip: 'Display help icons in forms.',
             class:'inline'
           },
-          { 
-            type: 'checkbox', 
-            name: 'allowPwToggle', 
+          {
+            type: 'checkbox',
+            name: 'allowPwToggle',
             width: '300px',
             placeholder: 'Enable Password Toggle',
             value:this.allowPwToggle,
             tooltip: 'This option enables/disables a password toggle button.',
             class:'inline'
           },
-          { 
-            type: 'checkbox', 
-            name: 'hideWarning', 
+          {
+            type: 'checkbox',
+            name: 'hideWarning',
             width: '300px',
-            placeholder: 'Hide warning config prompt on upgrade.',
+            placeholder: 'Hide "Save Configuration" Dialog Before Upgrade',
             value:this.hideWarning,
-            tooltip: T('This option enables/disables warning config on upgrade.'),
+            tooltip: T('Show or hide a dialog to save the system\
+                        configuration file. This dialog appears\
+                        after choosing to upgrade the system.'),
             class:'inline'
           }
         ]

--- a/src/app/pages/system/update/manualupdate/manualupdate.component.ts
+++ b/src/app/pages/system/update/manualupdate/manualupdate.component.ts
@@ -76,7 +76,7 @@ export class ManualUpdateComponent {
     {
       type: 'checkbox',
       name: 'secretseed',
-      placeholder: T('Export Password Secret Seed')
+      placeholder: T('Include Password Secret Seed')
     }
   ];
   public saveConfigFormConf: DialogFormConfiguration = {

--- a/src/app/pages/system/update/update.component.ts
+++ b/src/app/pages/system/update/update.component.ts
@@ -68,15 +68,18 @@ export class UpdateComponent implements OnInit {
   ];
   public saveConfigFormConf: DialogFormConfiguration = {
     title: "Save configuration settings from this machine before updating?",
-    message: "WARNING: This configuration file contains system passwords\
-              and other sensitive data. Keep the system configuration\
-              file stored in a secure location.",
+    message: "<b>WARNING:</b> This configuration file contains system\
+              passwords and other sensitive data.<br>",
     fieldConfig: this.saveConfigFieldConf,
+    warning: "Including the Password Secret Seed allows using this\
+              configuration file with a new boot device. It also\
+              decrypts all passwords used on this system.\
+              <b>Always secure the system configuration file!</b>",
     method_ws: 'core.download',
     saveButtonText: T('SAVE CONFIGURATION'),
     cancelButtonText: T('NO'),
     customSubmit: this.saveConfigSubmit,
-  }
+  };
 
   protected dialogRef: any;
   constructor(protected router: Router, protected route: ActivatedRoute, protected snackBar: MatSnackBar,

--- a/src/app/pages/system/update/update.component.ts
+++ b/src/app/pages/system/update/update.component.ts
@@ -42,8 +42,8 @@ export class UpdateComponent implements OnInit {
     "NIGHTLY_UPGRADE": T("Changing to a nightly train is one-way. Changing back to a stable train is not supported!")
   }
   public release_train: boolean;
-  public pre_release_train: boolean;  
-  public nightly_train: boolean;  
+  public pre_release_train: boolean;
+  public nightly_train: boolean;
   public updates_available = false;
   public currentTrainDescription: string;
   public fullTrainList: any[];
@@ -63,19 +63,18 @@ export class UpdateComponent implements OnInit {
     {
       type: 'checkbox',
       name: 'secretseed',
-      placeholder: T('Export Password Secret Seed')
+      placeholder: T('Include Password Secret Seed')
     },
-    {
-      type: 'checkbox',
-      name: 'hideWarning',
-      placeholder: T('Don\'t show this again'),
-    }
   ];
   public saveConfigFormConf: DialogFormConfiguration = {
-    title: "Before doing update, would you like to save a copy of the config?",
+    title: "Save configuration settings from this machine before updating?",
+    message: "WARNING: This configuration file contains system passwords\
+              and other sensitive data. Keep the system configuration\
+              file stored in a secure location.",
     fieldConfig: this.saveConfigFieldConf,
     method_ws: 'core.download',
-    saveButtonText: T('OK'),
+    saveButtonText: T('SAVE CONFIGURATION'),
+    cancelButtonText: T('NO'),
     customSubmit: this.saveConfigSubmit,
   }
 
@@ -214,8 +213,8 @@ export class UpdateComponent implements OnInit {
         if (this.compareTrains(this.train, i) === 'ALLOWED' || this.compareTrains(this.train, i) === 'NIGHTLY_UPGRADE' || this.train === i) {
           this.trains.push({ name: i, description: res.trains[i].description });
         }
-        
-      } 
+
+      }
       this.singleDescription = this.trains[0].description;
 
       // The following is a kluge until we stop overwriting (via middleware?) the description of the currently
@@ -344,7 +343,7 @@ export class UpdateComponent implements OnInit {
                         this.dialogRef.close(false);
                         this.snackBar.open(T("Updates successfully downloaded"),'close', { duration: 5000 });
                         this.pendingupdates();
-    
+
                       });
                       this.dialogRef.componentInstance.failure.subscribe((failure) => {
                         this.dialogService.errorReport(failure.error, failure.reason, failure.trace.formatted);
@@ -355,7 +354,7 @@ export class UpdateComponent implements OnInit {
                     }
                   }
                 });
-                
+
               } else {
                 this.dialogService.dialogForm(this.saveConfigFormConf).subscribe(()=>{
                   const ds  = this.dialogService.confirm(
@@ -371,7 +370,7 @@ export class UpdateComponent implements OnInit {
                           this.dialogRef.close(false);
                           this.snackBar.open(T("Updates successfully downloaded"),'close', { duration: 5000 });
                           this.pendingupdates();
-      
+
                         });
                         this.dialogRef.componentInstance.failure.subscribe((failure) => {
                           this.dialogService.errorReport(failure.error, failure.reason, failure.trace.formatted);

--- a/src/app/pages/system/update/update.component.ts
+++ b/src/app/pages/system/update/update.component.ts
@@ -74,7 +74,7 @@ export class UpdateComponent implements OnInit {
     warning: "Including the Password Secret Seed allows using this\
               configuration file with a new boot device. It also\
               decrypts all passwords used on this system.\
-              <b>Always secure the system configuration file!</b>",
+              <b>Keep the configuration file safe and protect it from unauthorized access!</b>",
     method_ws: 'core.download',
     saveButtonText: T('SAVE CONFIGURATION'),
     cancelButtonText: T('NO'),


### PR DESCRIPTION
- Rename the dialog box.
- Add warning.
- Remove unnecessary option.
- Add helptext
- Rename Buttons to conform with naming conventions
- Rename checkbox in Settings/Preferences.
- Add help text to checkbox.
- Alter "Export Password Secret Seed" to read "Include Password Secret Seed".
- Clean up whitespace.
- NPM testing: no issues.