### PR TITLE
Fixed mat-option hover and focus having same styles (stable)

### DIFF
--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -416,6 +416,7 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     @include variable(color, --fg2, $fg2); 
   }
 
+  .mat-select-panel .mat-option:hover,
   .ngx-datatable .datatable-body .datatable-row-wrapper:nth-child(odd){
     @include variable(background, --alt-bg1, $alt-bg1);
     @include variable(color, --alt-fg1, $alt-fg1);
@@ -434,7 +435,6 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
 
   // System wide hover effects
   .mat-select-panel .mat-option:focus,
-  .mat-select-panel .mat-option:hover,
   .mat-select-panel .mat-option.mat-selected:not(.mat-option-multiple){ 
     @include variable(background, --primary, $primary, !important);
     @include variable(color, --primary-txt, $primary-txt, !important);


### PR DESCRIPTION
Changed mat-option hover style to use --fg2 rules from theme palette