### PR TITLE
css fix for the shell

### DIFF
--- a/src/app/pages/shell/shell.component.css
+++ b/src/app/pages/shell/shell.component.css
@@ -5,4 +5,9 @@
 
 #terminal {
   margin-bottom: 10px;
+  overflow: hidden;
+}
+
+mat-card {
+  min-width: 700px;
 }


### PR DESCRIPTION
Ticket #66981
Keeps text from overflowing the shell
![screenshot from 2019-01-09 10-49-19](https://user-images.githubusercontent.com/9504493/50910721-6513e600-13fc-11e9-8e98-4f0cbdb293e8.png)
