### PR TITLE
Add overflow to content div on confirm dialog

### DIFF
--- a/src/app/pages/common/confirm-dialog/confirm-dialog.component.css
+++ b/src/app/pages/common/confirm-dialog/confirm-dialog.component.css
@@ -22,4 +22,5 @@ h1 {
 
 div.message-content {
     max-height: 300px;
+    overflow: auto;
 }


### PR DESCRIPTION
#62790 - Overflow shows up only when twelve or more lines get pushed to the content div on confirm dialog. Otherwise, seems not to bother all our regular confirm dialogs.
![screenshot from 2018-12-18 11-44-05](https://user-images.githubusercontent.com/9504493/50168884-6d27ac80-02ba-11e9-9295-761a6c961ec6.png)
