### PR TITLE
Fixed trailing zeros charts on front page dashboard (master)

### DIFF
--- a/src/app/services/stats.service.ts
+++ b/src/app/services/stats.service.ts
@@ -357,7 +357,7 @@ export class StatsService {
   }
 
   buildMessage(key,source):CoreEvent{
-    let options = {step:'10',start:'now-10m'}
+    let options = {step: '10', start:'now-10m', end:'now-20s'}
     let dataList = [];
     let src = source.prefix + key;
     let eventName;


### PR DESCRIPTION
Changed how stats service formats the start and end times for API call. Using epoch time previously led to null values and some sort of clock mismatch. Switching to 'now-xxx' syntax and limiting the end param to 20 seconds from present fixes things.

NOTE: requires latest middleware.