### PR TITLE
61641 alignment issues on pools tree for 11.2 stable

### DIFF
--- a/src/app/pages/common/entity/entity-tree-table/entity-tree-table.component.html
+++ b/src/app/pages/common/entity/entity-tree-table/entity-tree-table.component.html
@@ -1,4 +1,4 @@
-<p-treeTable [value]="conf.tableData" [columns]="conf.columns" [resizableColumns]="true">
+<p-treeTable [value]="conf.tableData" [columns]="conf.columns" [resizableColumns]="true" [autoLayout]="true">
 	<ng-template pTemplate="header" let-columns>
 		<tr>
 			<th *ngFor="let col of columns" [ttSortableColumn]="col.prop" id="theader_{{col.prop}}" ttResizableColumn>

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -1205,4 +1205,14 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     background-color:rgba(123,123,123,0.2);
   }
 
+  .ui-treetable-resizable .ui-treetable-tfoot>tr>td, .ui-treetable-resizable .ui-treetable-tbody>tr>td {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  .ui-treetable-thead {
+    text-align: left;
+  }
+
 } // end of ix theme

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -1206,9 +1206,7 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
   }
 
   .ui-treetable-resizable .ui-treetable-tfoot>tr>td, .ui-treetable-resizable .ui-treetable-tbody>tr>td {
-    overflow: hidden;
     white-space: nowrap;
-    text-overflow: ellipsis;
   }
 
   .ui-treetable-thead {

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -1201,16 +1201,24 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     @include variable(color, --fg2, $fg2 !important);
   }
 
-  .ui-treetable tr:nth-child(even){
+ .ui-treetable tr:nth-child(even){
     background-color:rgba(123,123,123,0.2);
-  }
-
-  .ui-treetable-resizable .ui-treetable-tfoot>tr>td, .ui-treetable-resizable .ui-treetable-tbody>tr>td {
-    white-space: nowrap;
   }
 
   .ui-treetable-thead {
     text-align: left;
+  }
+
+  app-volumes-list .ui-treetable-resizable .ui-treetable-tfoot>tr>td, .ui-treetable-resizable .ui-treetable-tbody>tr>td {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    max-width: 300px;
+  }
+
+  app-volumes-list td[id^="tbody__comments_"] {
+    white-space: normal !important;
+    text-overflow: unset;
+    min-width: 200px;
   }
 
 } // end of ix theme

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -1201,4 +1201,8 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     @include variable(color, --fg2, $fg2 !important);
   }
 
+  .ui-treetable tr:nth-child(even){
+    background-color:rgba(123,123,123,0.2);
+  }
+
 } // end of ix theme


### PR DESCRIPTION
Ticket #61641
Fixes alignment issues on pools data-tree - keeps name col from text-wrapping, but allows comments to wrap. Hopefully the best set of compromises
![screenshot from 2019-01-03 11-12-05](https://user-images.githubusercontent.com/9504493/50648426-30f67c00-0f49-11e9-912c-34fa1726ee78.png)
![screenshot from 2019-01-03 11-12-21](https://user-images.githubusercontent.com/9504493/50648432-32c03f80-0f49-11e9-8d96-b32b45797e43.png)

