### PR TITLE
Dszidi redo tables

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -22,6 +22,7 @@
         "testTsconfig": "tsconfig.spec.json",
         "prefix": "app",
         "styles": [
+          "assets/styles/reset.css",
           "../node_modules/xterm/dist/xterm.css",
           "../node_modules/quill/dist/quill.core.css",
           "../node_modules/quill/dist/quill.snow.css",
@@ -34,12 +35,12 @@
           "../node_modules/c3/c3.min.css",
           "../node_modules/angular-tree-component/dist/angular-tree-component.css",
           
+          "../node_modules/primeicons/primeicons.css",
+          "../node_modules/primeng/resources/primeng.min.css",
           "assets/styles/themes/ix-blue.scss",
           "assets/styles/fn-styles.css",
           "assets/styles/charts.css",
           "assets/styles/egret_overrides.css",
-          "../node_modules/primeicons/primeicons.css",
-          "../node_modules/primeng/resources/primeng.min.css",
           "assets/styles/material-reduction.css"
         ],
         "scripts": [

--- a/src/app/core/services/preferences.service.ts
+++ b/src/app/core/services/preferences.service.ts
@@ -14,6 +14,7 @@ export interface UserPreferences {
   metaphor:string; // Prefer Cards || Tables || Auto (gui decides based on data array length)
   allowPwToggle:boolean;
   enableWarning:boolean;
+  preferIconsOnly:boolean;
 }
 
 @Injectable()
@@ -30,7 +31,8 @@ export class PreferencesService {
     "showTooltips":true,
     "metaphor":"auto",
     "allowPwToggle":true,
-    "enableWarning": true
+    "enableWarning": true,
+    "preferIconsOnly": false
   }
   constructor(protected core: CoreService, protected themeService: ThemeService,private api:ApiService,private router:Router,
     private aroute: ActivatedRoute) {
@@ -38,7 +40,13 @@ export class PreferencesService {
     this.core.register({observerClass:this, eventName:"Authenticated",sender:this.api}).subscribe((evt:CoreEvent) => {
       //console.log(evt.data);
       if(evt.data){
-        this.core.emit({name:"UserDataRequest", data: [[["id", "=", 1 ]]] });
+        this.core.emit({name:"UserPreferencesChanged", data: this.preferences });
+      }
+    });
+
+    this.core.register({observerClass:this, eventName:"UserPreferencesRequest"}).subscribe((evt:CoreEvent) => {
+      if(evt.data){
+        this.core.emit({name:"UserDataRequest", data: [[[ "id", "=", 1 ]]]});
       }
     });
 

--- a/src/app/pages/common/entity/entity-table/entity-table-add-actions.component.html
+++ b/src/app/pages/common/entity/entity-table/entity-table-add-actions.component.html
@@ -1,0 +1,54 @@
+  	<!--<div *ngIf="this.entity.conf.route_add || this.actions.length > 0">
+		<smd-fab-speed-dial id="myFab" #myFab [direction]="direction" [animationMode]="animationMode"
+				(mouseenter)="myFab.open = true" (mouseleave)="myFab.open = false">
+			<smd-fab-trigger [spin]="!this.entity.conf.route_add">
+				<button id="add_action_button" *ngIf="this.entity.conf.route_add; else elseBlock" mat-fab (click)="this.entity.doAdd()" matTooltip="{{this.entity.conf.route_add_tooltip | translate}}">
+					<mat-icon>add</mat-icon>
+				</button>
+				<ng-template #elseBlock>
+					<button mat-fab><mat-icon>list</mat-icon></button>
+				</ng-template>
+			</smd-fab-trigger>
+			<smd-fab-actions>
+				<button id="add_action_button_{{action?.label}}" *ngFor="let action of actions" mat-mini-fab (click)="action.onClick()" matTooltip="{{action.label | translate}}">
+					<mat-icon>{{action.icon}}</mat-icon>
+				</button>
+			</smd-fab-actions>
+		</smd-fab-speed-dial>
+                </div>-->
+
+
+
+                <!-- NO FAB BUTTONS BELOW THIS POINT -->
+
+                <!--<div *ngIf="this.entity.conf.route_add || this.actions.length > 0; else elseBlock">-->
+<div class="entity-add-actions-wrapper" style="display:inline-block; text-align:left;" *ngIf="this.totalActions> 0">
+
+  <button style="height:37px; margin-top:-1px;" mat-button color="primary" [matMenuTriggerFor]="menu" class="menu-toggle" *ngIf="this.totalActions> 1; else elseBlock"  matTooltip="{{ this.menuTriggerMessage | translate}}">
+    <!--<button mat-button [matMenuTriggerFor]="menu">-->
+    <span>ACTIONS <mat-icon class="menu-caret ">arrow_drop_down</mat-icon></span>
+  </button>
+  <mat-menu #menu="matMenu" overlapTrigger="false">
+    <button mat-menu-item (click)="this.entity.doAdd()" *ngIf="this.entity.conf.route_add" id="add_action_button">
+    <mat-icon>add</mat-icon>
+    <span>{{this.entity.conf.route_add_tooltip | translate}}</span>
+  </button>
+  <button id="add_action_button_{{action?.label}}" *ngFor="let action of actions" mat-menu-item (click)="action.onClick()">
+    <mat-icon>{{action.icon}}</mat-icon><span>{{action.label | translate}}</span>
+  </button>
+    <!--<button mat-menu-item>
+      <mat-icon>dialpad</mat-icon>
+      <span>Redial</span>
+      </button>-->
+  </mat-menu>
+
+  <ng-template #elseBlock>
+    <!--When there is no route_add -->
+    <button mat-button color="primary" (click)="this.entity.doAdd()" *ngIf="this.entity.conf.route_add" matTooltip="{{this.entity.conf.route_addd_tooltip | translate}}" id="add_action_button">ADD</button>
+
+    <button id="add_action_button_{{action?.label}}" mat-button color="primary" *ngIf="!this.entity.conf.route_add && this.actions== 1" (click)="this.actions[0].onClick()"  matTooltip="{{action.label | translate}}">
+    <span>{{this.actions[0].label | translate }}</span> 
+    <span> &nbsp; {{this.actions.length}}</span>
+  </button>
+  </ng-template>
+</div>

--- a/src/app/pages/common/entity/entity-table/entity-table-add-actions.component.ts
+++ b/src/app/pages/common/entity/entity-table/entity-table-add-actions.component.ts
@@ -9,7 +9,8 @@ import {EntityTableComponent} from './entity-table.component';
 
 @Component({
   selector : 'app-entity-table-add-actions',
-  template : `
+  templateUrl : 'entity-table-add-actions.component.html'
+  /*template : `
   	<div *ngIf="this.entity.conf.route_add || this.actions.length > 0">
 		<smd-fab-speed-dial id="myFab" #myFab [direction]="direction" [animationMode]="animationMode"
 				(mouseenter)="myFab.open = true" (mouseleave)="myFab.open = false">
@@ -28,17 +29,22 @@ import {EntityTableComponent} from './entity-table.component';
 			</smd-fab-actions>
 		</smd-fab-speed-dial>
 	</div>
-  `
+  `*/
 })
 export class EntityTableAddActionsComponent implements OnInit {
 
   @Input('entity') entity: any;
 
   public actions: any[];
+  public menuTriggerMessage:string = "Click for options";
 
   public spin: boolean = true;
   public direction: string = 'left';
   public animationMode: string = 'fling';
+  get totalActions(){
+    let addAction = this.entity.conf.route_add ? 1 : 0;
+    return this.actions.length + addAction;
+  }
 
   constructor(protected translate: TranslateService) { }
 

--- a/src/app/pages/common/entity/entity-table/entity-table.component.html
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.html
@@ -1,76 +1,139 @@
+<div class="legacy-warning" *ngIf="legacyWarning">
+      {{ legacyWarning | translate }} 
+      <span class="legacy-warning-link" (click)="onGoToLegacy()">
+        {{ legacyWarningLink | translate }}.
+      </span>
+    </div>
+
 <div id="entity-table-component" class="material mat-card mat-card-table">
-  <div class="mat-toolbar mat-card-toolbar" *ngIf="hideTopActions === false">
-    <div class="mat-card-title-text">{{ title | translate }}</div>
-    <div class="legacy-warning" *ngIf="legacyWarning">{{ legacyWarning | translate }} <span class="legacy-warning-link" (click)="onGoToLegacy()">{{ legacyWarningLink | translate }}.</span></div>
-    <mat-spinner 
-      [diameter]='40' 
-      id="entity-spinner"
-      *ngIf="!showDefaults && showSpinner" #entityspinner>
-    </mat-spinner> 
-    <app-entity-table-add-actions [entity]="this"></app-entity-table-add-actions>
-  </div>
+  <div class="mat-toolbar mat-card-toolbar" *ngIf="hideTopActions === false" fxLayout="row wrap" fxLayoutAlign="space-between center">
+    <div fxFlex="300px" class="mat-card-title-text">{{ title | translate }}</div>
 
-  <div id="filter">
-    <mat-input-container floatPlaceholder="never">
-      <input matInput #filter placeholder="{{'Filter' | translate}} {{title | translate}}">
-    </mat-input-container>
-    <tooltip message="{{'Show only entries that contain this text' | translate}}"></tooltip>
+  <!-- START OF CONTROLS SECTION -->
+  <div fxFlex class="entity-table-controls" fxLayout="row wrap" fxLayoutAlignGap="16px" fxLayoutAlign="end center">
+    <div id="filter" >
+      <mat-icon>search</mat-icon>
+      <mat-input-container floatPlaceholder="never">
+        <input matInput #filter placeholder="{{'Filter' | translate}} {{title | translate}}">
+      </mat-input-container>
+      <!--<tooltip message="{{'Show only entries that contain this text' | translate}}"></tooltip>-->
+    </div>
+  
+  <!-- START MultiMenu-->
+  <div *ngIf="allColumns && allColumns.length > 0">
+  <button mat-button [matMenuTriggerFor]="menu" color="primary" class="menu-toggle">
+    <span>Columns <mat-icon class="menu-caret">arrow_drop_down</mat-icon> </span>
+  </button>
+  <mat-menu #menu="matMenu" multiple overlapTrigger="false">
+  
+    <!-- SELECT ALL -->
+    <div (click)="$event.stopPropagation()">
+      <button mat-menu-item (click)="checkAll()" id="check-all">
+        <span>
+          <mat-icon *ngIf="checkLength()">check_circle</mat-icon> 
+          <mat-icon *ngIf="!checkLength()">remove</mat-icon> 
+        </span> 
+        <span>Select All</span>
+      </button>
+    </div>
+  
+    <!-- INDIVIDUAL COLUMNS-->
+    <div (click)="$event.stopPropagation()">
+      <button mat-menu-item *ngFor="let col of allColumns" (click)="toggle(col);" [id]="col.name">
+        <span>
+          <mat-icon *ngIf="isChecked(col)">check_circle</mat-icon> 
+          <mat-icon *ngIf="!isChecked(col)">remove</mat-icon> 
+        </span> 
+        <span>{{col.name}}</span>
+      </button>
+    </div>
+  </mat-menu>
   </div>
-
-  <div id="action-button-wrapper" *ngIf="conf.custActions">
-    <span *ngFor="let custBtn of conf.custActions">
-      <button id="cust_button_{{custBtn.name}}" mat-button *ngIf="!conf.isCustActionVisible || conf.isCustActionVisible(custBtn.id)" type="button" (click)="custBtn['function']()">{{custBtn.name | translate}}</button>
-    </span>
-  </div>
-
-<!-- Selected columns checkbox ----------------- -->
-<div id="col-select-box" class="selected-columns" *ngIf="allColumns.length > 10 ? true : false">
-  <div id="select-all-checkbox-and-label">
-    <mat-checkbox
-      type="checkbox"
-      [id]="check-all"
-      [checked]="checkLength()"
-      (change)="checkAll()"
-      labelPosition = 'before'>
-      Toggle
-     </mat-checkbox> 
-  </div>
-  <ul>
-    <li *ngFor="let col of allColumns">
-      <div>
-        <mat-checkbox
-          type="checkbox"
-          class="colselect"
-          [id]="col.name"
-          (change)="toggle(col)"
-          [checked]="isChecked(col)">
-          {{col.name}}
-        </mat-checkbox>
-      </div>
-    </li>
-  </ul>
-</div>
-<!-- End checkbox ------------------------------ -->
-
-  <div fxLayout="row wrap" fxLayoutAlign="start center" class="multiActionsButton">
-    <div [style.visibility]="selected.length > 0 ? 'visible' : 'hidden'" >
-      <div *ngIf="conf.multiActions; else defaultMultiActions" fxFlex="100">
-        <span *ngFor="let maction of conf.multiActions">
-          <button id="{{ maction?.id }}" 
-            mat-button matTooltip="{{ maction?.label  | translate }}" [matTooltipPosition]=maction?.ttpos 
-            *ngIf="maction.enable" (click)="maction.onClick(this.selected);">
-            <mat-icon>{{ maction?.icon }}</mat-icon>
+  <!-- END MultiMenu-->
+  
+  
+      <div style="text-align:right;"><app-entity-table-add-actions [entity]="this"></app-entity-table-add-actions></div>
+      <mat-spinner 
+        [diameter]='40' 
+        id="entity-spinner"
+        *ngIf="!showDefaults && showSpinner" #entityspinner>
+      </mat-spinner> 
+  
+      <ng-container *ngIf="conf && conf.custActions">
+        <!--<div id="action-button-wrapper" *ngIf="conf && conf.custActions">-->
+        <span *ngFor="let custBtn of conf.custActions">
+          <button id="cust_button_{{custBtn.name}}" mat-button 
+            *ngIf="!conf.isCustActionVisible || conf.isCustActionVisible(custBtn.id)" 
+            type="button" 
+            color="primary"
+            (click)="custBtn['function']()">
+            {{custBtn.name | translate}}
           </button>
         </span>
-      </div>
-      <ng-template #defaultMultiActions>
-        <button mat-button (click)="doMultiDelete(this.selected);">
-        </button>
-      </ng-template>
-    </div>
-  </div>
+        <!--</div>-->
+        </ng-container>
+    </div><!-- end of mat-toolbar -->
+  
 
-  <div>
+  </div>
+  <!-- END OF CONTROLS SECTION -->
+  
+  
+  
+  <div  fxLayout="row wrap" fxLayoutAlign="start center" class="multiActionsButton fn-toolbar" [ngClass]="{'icons-only': multiActionsIconsOnly}" *ngIf="conf && selected.length > 0" [style.display]="selected.length > 0 ? 'block' : 'none'" >
+      <div>
+        <div class="multiactions-title" *ngIf="conf.multiActions.length > 0 && !multiActionsIconsOnly">
+          <strong>Batch Operations</strong> 
+        </div>
+        <!-- -->
+        <div *ngIf="conf.multiActions && conf.multiActions.length > 0">
+          <span *ngFor="let maction of conf.multiActions">
+            <!-- DEFAULT -->
+            <ng-container *ngIf="!multiActionsIconsOnly">
+              <button id="{{ maction?.id }}" 
+                mat-button 
+                *ngIf="maction.enable" (click)="maction.onClick(this.selected);">
+                <mat-icon>{{ maction?.icon }}</mat-icon><br><span>{{maction?.label | translate}}</span>
+                </button>
+            </ng-container>
+
+            <!-- ICONS ONLY -->
+            <ng-container *ngIf="multiActionsIconsOnly">
+              <button id="{{ maction?.id }}" 
+                mat-button matTooltip="{{ maction?.label  | translate }}" [matTooltipPosition]=maction?.ttpos 
+                *ngIf="maction.enable" (click)="maction.onClick(this.selected);">
+                <mat-icon>{{ maction?.icon }}</mat-icon>
+                </button>
+            </ng-container>
+
+          </span>
+        </div>
+
+        <div *ngIf="!conf.multiActions || conf.multiActions.length == 0">
+          <span>
+            <!-- With Labels -->
+            <ng-container>
+              <button mat-button (click)="doMultiDelete(this.selected);">
+                <mat-icon>delete</mat-icon><br><span>DELETE</span>
+              </button>
+            </ng-container>
+            
+            <!-- Without Labels -->
+            <ng-container>
+              <button (click)="doMultiDelete(this.selected);"
+                mat-button matTooltip="{{ 'Delete selections'  | translate }}" 
+                matTooltipPosition="below" >
+                  <mat-icon>delete</mat-icon>
+              </button>
+            </ng-container>
+          </span>
+        </div>
+
+      </div>
+    </div>
+
+  <!-- DATATABLE START -->
+  <div class="no-padding">
     <ngx-datatable *ngIf="showDefaults" class='material' 
       [rows]='currentRows' 
       [columns]="conf.columns" 

--- a/src/app/pages/common/entity/entity-table/entity-table.component.scss
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.scss
@@ -35,7 +35,7 @@
  #select-all-checkbox-and-label {
      max-width: 100px;
      font-weight: 700;
-     margin-left: 4px;
+     margin-left: 2px;
  }
  
 #footer {
@@ -59,6 +59,10 @@
     display: inline-block;
 }
 
+#filter{
+  margin-right:16px;
+}
+
 #filter, .mat-toolbar {
     display: inline-block;
 }
@@ -67,23 +71,35 @@
     font-size: 14px;
 }
 
-#filter {
-    position: absolute;
-    right: 150px;
-    top: 9px;
-    z-index: 10;
+#filter .mat-icon{
+  position:absolute;
+  top:24px;
 }
+
+#filter .mat-input-container{
+  padding-left:32px;
+}
+
+//#filter {
+//    position: absolute;
+//    right: 150px;
+//    top: 9px;
+//    z-index: 10;
+//}
 
 #action-button-wrapper {
     height: 36px;
 }
 
 .legacy-warning {
-    position: absolute;
-    font-size: .8rem;
-    top: 75px;
-    right: 10px;
-    z-index: 10;
+  font-weight:500;
+  margin:0 24px;
+  color:var(--fg2);
+//    position: absolute;
+//    font-size: .8rem;
+//    top: 75px;
+//    right: 10px;
+//    z-index: 10;
 }
 
 .legacy-warning-link {

--- a/src/app/pages/common/entity/entity-table/entity-table.component.ts
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, ElementRef, ViewEncapsulation, ViewChild, AfterViewInit } from '@angular/core';
+import { Component, OnInit,OnDestroy, Input, ElementRef, ViewEncapsulation, ViewChild, AfterViewInit} from '@angular/core';
 import { Router } from '@angular/router';
 import { DataSource } from '@angular/cdk/collections';
 import { MatPaginator, MatSort, PageEvent, MatSnackBar } from '@angular/material';
@@ -20,6 +20,8 @@ import { DialogService } from '../../../../services';
 import { ErdService } from '../../../../services/erd.service';
 import { StorageService } from '../../../../services/storage.service'
 import { Subscription } from 'rxjs/Subscription';
+import { CoreService, CoreEvent } from 'app/core/services/core.service';
+import { ViewControllerComponent } from 'app/core/components/viewcontroller/viewcontroller.component';
 
 
 
@@ -36,6 +38,7 @@ export interface InputTableConf {
   isActionVisible?: any;
   custActions?: any[];
   multiActions?:any[];
+  multiActionsIconsOnly?:boolean;
   config?: any;
   confirmDeleteDialog?: Object;
   checkbox_confirm?: any;
@@ -71,7 +74,7 @@ export interface TableConfig {
   styleUrls: ['./entity-table.component.scss'],
   providers: [DialogService, StorageService]
 })
-export class EntityTableComponent implements OnInit, AfterViewInit {
+export class EntityTableComponent /*extends ViewControllerComponent*/ implements OnInit, AfterViewInit, OnDestroy {
 
   @Input() title = '';
   @Input() legacyWarning = '';
@@ -79,6 +82,7 @@ export class EntityTableComponent implements OnInit, AfterViewInit {
   @Input('conf') conf: InputTableConf;
 
   @ViewChild('filter') filter: ElementRef;
+  @ViewChild('defaultMultiActions') defaultMultiActions: ElementRef;
 
   // MdPaginator Inputs
   public paginationPageSize: number = 8;
@@ -111,17 +115,33 @@ export class EntityTableComponent implements OnInit, AfterViewInit {
   public showDefaults: boolean = false;
   public showSpinner: boolean = false;
   public showActions: boolean = true;
+  private _multiActionsIconsOnly: boolean = false;
+  get multiActionsIconsOnly(){
+    return this._multiActionsIconsOnly;
+  }
+  set multiActionsIconsOnly(value:boolean){
+    this._multiActionsIconsOnly = value;
+  }
 
   protected loaderOpen = false;
   public selected = [];
 
-  constructor(protected rest: RestService, protected router: Router, protected ws: WebSocketService,
+  constructor(protected core: CoreService, protected rest: RestService, protected router: Router, protected ws: WebSocketService,
     protected _eRef: ElementRef, protected dialogService: DialogService, protected loader: AppLoaderService, 
     protected erdService: ErdService, protected translate: TranslateService, protected snackBar: MatSnackBar,
-    public sorter: StorageService) { }
+    public sorter: StorageService) { 
+      //super();
+      this.core.register({observerClass:this, eventName:"UserPreferencesChanged"}).subscribe((evt:CoreEvent) => {
+        this.multiActionsIconsOnly = evt.data.preferIconsOnly;
+      });
+      this.core.emit({name:"UserPreferencesRequest"});
+    }
 
-  ngOnInit() {
+    ngOnDestroy(){
+      this.core.unregister({observerClass:this});
+    }
 
+  ngOnInit(): void {
     this.setTableHeight(); 
   
     if (this.conf.preInit) {
@@ -152,10 +172,33 @@ export class EntityTableComponent implements OnInit, AfterViewInit {
       this.hideTopActions = this.conf.hideTopActions;
     }
 
+
+      // Delay spinner 500ms so it won't show up on a fast-loading page
+      setTimeout(() => { this.setShowSpinner(); }, 500);
+
+      // Next section sets the checked/displayed columns
+      if (this.conf.columns && this.conf.columns.length > 10) {
+        this.conf.columns = [];
+
+        for (let item of this.allColumns) {
+          if (!item.hidden) {
+            this.conf.columns.push(item);
+            this.presetDisplayedCols.push(item);
+          }
+        }
+
+        this.currentPreferredCols = this.conf.columns;
+      }
+        // End of checked/display section ------------                 
+        
+    this.erdService.attachResizeEventToElement("entity-table-component");
+  }
+
+  ngAfterViewInit() {
     Observable.fromEvent(this.filter.nativeElement, 'keyup')
       .debounceTime(150)
       .distinctUntilChanged()
-      .subscribe(() => {
+      .subscribe((evt) => {
         const filterValue: string = this.filter.nativeElement.value;
         let newData: any[] = [];
 
@@ -183,24 +226,6 @@ export class EntityTableComponent implements OnInit, AfterViewInit {
         this.paginationPageIndex  = 0;
         this.setPaginationInfo();
       });
-
-      // Delay spinner 500ms so it won't show up on a fast-loading page
-      setTimeout(() => { this.setShowSpinner(); }, 500);
-
-      // Next section sets the checked/displayed columns
-      if (this.conf.columns && this.conf.columns.length > 10) {
-        this.conf.columns = [];
-
-        for (let item of this.allColumns) {
-          if (!item.hidden) {
-            this.conf.columns.push(item);
-            this.presetDisplayedCols.push(item);
-          }
-        }
-
-        this.currentPreferredCols = this.conf.columns;
-      }
-        // End of checked/display section ------------                 
   }
 
   setTableHeight() {
@@ -229,12 +254,6 @@ export class EntityTableComponent implements OnInit, AfterViewInit {
 
   setShowSpinner() {
     this.showSpinner = true;
-  }
-
-  ngAfterViewInit(): void {
-
-    this.erdService.attachResizeEventToElement("entity-table-component");
-
   }
 
   getData() {
@@ -670,4 +689,8 @@ export class EntityTableComponent implements OnInit, AfterViewInit {
   }
 
   // End checkbox section -----------------------
+  
+  toggleLabels(){
+    this.multiActionsIconsOnly = !this.multiActionsIconsOnly;
+  }
 }

--- a/src/app/pages/preferences/page/forms/general-preferences-form.component.ts
+++ b/src/app/pages/preferences/page/forms/general-preferences-form.component.ts
@@ -39,15 +39,16 @@ export class GeneralPreferencesFormComponent implements OnInit, OnChanges, OnDes
   private favoriteFields: any[] = []
   public fieldConfig:FieldConfig[] = [];
   public showTooltips:boolean = this.prefs.preferences.showTooltips;
-  public allowPwToggle:boolean = this.prefs.preferences.allowPwToggle;;
+  public allowPwToggle:boolean = this.prefs.preferences.allowPwToggle;
   public enableWarning:boolean = this.prefs.preferences.enableWarning;
+  public preferIconsOnly: boolean = this.prefs.preferences.preferIconsOnly;
   public fieldSetDisplay:string = 'no-margins';//default | carousel | stepper
     public fieldSets: FieldSet[] = [
       {
         name:'General Preferences',
         class:'preferences',
         label:true,
-        width:'300px',
+        width:'400px',
         config:[
           {
             type: 'select',
@@ -59,15 +60,15 @@ export class GeneralPreferencesFormComponent implements OnInit, OnChanges, OnDes
             tooltip:'Choose a preferred theme.',
             class:'inline'
           },
-          /*{
-            type: 'radio',
-            name: 'metaphor',
+          {
+            type: 'checkbox',
+            name: 'preferIconsOnly',
             width:'300px',
-            placeholder: 'View Type Preference',
-            options:[{label:'Cards',value:'cards'},{label:'Tables',value:'tables'},{label:'Auto',value:'auto'}],
-            value:'cards',
-            tooltip: 'Choose the preferred view type.',
-          },*/
+            placeholder: 'Prefer buttons with icons only',
+            value:this.preferIconsOnly,
+            tooltip: 'To save space, prefer buttons with icons and tooltips instead of labels',
+            class:'inline'
+          },
           {
             type: 'checkbox',
             name: 'showTooltips',
@@ -89,7 +90,7 @@ export class GeneralPreferencesFormComponent implements OnInit, OnChanges, OnDes
           {
             type: 'checkbox',
             name: 'enableWarning',
-            width: '300px',
+            width: '400px',
             placeholder: 'Enable "Save Configuration" Dialog Before Upgrade',
             value:this.enableWarning,
             tooltip: T('Show or hide a dialog to save the system\

--- a/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
@@ -15,6 +15,7 @@ import * as _ from 'lodash';
 import { MatSnackBar } from '@angular/material';
 import * as moment from 'moment';
 import {TreeNode} from 'primeng/api';
+import { CoreService } from 'app/core/services/core.service';
 
 import { Injectable } from '@angular/core';
 import { ErdService } from 'app/services/erd.service';
@@ -765,11 +766,11 @@ export class VolumesListComponent extends EntityTableComponent implements OnInit
   public paintMe = true;
 
 
-  constructor(protected rest: RestService, protected router: Router, protected ws: WebSocketService,
+  constructor(protected core:CoreService, protected rest: RestService, protected router: Router, protected ws: WebSocketService,
     protected _eRef: ElementRef, protected dialogService: DialogService, protected loader: AppLoaderService,
     protected mdDialog: MatDialog, protected erdService: ErdService, protected translate: TranslateService,
     public sorter: StorageService, protected snackBar: MatSnackBar) {
-    super(rest, router, ws, _eRef, dialogService, loader, erdService, translate, snackBar, sorter);
+    super(core, rest, router, ws, _eRef, dialogService, loader, erdService, translate, snackBar, sorter);
   }
 
   public repaintMe() {

--- a/src/app/views/sessions/signin/signin.component.css
+++ b/src/app/views/sessions/signin/signin.component.css
@@ -37,14 +37,16 @@ div.fake-icon{
 
 #legacy-btn-wrapper{
   text-align:center;
+  margin:0px 32px 0;
 }
 
 #legacy-btn-wrapper button.mat-button{
   font-weight:normal !important;
   opacity:0.75;
+  background: rgba(0,0,0,0.4);
 }
 
-form{
+form {
   margin:32px 32px 0;
 }
 

--- a/src/app/views/sessions/signin/signin.component.html
+++ b/src/app/views/sessions/signin/signin.component.html
@@ -59,7 +59,7 @@
             </form>
           </ng-template>
           <div id="legacy-btn-wrapper">
-            <button mat-button color="default" class="mb-1" style="text-transform:capitalize !important;" (click)="onGoToLegacy()">{{"Legacy Web Interface" | translate}}</button>
+            <button mat-button color="default" class="mb-1 full-width" style="text-transform:capitalize !important;" (click)="onGoToLegacy()">{{"LEGACY WEB INTERFACE" | translate}}</button>
           </div>
           <div>
             <span fxFlex class="copyright-txt">

--- a/src/assets/styles/reset.css
+++ b/src/assets/styles/reset.css
@@ -1,0 +1,48 @@
+/* http://meyerweb.com/eric/tools/css/reset/ 
+   v2.0 | 20110126
+   License: none (public domain)
+*/
+
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed, 
+figure, figcaption, footer, header, hgroup, 
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure, 
+footer, header, hgroup, menu, nav, section {
+	display: block;
+}
+body {
+	line-height: 1;
+}
+ol, ul {
+	list-style: none;
+}
+blockquote, q {
+	quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
+}
+table {
+	border-collapse: collapse;
+	border-spacing: 0;
+}


### PR DESCRIPTION
Redid entity-tables templates. Added preference for buttons with icons only and fixed slight layout issue in the preferences form (tooltip icons was wrapping to new line). Fixed CSS bug by adding css reset file that is imported before any app css. The default browser stylesheet was causing enormous margins.