### PR TITLE
FIX-9688

### DIFF
--- a/src/app/components/common/layouts/admin-layout/admin-layout.template.html
+++ b/src/app/components/common/layouts/admin-layout/admin-layout.template.html
@@ -49,6 +49,7 @@
     <app-breadcrumb></app-breadcrumb>
     <div class="rightside-content-hold" [ngClass]="{'has-footer':isShowFooterConsole}">
       <router-outlet></router-outlet>
+      <div class="temp" [style.height.px]="50" *ngIf="isShowFooterConsole"></div>
     </div>
     <div class="footer-console-bar" *ngIf="isShowFooterConsole">
       <pre #footerBarScroll class="message" (click)="onShowConsolePanel()">{{consoleMsg}}</pre>

--- a/src/app/pages/common/entity/entity-job/entity-job.component.html
+++ b/src/app/pages/common/entity/entity-job/entity-job.component.html
@@ -7,7 +7,7 @@
 			[value]="progressTotalPercent"
 			bufferValue="bufferValue">
     	</mat-progress-bar>
-    	{{ progressTotalPercent | number: '1.0-0'}}%
+    	{{ progressTotalPercent | number: '.2'}}%
     </div>
     <div>
 		<span *ngIf="description" [innerHTML]="description | translate"></span>

--- a/src/app/pages/common/entity/entity-job/entity-job.component.html
+++ b/src/app/pages/common/entity/entity-job/entity-job.component.html
@@ -7,7 +7,7 @@
 			[value]="progressTotalPercent"
 			bufferValue="bufferValue">
     	</mat-progress-bar>
-    	{{ progressTotalPercent | number: '.2'}}%
+    	{{ progressTotalPercent | number: '1.0-0'}}%
     </div>
     <div>
 		<span *ngIf="description" [innerHTML]="description | translate"></span>


### PR DESCRIPTION
Ticket 59688
Seems like this was partly fixed already, as the footer console appears at the bottom of the viewport, isn't affected by scrolling; The fix I added was to make room for content at the bottom to scroll up into view when the console is on.
![screenshot from 2019-02-20 11-34-38](https://user-images.githubusercontent.com/9504493/53111735-acb58380-350b-11e9-8832-34ac230efeb4.png)
