### PR TITLE
Make Hard Disks VM labels more concise (11.2-stable).

### DIFF
--- a/src/app/helptext/vm/vm-wizard/vm-wizard.ts
+++ b/src/app/helptext/vm/vm-wizard/vm-wizard.ts
@@ -62,16 +62,16 @@ disk_radio_tooltip: T('Select <i>Create new disk image</i> to create a new\
 disk_radio_options:[{label:T("Create new disk image"), value: true},
 {label:T("Use existing disk image"), value: false}],
 
-volsize_placeholder : T('Define the size (GiB) for the zvol'),
+volsize_placeholder : T('Size (GiB)'),
 volsize_tooltip: T('Allocate a number of gigabytes of space for the\
  new zvol.'),
 volsize_validation: [Validators.required, Validators.min(1)],
 
-pool_detach_warning_paraText: T("Select a zvol"),
+pool_detach_warning_paraText: T("Select zvol"),
 
 datastore_tooltip: T('Choose a pool or dataset for the new zvol.'),
 
-hdd_type_placeholder: T('Select desired type of disk'),
+hdd_type_placeholder: T('Select Disk Type'),
 hdd_type_tooltip: T('Select desired disk type.'),
 hdd_type_options : [
   {label : 'AHCI', value : 'AHCI'},
@@ -79,7 +79,7 @@ hdd_type_options : [
 ],
 hdd_type_value: 'AHCI',
 
-hdd_path_placeholder: T('Select an existing zvol'),
+hdd_path_placeholder: T('Select Existing zvol'),
 hdd_path_tooltip: T('Browse to the desired zvol on the disk.'),
 
 NIC_label: T('Network Interface'),


### PR DESCRIPTION
(cherry picked from commit 4f4e4ba0ea57dec75f0cb686418ce193cf86172e)

As per [Warrens comment](https://github.com/freenas/freenas-docs/pull/616#pullrequestreview-195066552)