### PR TITLE
edit style for more visible error state

### DIFF
--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -469,7 +469,7 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
   .mat-form-field-label,
   .mat-selection-list .mat-list-item,.mat-option,
   .mat-select-arrow, .mat-select-value {
-    @include variable(color, --fg2, $fg2, !important);
+    @include variable(color, --fg2, $fg2);
   }
 
   .mat-menu-panel button{


### PR DESCRIPTION
Ticket #59490
Makes invalid fields more visible (we were accidentally overwriting the red color on the label)
The material spec for helping the visually impaired is to have the red label and underline, and maybe a warning message ('email is required', etc.) We could consider adding messages, as much for catching the eye as for their content.

![screenshot from 2019-01-08 14-11-24](https://user-images.githubusercontent.com/9504493/50853462-4eb05080-1350-11e9-8f22-30ae658be8af.png)


![screenshot from 2019-01-08 09-04-17](https://user-images.githubusercontent.com/9504493/50853455-48ba6f80-1350-11e9-972c-6939d2d53174.png)
