### PR TITLE
recolor cursor on cron fields

### DIFF
--- a/src/app/pages/common/entity/entity-form/components/form-scheduler/form-scheduler.component.css
+++ b/src/app/pages/common/entity/entity-form/components/form-scheduler/form-scheduler.component.css
@@ -129,6 +129,10 @@ ul.schedule-list li:nth-child(odd){
   color:var(--red) !important;
 }
 
+.cron-fields .mat-input-element {
+  caret-color: var(--primary-txt) !important; 
+}
+
 /*Button Toggle Group*/
 .cron-fields mat-button-toggle-group{
   margin:16px 0;


### PR DESCRIPTION
Ticket: #68115 - Fixes just the cursor on cron fields; the highlight is okay in 11.2 stable
![screenshot from 2019-01-07 14-14-51](https://user-images.githubusercontent.com/9504493/50789020-0417d100-1289-11e9-9562-9fb07a083d31.png)
