### PR TITLE
Add css styling to make <b> and <i> tags in tooltips work again

### DIFF
--- a/src/assets/styles/reset.css
+++ b/src/assets/styles/reset.css
@@ -46,3 +46,11 @@ table {
 	border-collapse: collapse;
 	border-spacing: 0;
 }
+
+em, i {
+    font-style: italic;
+}
+
+strong, b {
+    font-weight:700;
+}


### PR DESCRIPTION
Ticket: #72635
(cherry picked from commit 05ccba54beca4116f15a517cac5b609940b34d10)