### PR TITLE
Fix 59688 stable

### DIFF
--- a/src/app/components/common/layouts/admin-layout/admin-layout.component.css
+++ b/src/app/components/common/layouts/admin-layout/admin-layout.component.css
@@ -9,5 +9,5 @@
 
 /* To get rid of VScroll on entity tables */
 .rightside-content-hold {
-	padding-bottom: 5px;
+	padding-bottom: 50px;
 }

--- a/src/app/components/common/layouts/admin-layout/admin-layout.component.css
+++ b/src/app/components/common/layouts/admin-layout/admin-layout.component.css
@@ -9,5 +9,5 @@
 
 /* To get rid of VScroll on entity tables */
 .rightside-content-hold {
-	padding-bottom: 50px;
+	padding-bottom: 5px;
 }

--- a/src/app/components/common/layouts/admin-layout/admin-layout.template.html
+++ b/src/app/components/common/layouts/admin-layout/admin-layout.template.html
@@ -49,6 +49,7 @@
     <app-breadcrumb></app-breadcrumb>
     <div class="rightside-content-hold" [ngClass]="{'has-footer':isShowFooterConsole}">
       <router-outlet></router-outlet>
+      <div class="temp" [style.height.px]="50" *ngIf="isShowFooterConsole"></div>
     </div>
     <div class="footer-console-bar" *ngIf="isShowFooterConsole">
       <pre #footerBarScroll class="message" (click)="onShowConsolePanel()">{{consoleMsg}}</pre>


### PR DESCRIPTION
Ticket 59688
Seems like this was partly fixed already, as the footer console appears at the bottom of the viewport, isn't affected by scrolling; The fix I added was to make room for content at the bottom to scroll up into view when the console is on.
![screenshot from 2019-02-20 11-34-38](https://user-images.githubusercontent.com/9504493/53112050-67de1c80-350c-11e9-8dc2-0f547f946a11.png)
