### PR TITLE
Found a problem where legend analytics would cause endless loop if no data

### DIFF
--- a/src/app/components/common/lineChart/lineChart.component.ts
+++ b/src/app/components/common/lineChart/lineChart.component.ts
@@ -307,17 +307,17 @@ export class LineChartComponent implements OnInit, AfterViewInit, OnDestroy, Han
       let label = colStrings[0];
       let col = colStrings.map(x => Number(x));
       col.shift(col[0]);
-  
-      let total = col.reduce((accumulator, currentValue) => Number(accumulator) + Number(currentValue));
-      let avg = Number((total / col.length).toFixed(2));
+      
+      let total = col.length > 0 ? col.reduce((accumulator, currentValue) => Number(accumulator) + Number(currentValue)) : "N/A";
+      let avg = total !== "N/A" ? Number((total / col.length).toFixed(2)) : total;
       //console.log("Total type: " + typeof col.length)
       let myResult:Analytics = {
         label:label,
-        min: this.getMin(col),//.toFixed(2),
-        max: this.getMax(col),//.toFixed(2),
+        min: total !== "N/A" ? this.getMin(col) : total ,//.toFixed(2),
+        max: total !== "N/A" ? this.getMax(col) : total,//.toFixed(2),
         avg: avg,
-        last: Number(col[col.length - 1].toFixed(2)),
-        total:Number(total.toFixed(2))
+        last: total !== "N/A" ? Number(col[col.length - 1].toFixed(2)) : total,
+        total: total !== "N/A" ? Number(total.toFixed(2)) : total
       }
       allColumns.push(myResult);
     }

--- a/src/app/pages/reportsdashboard/components/report/report.component.html
+++ b/src/app/pages/reportsdashboard/components/report/report.component.html
@@ -83,10 +83,10 @@
 
                   <!-- Analytics -->
                   <div fxFlex class="report-analytics" *ngIf="lineChart.legendAnalytics | async as analytics" fxLayout="row" fxLayoutAlign="space-between start" fxLayoutGap="16px">
-                    <span fxFlex="105px"><strong>Min:</strong>  {{analytics[i].min}}{{lineChart.units}}</span>
-                    <span fxFlex="105px"><strong>Max:</strong>  {{analytics[i].max}}{{lineChart.units}}</span>
-                    <span fxFlex="105px"><strong>Avg:</strong>  {{analytics[i].avg}}{{lineChart.units}}</span>
-                    <span fxFlex=""><strong>Total:</strong>  {{analytics[i].total}}{{lineChart.units}}</span>
+                    <span fxFlex="105px"><strong>Min:</strong>  {{analytics[i].min}}<span *ngIf="analytics[i].min !== 'N/A'">{{lineChart.units}}</span></span>
+                      <span fxFlex="105px"><strong>Max:</strong>  {{analytics[i].max}}<span *ngIf="analytics[i].max !== 'N/A'">{{lineChart.units}}</span></span>
+                        <span fxFlex="105px"><strong>Avg:</strong>  {{analytics[i].avg}}<span *ngIf="analytics[i].avg !== 'N/A'">{{lineChart.units}}</span></span>
+                          <span fxFlex=""><strong>Total:</strong>  {{analytics[i].total}}<span *ngIf="analytics[i].total !== 'N/A'">{{lineChart.units}}</span></span>
                   </div>
 
               </div>


### PR DESCRIPTION
Reports analytics elements (min,max,avg,total) in elements gracefully degrade when no data is available. Hard to test but I happened to find it when trying to display disk io-time