### PR TITLE
59490 for 11.3

### DIFF
--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -412,6 +412,7 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
 .mat-form-field-ripple{
   @include variable(background-color, --primary, $primary);
 }
+
   .mat-color-primary, 
   .mat-button.mat-primary,
   .sidebar-panel.mat-sidenav .sidebar-list-item.open > .mat-list-item-content > a > span, 
@@ -419,6 +420,10 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
   .mat-form-field.mat-focused.mat-primary
   .mat-focused .mat-form-field-label{
     @include variable(color, --primary, $primary, !important);
+  }
+
+  .mat-form-field.mat-form-field-invalid .mat-form-field-label {
+    color: #f44336 !important;
   }
 
   .mat-button.mat-accent {

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -422,7 +422,7 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     @include variable(color, --primary, $primary, !important);
   }
 
-  .mat-form-field.mat-form-field-invalid .mat-form-field-label {
+  .mat-form-field-invalid .mat-form-field-label {
     color: #f44336 !important;
   }
 


### PR DESCRIPTION
Ticket #59490
Makes invalid fields more visible (we were accidentally overwriting the red color on the label)
The material spec for helping the visually impaired is to have the red label and underline, and maybe a warning message ('email is required', etc.) We could consider adding messages, as much for catching the eye as for their content.
![screenshot from 2019-01-08 14-11-24](https://user-images.githubusercontent.com/9504493/50853358-f5482180-134f-11e9-8981-14d9b3e9ef0b.png)
![screenshot from 2019-01-08 09-04-17](https://user-images.githubusercontent.com/9504493/50853395-11e45980-1350-11e9-9225-e32ebef21e73.png)

