### PR TITLE
61641 align pool data tree

### DIFF
--- a/src/app/pages/common/entity/entity-tree-table/entity-tree-table.component.html
+++ b/src/app/pages/common/entity/entity-tree-table/entity-tree-table.component.html
@@ -1,4 +1,4 @@
-<p-treeTable [value]="conf.tableData" [columns]="conf.columns" [resizableColumns]="true">
+<p-treeTable [value]="conf.tableData" [columns]="conf.columns" [resizableColumns]="true" [autoLayout]="true">
 	<ng-template pTemplate="header" let-columns>
 		<tr>
 			<th *ngFor="let col of columns" [ttSortableColumn]="col.prop" id="theader_{{col.prop}}" ttResizableColumn>

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -1062,4 +1062,16 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     @include variable(color, --fg2, $fg2 !important);
   }
 
+  .ui-treetable tr:nth-child(even){
+    background-color:rgba(123,123,123,0.2);
+  }
+
+  .ui-treetable-resizable .ui-treetable-tfoot>tr>td, .ui-treetable-resizable .ui-treetable-tbody>tr>td {
+    white-space: nowrap;
+  }
+
+  .ui-treetable-thead {
+    text-align: left;
+  }
+
 } // end of ix theme

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -1066,12 +1066,21 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     background-color:rgba(123,123,123,0.2);
   }
 
-  .ui-treetable-resizable .ui-treetable-tfoot>tr>td, .ui-treetable-resizable .ui-treetable-tbody>tr>td {
-    white-space: nowrap;
-  }
-
   .ui-treetable-thead {
     text-align: left;
+    vertical-align: top;
+  }
+
+  app-volumes-list .ui-treetable-resizable .ui-treetable-tfoot>tr>td, .ui-treetable-resizable .ui-treetable-tbody>tr>td {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    max-width: 300px;
+  }
+
+  app-volumes-list td[id^="tbody__comments_"] {
+    white-space: normal !important;
+    text-overflow: unset;
+    min-width: 200px;
   }
 
 } // end of ix theme


### PR DESCRIPTION
Ticket #61641
Fixes alignment issues on pools data-tree - keeps name col from text-wrapping, but allows comments to wrap. Hopefully the best set of compromises
![screenshot from 2019-01-03 11-12-05](https://user-images.githubusercontent.com/9504493/50650149-a8c6a580-0f4d-11e9-8ff7-a47c2c876ecb.png)
![screenshot from 2019-01-03 11-12-21](https://user-images.githubusercontent.com/9504493/50650151-aa906900-0f4d-11e9-8569-2116cb478db6.png)


