### PR TITLE
Assign min-width to shell, prevent text overflow

### DIFF
--- a/src/app/pages/shell/shell.component.css
+++ b/src/app/pages/shell/shell.component.css
@@ -5,4 +5,9 @@
 
 #terminal {
   margin-bottom: 10px;
+  overflow: hidden;
+}
+
+mat-card {
+  min-width: 700px;
 }


### PR DESCRIPTION
Ticket #66981
Keeps text from overflowing shell
![screenshot from 2019-01-09 10-49-19](https://user-images.githubusercontent.com/9504493/50910834-9d1b2900-13fc-11e9-9178-2656f5ed67b8.png)
