### PR TITLE
Storage/Pools encryption icon element is clickable again

### DIFF
--- a/src/app/pages/storage/volumes/volumes-list/volumes-list.component.css
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list.component.css
@@ -28,6 +28,8 @@
     float: right; 
     padding-bottom: 20px;
     padding-top: 4px;
+    position:relative;
+    z-index:50;
 }
 
 .unlock_button {


### PR DESCRIPTION
Storage/Pools encryption icon element was being rendered behind the entity-tree-table, keeping it from reacting user click events. Adding position relative and higher z-index made it clickable again