### PR TITLE
modify cert and ca tooltips for private key

### DIFF
--- a/src/app/pages/system/ca/ca-add/ca-add.component.ts
+++ b/src/app/pages/system/ca/ca-add/ca-add.component.ts
@@ -190,7 +190,7 @@ export class CertificateAuthorityAddComponent {
       placeholder : T('Private Key'),
       tooltip : T('Paste the private key associated with the\
                    Certificate when available. Please provide\
-                   a key with size greater than or equal to 1024 bits'),
+                   a key at least 1024 bits long.'),
       isHidden: true,
     },
     {

--- a/src/app/pages/system/ca/ca-add/ca-add.component.ts
+++ b/src/app/pages/system/ca/ca-add/ca-add.component.ts
@@ -189,7 +189,8 @@ export class CertificateAuthorityAddComponent {
       name : 'privatekey',
       placeholder : T('Private Key'),
       tooltip : T('Paste the private key associated with the\
-                   Certificate when available.'),
+                   Certificate when available. Please provide\
+                   a key with size greater than or equal to 1024 bits'),
       isHidden: true,
     },
     {

--- a/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
+++ b/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
@@ -190,7 +190,8 @@ export class CertificateAddComponent {
       name : 'privatekey',
       placeholder : T('Private Key'),
       tooltip : T('Paste the private key associated with the\
-                   Certificate when available.'),
+                   Certificate when available. Please provide\
+                   a key with size greater than or equal to 1024 bits'),
       isHidden: true,
     },
     {

--- a/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
+++ b/src/app/pages/system/certificates/certificate-add/certificate-add.component.ts
@@ -191,7 +191,7 @@ export class CertificateAddComponent {
       placeholder : T('Private Key'),
       tooltip : T('Paste the private key associated with the\
                    Certificate when available. Please provide\
-                   a key with size greater than or equal to 1024 bits'),
+                   a key at least 1024 bits long.'),
       isHidden: true,
     },
     {


### PR DESCRIPTION
Ticket: #66925
Front end is already fixed to work with middleware to display error messages about key strength. This PR proposes only a tooltip modification. However, making a certificate on 11.3 seems to be broken right now awaiting #55986