### PR TITLE
Fixed regression with Firefox. 

### DIFF
--- a/src/app/pages/reportsdashboard/components/report/report.component.html
+++ b/src/app/pages/reportsdashboard/components/report/report.component.html
@@ -6,8 +6,8 @@
         <!-- Controls/Tools -->
         <div fxFlex="calc(35%)" class="line-chart-tools-wrapper">
           <div class="line-chart-tools" *ngIf="lineChart.chart"> 
-                  <button class="tool-icon" mat-icon-button [disabled]="timeZoomIndex >= (zoomLevels.length - 1)" >
-                    <mat-icon role="img" fontSet="mdi-set" fontIcon="mdi-magnify-plus" (click)="timeZoomIn()"></mat-icon>
+            <button class="tool-icon" mat-icon-button [disabled]="timeZoomIndex >= (zoomLevels.length - 1)" (click)="timeZoomIn()">
+                    <mat-icon role="img" fontSet="mdi-set" fontIcon="mdi-magnify-plus" ></mat-icon>
                   </button>
                 
                   <button class="tool-icon" mat-icon-button [disabled]="timeZoomIndex <= 0" (click)="timeZoomOut()">

--- a/src/app/pages/reportsdashboard/components/report/report.component.html
+++ b/src/app/pages/reportsdashboard/components/report/report.component.html
@@ -10,12 +10,12 @@
                     <mat-icon role="img" fontSet="mdi-set" fontIcon="mdi-magnify-plus" (click)="timeZoomIn()"></mat-icon>
                   </button>
                 
-                  <button class="tool-icon" mat-icon-button [disabled]="timeZoomIndex <= 0">
-                    <mat-icon role="img" fontSet="mdi-set" fontIcon="mdi-magnify-minus" (click)="timeZoomOut()"></mat-icon>
+                  <button class="tool-icon" mat-icon-button [disabled]="timeZoomIndex <= 0" (click)="timeZoomOut()">
+                    <mat-icon role="img" fontSet="mdi-set" fontIcon="mdi-magnify-minus"></mat-icon>
                   </button>
                 
-                  <button class="tool-icon" mat-icon-button >
-                    <mat-icon role="img" fontSet="mdi-set" fontIcon="mdi-rewind" (click)="stepBack()"></mat-icon>
+                  <button class="tool-icon" mat-icon-button (click)="stepBack()">
+                    <mat-icon role="img" fontSet="mdi-set" fontIcon="mdi-rewind" ></mat-icon>
                   </button>
                 
                   <button class="tool-icon" mat-icon-button (click)="stepForward()" [disabled]="stepForwardDisabled">


### PR DESCRIPTION
Moved click() event handler in report component html template from icon element to the button element.

(cherry picked from commit 49e60917efdf5522e1d43d490d6f8639ee50788a)