### PR TITLE
position and size tooltips to stay within margins

### DIFF
--- a/src/app/pages/common/entity/entity-form/components/tooltip/tooltip.component.ts
+++ b/src/app/pages/common/entity/entity-form/components/tooltip/tooltip.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input, ViewChild, ElementRef } from '@angular/core';
-import { TooltipPosition } from '@angular/material';
 import { TranslateService } from '@ngx-translate/core';
 
 @Component({
@@ -24,8 +23,8 @@ export class TooltipComponent {
     let screenH = document.body.clientHeight;
     let posX = this.tooltip.nativeElement.getBoundingClientRect().left;
     let posY = this.tooltip.nativeElement.getBoundingClientRect().bottom;
-    let dynamicWidth = this.message.length * 9.5;
-
+    let dynamicWidth = this.message.length * 8.5;
+    
     if((posY / screenH > .85)) {
       this.tooltip.nativeElement.lastElementChild.id = "raised-tooltip";
     } else {
@@ -33,28 +32,23 @@ export class TooltipComponent {
     }
 
     if(this.message.length <= 40) {
-      if((screenW - posX) > 420) {
+      if((posX/screenW) <= .6) {
         this.tooltipMsgStyle = {'left' : '0px', 'max-width' : dynamicWidth + 'px'};
       }
-      else if(posX > 420) {
+      else {
         this.tooltipMsgStyle = {'right' : '8px', 'max-width' :  dynamicWidth + 'px'};
       }
-      else {
-        let diffX = 'calc( -45vw - ' + (posX - screenW/2) + 'px )';
-        this.tooltipMsgStyle = {'left' : diffX, 'max-width' : dynamicWidth + 'px'};
-      }    
     }
     else {
-      if((screenW - posX) > 420) {
+      if((posX/screenW) <= .52) {
         this.tooltipMsgStyle = {'left' : '0px'};
       }
-      else if(posX > 420) {
-        this.tooltipMsgStyle = {'right' : '8px'};
+      else if((posX/screenW) <= .63) {
+        this.tooltipMsgStyle = {'left' : '0px', 'max-width' : '270px'};
       }
       else {
-        let diffX = 'calc( -45vw - ' + (posX - screenW/2) + 'px )';
-        this.tooltipMsgStyle = {'left' : diffX};
-      }    
+        this.tooltipMsgStyle = {'right' : '8px'};
+      }
     }
   }
 


### PR DESCRIPTION
Ticket: #62550 and duplicates
Positions tooltips and dynamically resizes some of them to keep all of them within the margins of the card where they originate; to fix a bug where tooltips sometimes get cut off at the margin or padding.
![screenshot from 2019-01-04 11-53-53](https://user-images.githubusercontent.com/9504493/50701726-a67f4c80-101c-11e9-9eaf-2957de298aa2.png)
