### PR TITLE
63483: Add help text to new Cloud Credentials/S3 fields:

### DIFF
--- a/src/app/pages/system/CloudCredentials/cloudcredentials-form/cloudcredentials-form.component.ts
+++ b/src/app/pages/system/CloudCredentials/cloudcredentials-form/cloudcredentials-form.component.ts
@@ -153,7 +153,7 @@ export class CloudCredentialsFormComponent {
       type: 'checkbox',
       name: 'skip_region-S3',
       placeholder: T('Disable Endpoint Region'),
-      tooltip: T('Skips automatic detection of the Endpoint URL\
+      tooltip: T('Skip automatic detection of the Endpoint URL\
                   region. Set this when configuring a custom\
                   Endpoint URL.'),
       isHidden: true,

--- a/src/app/pages/system/CloudCredentials/cloudcredentials-form/cloudcredentials-form.component.ts
+++ b/src/app/pages/system/CloudCredentials/cloudcredentials-form/cloudcredentials-form.component.ts
@@ -152,8 +152,10 @@ export class CloudCredentialsFormComponent {
     {
       type: 'checkbox',
       name: 'skip_region-S3',
-      placeholder: T('Skip Region Autodetect'),
-      // tooltip: T(''),
+      placeholder: T('Disable Endpoint Region'),
+      tooltip: T('Skips automatic detection of the Endpoint URL\
+                  region. Set this when configuring a custom\
+                  Endpoint URL.'),
       isHidden: true,
       relation: [
         {
@@ -168,8 +170,11 @@ export class CloudCredentialsFormComponent {
     {
       type: 'checkbox',
       name: 'signatures_v2-S3',
-      placeholder: T('Use V2 Signatures'),
-      // tooltip: T(''),
+      placeholder: T('Use Signature Version 2'),
+      tooltip: T('Force using <a href="https://docs.aws.amazon.com/general/latest/gr/signature-version-2.html"\
+                  target="_blank">Signature Version 2</a> to sign API\
+                  requests. Set this when configuring a custom\
+                  Endpoint URL.'),
       isHidden: true,
       relation: [
         {


### PR DESCRIPTION
- Rename fields to Disable Enpoint Region and Use Signature Version 2.
- Add simple help text describing function and usage of these fields.
- Local yarn build test: no issues.