### PR TITLE
63636 update page for 11.2 stable

### DIFF
--- a/ports/freenas/freenas-webui/Makefile
+++ b/ports/freenas/freenas-webui/Makefile
@@ -14,7 +14,8 @@ EXTRACT_ONLY=
 
 FETCH_DEPENDS=	npm:freenas/npm5 \
 		git>0:devel/git \
-		python2>0:lang/python2
+		python2>0:lang/python2 \
+		gmake:devel/gmake
 BUILD_DEPENDS=	rsync>0:net/rsync \
 		npm:freenas/npm5 \
 		python2>0:lang/python2

--- a/src/app/pages/system/update/update.component.ts
+++ b/src/app/pages/system/update/update.component.ts
@@ -198,17 +198,20 @@ export class UpdateComponent implements OnInit {
         });
       }
     });
+
     this.busy = this.rest.get('system/update', {}).subscribe((res) => {
       this.autoCheck = res.data.upd_autocheck;
-      if (this.autoCheck){
-        this.check();
-      }
     });
+
     this.busy2 = this.ws.call('update.get_trains').subscribe((res) => {
       this.fullTrainList = res.trains;
       // On page load, make sure we are working with train of the current OS
       this.train = res.current;
       this.selectedTrain = res.current;
+
+      if (this.autoCheck){
+        this.check();
+      }
 
       this.trains = [];
       for (const i in res.trains) {

--- a/src/app/pages/system/update/update.component.ts
+++ b/src/app/pages/system/update/update.component.ts
@@ -45,6 +45,7 @@ export class UpdateComponent implements OnInit {
   public nightly_train: boolean;
   public updates_available = false;
   public currentTrainDescription: string;
+  public trainDescriptionOnPageLoad: string;
   public fullTrainList: any[];
 
   public busy: Subscription;
@@ -85,6 +86,7 @@ export class UpdateComponent implements OnInit {
     protected rest: RestService, protected ws: WebSocketService, protected dialog: MatDialog,
     protected loader: AppLoaderService, protected dialogService: DialogService, public translate: TranslateService) {
   }
+
   parseTrainName(name) {
     const version = []
     let sw_version = "";
@@ -107,7 +109,6 @@ export class UpdateComponent implements OnInit {
       version.push(sw_version);
       version.push(branch);
     }
-
     return version;
   }
 
@@ -122,8 +123,6 @@ export class UpdateComponent implements OnInit {
         const version2 = v2[0].split('.');
         const branch1 = v1[1].toLowerCase();
         const branch2 = v2[1].toLowerCase();
-
-
 
         if(branch1 !== branch2) {
 
@@ -207,12 +206,17 @@ export class UpdateComponent implements OnInit {
     });
     this.busy2 = this.ws.call('update.get_trains').subscribe((res) => {
       this.fullTrainList = res.trains;
-      this.train = res.selected;
-      this.selectedTrain = res.selected;
+      // On page load, make sure we are working with train of the current OS
+      this.train = res.current;
+      this.selectedTrain = res.current;
 
       this.trains = [];
       for (const i in res.trains) {
-        if (this.compareTrains(this.train, i) === 'ALLOWED' || this.compareTrains(this.train, i) === 'NIGHTLY_UPGRADE' || this.train === i) {
+        if (this.compareTrains(this.train, i) === 'ALLOWED' || 
+        this.compareTrains(this.train, i) === 'NIGHTLY_UPGRADE' || 
+        this.compareTrains(this.train, i) === 'MINOR_UPGRADE' || 
+        this.compareTrains(this.train, i) === 'MAJOR_UPGRADE' || 
+        this.train === i) {
           this.trains.push({ name: i, description: res.trains[i].description });
         }
 
@@ -230,10 +234,18 @@ export class UpdateComponent implements OnInit {
       } else {
         this.currentTrainDescription = res.trains[this.selectedTrain].description.toLowerCase();
       }
+      // To remember train descrip if user switches away and then switches back
+      this.trainDescriptionOnPageLoad = this.currentTrainDescription;
     });
   }
 
   onTrainChanged(event){
+    // For the case when the user switches away, then BACK to the train of the current OS
+    if (event.value === this.selectedTrain) {
+      this.currentTrainDescription = this.trainDescriptionOnPageLoad;
+      this.check();
+      return;
+    }
     const compare = this.compareTrains(this.selectedTrain, event.value);
     if(compare === "NIGHTLY_DOWNGRADE" || compare === "MINOR_DOWNGRADE" || compare === "MAJOR_DOWNGRADE" || compare ==="SDK") {
       this.dialogService.Info("Error", this.train_msg[compare]).subscribe((res)=>{
@@ -250,7 +262,7 @@ export class UpdateComponent implements OnInit {
             this.currentTrainDescription = this.fullTrainList[this.train].description.toLowerCase();
           }
         })
-    } else if (compare === "ALLOWED") {
+    } else if (compare === "ALLOWED" || compare === "MINOR_UPGRADE" || compare === "MAJOR_UPGRADE") {
       this.dialogService.confirm(T("Switch Train"), T("Switch update trains?")).subscribe((train_res)=>{
         if(train_res){
           this.train = event.value;
@@ -472,6 +484,10 @@ export class UpdateComponent implements OnInit {
 }
 
   check() {
+    // Reset the template
+    this.updates_available = false; 
+    this.releaseNotes = '';
+
     this.showSpinner = true;
     this.pendingupdates();
     this.error = null;


### PR DESCRIPTION
Sets the train of current OS as default, to fix issue where config file from older version causes wrong train options to load

Adds ‘MINOR_UPGRADE’ and ‘MAJOR_UPGRADE’ to the legit upgrade list, which seems consistent with 11.1

Fixes it so if user switches to another train, but then switches back before actually updating, the display resets and then reloads properly

Moves the first check for updates to later in ngOnInit, AFTER the value of this.trains is set; otherwise, the update check runs on a default value which can be wrong, at least when you have loaded a config file from an older version.