### PR TITLE
Fixed mat-option hover and focus having same styles (master)

### DIFF
--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -357,6 +357,8 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     background-color:rgba(0,0,0,0.1);
     @include variable(color, --fg2, $fg2); 
   }
+
+  .mat-select-panel .mat-option:hover,
   .ngx-datatable .datatable-body .datatable-row-wrapper:nth-child(odd){
     @include variable(background, --alt-bg1, $alt-bg1);
     @include variable(color, --alt-fg1, $alt-fg1);
@@ -514,7 +516,6 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
 
   // System wide hover effects
   .mat-select-panel .mat-option:focus,
-  .mat-select-panel .mat-option:hover,
   .mat-select-panel .mat-option.mat-selected:not(.mat-option-multiple){ 
     @include variable(background, --primary, $primary, !important);
     @include variable(color, --primary-txt, $primary-txt, !important);


### PR DESCRIPTION
Changed mat-option hover style to use --fg2 rules from theme palette 