### PR TITLE
fix Misspelled "successful in the Restart dialogue.

### DIFF
--- a/src/app/pages/system/update/manualupdate/manualupdate.component.ts
+++ b/src/app/pages/system/update/manualupdate/manualupdate.component.ts
@@ -137,7 +137,7 @@ export class ManualUpdateComponent {
     this.dialogRef.componentInstance.success.subscribe((succ)=>{
       this.dialogRef.close(false);
       this.translate.get('Restart').subscribe((reboot: string) => {
-        this.translate.get('Update successfull. Please reboot for the update to take effect. Reboot now?').subscribe((reboot_prompt: string) => {
+        this.translate.get('Update successful. Please reboot for the update to take effect. Reboot now?').subscribe((reboot_prompt: string) => {
           this.dialogService.confirm(reboot, reboot_prompt).subscribe((reboot_res) => {
             if (reboot_res) {
               this.router.navigate(['/others/reboot']);


### PR DESCRIPTION
(cherry picked from commit be239bee1a8b25bece99c339e860dd3e4d13f2dd)