### PR TITLE
FIX-75631-stable

### DIFF
--- a/src/app/pages/common/entity/entity-job/entity-job.component.html
+++ b/src/app/pages/common/entity/entity-job/entity-job.component.html
@@ -7,7 +7,7 @@
 			[value]="progressTotalPercent"
 			bufferValue="bufferValue">
     	</mat-progress-bar>
-    	{{ progressTotalPercent | number: '.2'}}%
+    	{{ progressTotalPercent | number: '1.0-0'}}%
     </div>
     <div>
 		<span *ngIf="description" [innerHTML]="description | translate"></span>

--- a/src/app/pages/common/entity/entity-job/entity-job.component.html
+++ b/src/app/pages/common/entity/entity-job/entity-job.component.html
@@ -7,7 +7,7 @@
 			[value]="progressTotalPercent"
 			bufferValue="bufferValue">
     	</mat-progress-bar>
-    	{{ progressTotalPercent | number: '1.0-0'}}%
+    	{{ progressTotalPercent | number: '1.2-2'}}%
     </div>
     <div>
 		<span *ngIf="description" [innerHTML]="description | translate"></span>


### PR DESCRIPTION
Ticket 75631
Display update percentage as integer not float. We apparently don't label file size or download rate on the front end, so this PR doesn't relabel MB to MiB, etc. as suggested in the ticket.