### PR TITLE
Remove redundant "SAVE CONFIG" button in System/Update/Manual Update

### DIFF
--- a/src/app/pages/system/update/manualupdate/manualupdate.component.ts
+++ b/src/app/pages/system/update/manualupdate/manualupdate.component.ts
@@ -34,15 +34,15 @@ export class ManualUpdateComponent {
   protected dialogRef: any;
   public fileLocation: any;
   public subs: any;
-  public custActions: Array<any> = [
-    {
-      id : 'save_config',
-      name : T('Save Config'),
-      function : () => {
-        this.dialogservice.dialogForm(this.saveConfigFormConf);
-      }
-    }
-  ];
+  // public custActions: Array<any> = [
+  //   {
+  //     id : 'save_config',
+  //     name : T('Save Config'),
+  //     function : () => {
+  //       this.dialogservice.dialogForm(this.saveConfigFormConf);
+  //     }
+  //   }
+  // ];
   public saveSubmitText ="Apply Update";
   protected fieldConfig: FieldConfig[] = [
     {

--- a/src/app/pages/system/update/update.component.ts
+++ b/src/app/pages/system/update/update.component.ts
@@ -451,7 +451,16 @@ export class UpdateComponent implements OnInit {
   };
 
   ManualUpdate(){
-    this.router.navigate([this.router.url +'/manualupdate']);
+    this.ws.call('user.query',[[["id", "=",1]]]).subscribe((ures)=>{
+      if(ures[0].attributes.preferences !== undefined && ures[0].attributes.preferences.hideWarning) {
+        this.router.navigate([this.router.url +'/manualupdate']);
+      }
+      else {
+        this.dialogService.dialogForm(this.saveConfigFormConf).subscribe(()=>{
+          this.router.navigate([this.router.url +'/manualupdate']);
+        });
+      };
+    });
   }
 
   pendingupdates(){


### PR DESCRIPTION
show Save Config dailoge when user clicks  INSTALL MANUAL UDPATE FILE

(cherry picked from commit 7b2c852a8dbfc8f3f8d83aebde882b01dd197e26)