### PR TITLE
jail-edit on iOS Fix (master)

### DIFF
--- a/src/app/pages/jails/jail-edit/jail-edit.component.html
+++ b/src/app/pages/jails/jail-edit/jail-edit.component.html
@@ -1,6 +1,6 @@
 <mat-card>
   <form (ngSubmit)="onSubmit()" [formGroup]="formGroup">
-    <mat-expansion-panel [expanded]="step === 0" (opened)="setStep(0)">
+    <mat-expansion-panel [expanded]="step === 0 && isReady" (opened)="setStep(0)" #basic>
       <mat-expansion-panel-header>
         <mat-panel-title>
           {{ "Basic Properties" | translate }}
@@ -18,7 +18,7 @@
         <button mat-button color="primary" type="button" (click)="nextStep()">{{ "Next" | translate }}</button>
       </mat-action-row>
     </mat-expansion-panel>
-    <mat-expansion-panel [expanded]="step === 1" (opened)="setStep(1)">
+    <mat-expansion-panel [expanded]="step === 1 && isReady" (opened)="setStep(1)">
       <mat-expansion-panel-header>
         <mat-panel-title>
           {{ "Jail Properties" | translate }}
@@ -33,7 +33,7 @@
         <button mat-button color="primary" type="button" (click)="nextStep()">{{ "Next" | translate }}</button>
       </mat-action-row>
     </mat-expansion-panel>
-    <mat-expansion-panel [expanded]="step === 2" (opened)="setStep(2)">
+    <mat-expansion-panel [expanded]="step === 2 && isReady" (opened)="setStep(2)">
       <mat-expansion-panel-header>
         <mat-panel-title>
           {{ "Network Properties" | translate }}
@@ -48,7 +48,7 @@
         <button mat-button color="primary" type="button" (click)="nextStep()">{{ "Next" | translate }}</button>
       </mat-action-row>
     </mat-expansion-panel>
-    <mat-expansion-panel [expanded]="step === 3" (opened)="setStep(3)">
+    <mat-expansion-panel [expanded]="step === 3 && isReady" (opened)="setStep(3)">
       <mat-expansion-panel-header>
         <mat-panel-title>
           {{ "Custom Properties" | translate }}

--- a/src/app/pages/jails/jail-edit/jail-edit.component.ts
+++ b/src/app/pages/jails/jail-edit/jail-edit.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, AfterViewInit, ViewChild } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 import { Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material';
@@ -24,8 +24,10 @@ import { EntityJobComponent } from '../../common/entity/entity-job/entity-job.co
   styleUrls: ['../../common/entity/entity-form/entity-form.component.scss'],
   providers: [JailService, EntityFormService, FieldRelationService, NetworkService]
 })
-export class JailEditComponent implements OnInit {
+export class JailEditComponent implements OnInit, AfterViewInit {
 
+  @ViewChild('basic') basicPanel:any;
+  public isReady: boolean =  false;
   protected updateCall = 'jail.do_update';
   protected upgradeCall = 'jail.upgrade';
   protected queryCall = 'jail.query';
@@ -1042,6 +1044,14 @@ export class JailEditComponent implements OnInit {
       this.formGroup.controls['ip6_interface'].clearValidators();
       this.formGroup.controls['ip6_interface'].updateValueAndValidity();
     }
+  }
+
+  ngAfterViewInit(){
+    setTimeout(() => {
+      //this.basicPanel.open();
+      this.isReady = true;
+      this.setStep(0);
+    }, 100);
   }
 
   ngOnInit() {


### PR DESCRIPTION
Added isReady property to jail-edit. This variable makes the expansion panels active and is set during AfterViewInit lifecycle hook. This was causing problems in iOS.