### PR TITLE
Remove tooltip stating password must be <= 9 chars

### DIFF
--- a/src/app/pages/account/users/user-form/user-form.component.ts
+++ b/src/app/pages/account/users/user-form/user-form.component.ts
@@ -78,8 +78,7 @@ export class UserFormComponent {
           type : 'input',
           name : 'password',
           placeholder : T('Password'),
-          tooltip : T('Enter password of nine characters or less\
-                      Required unless <b>Enable password login</b> is\
+          tooltip : T('Required unless <b>Enable password login</b> is\
                       <i>No</i>. Passwords cannot contain a <b>?</b>.'),
           inputType : 'password',
           togglePw: true,
@@ -100,8 +99,7 @@ export class UserFormComponent {
           type : 'input',
           name : 'password_edit',
           placeholder : T('Password'),
-          tooltip : T('Enter password of nine characters or less\
-                      Required unless <b>Enable password login</b> is\
+          tooltip : T('Required unless <b>Enable password login</b> is\
                       <i>No</i>. Passwords cannot contain a <b>?</b>.'),
           inputType : 'password',
           togglePw: true,


### PR DESCRIPTION
The validator forcing the max password length to <= 9 characters was
removed in 94e555c96f17bcb10f466948f5f1203ebea619ff, but the tooltip
was not. This change adjusts the tooltip accordingly.