### PR TITLE
Dashboard performance improvements

### DIFF
--- a/src/app/core/components/widgets/widgetcputemps/widgetcputemps.component.ts
+++ b/src/app/core/components/widgets/widgetcputemps/widgetcputemps.component.ts
@@ -72,33 +72,10 @@ export class WidgetCpuTempsComponent extends WidgetChartComponent implements Aft
   }
 
   registerObservers(cores){
-    //for(let i = 0; i < cores; i++){
-      //this.core.register({observerClass:this,eventName:"StatsCpuTemp" + i}).subscribe((evt:CoreEvent) => {
       this.core.register({observerClass:this,eventName:"StatsCpuTemp"}).subscribe((evt:CoreEvent) => {
-        this.setChartData(evt);
         this.loader = false;
-        /*let clone = Object.assign({}, evt);
-        clone.data.data = clone.data.data.map( value => value/100);
-        this.setChartData(clone);*/
-
-        //let md = this.mergeData(evt.data.data)
-        //this.collectedMeta = evt.data.meta;
-        /*let valid = true;
-        for(let i = 0; i < evt.data.data.length; i++){
-          if(evt.data.data[i] !== -1 && parseInt(evt.data.data[i]) >= 0){
-            break;
-          } else {
-            valid = false;
-          }
-        }
-        if(!valid){
-          this.invalidData = true;
-          this.loader = false;
-        } else {
-          this.collectData(i, evt.data);
-        }*/
+        this.setChartData(evt);
       });
-    //}
   }
 
 
@@ -235,7 +212,9 @@ export class WidgetCpuTempsComponent extends WidgetChartComponent implements Aft
           data:[]
         }
         for(let i in evt.data.data){
-          chartData.data.push(evt.data.data[i][index]/100);
+          //Convert from deci-kelvin to celsius
+          let converted = (evt.data.data[i][index] / 10) - 273.15; 
+          chartData.data.push(converted);
         }
         parsedData.push(chartData);
       }

--- a/src/app/core/components/widgets/widgetcputemps/widgetcputemps.component.ts
+++ b/src/app/core/components/widgets/widgetcputemps/widgetcputemps.component.ts
@@ -72,9 +72,18 @@ export class WidgetCpuTempsComponent extends WidgetChartComponent implements Aft
   }
 
   registerObservers(cores){
-    for(let i = 0; i < cores; i++){
-      this.core.register({observerClass:this,eventName:"StatsCpuTemp" + i}).subscribe((evt:CoreEvent) => {
-        let valid = true;
+    //for(let i = 0; i < cores; i++){
+      //this.core.register({observerClass:this,eventName:"StatsCpuTemp" + i}).subscribe((evt:CoreEvent) => {
+      this.core.register({observerClass:this,eventName:"StatsCpuTemp"}).subscribe((evt:CoreEvent) => {
+        this.setChartData(evt);
+        this.loader = false;
+        /*let clone = Object.assign({}, evt);
+        clone.data.data = clone.data.data.map( value => value/100);
+        this.setChartData(clone);*/
+
+        //let md = this.mergeData(evt.data.data)
+        //this.collectedMeta = evt.data.meta;
+        /*let valid = true;
         for(let i = 0; i < evt.data.data.length; i++){
           if(evt.data.data[i] !== -1 && parseInt(evt.data.data[i]) >= 0){
             break;
@@ -87,9 +96,9 @@ export class WidgetCpuTempsComponent extends WidgetChartComponent implements Aft
           this.loader = false;
         } else {
           this.collectData(i, evt.data);
-        }
+        }*/
       });
-    }
+    //}
   }
 
 
@@ -118,10 +127,15 @@ export class WidgetCpuTempsComponent extends WidgetChartComponent implements Aft
       }
     }
 
-  mergeData(){
+  mergeData(evtData?){
     let mergedData: any[] = [];
     let legend:any[] = Object.keys(this.collectedTemps);
-    let dataPoints = this.collectedTemps[legend[0]];
+    let dataPoints;
+    if (!evtData){
+      dataPoints = this.collectedTemps[legend[0]];
+    } else {
+      dataPoints = evtData;
+    }
 
     for(let index = 0; index < dataPoints.length; index++){
       let dp = [];
@@ -136,6 +150,7 @@ export class WidgetCpuTempsComponent extends WidgetChartComponent implements Aft
       data: mergedData,
       meta: meta
     }
+    console.log(result);
     return result;
   }
 
@@ -220,7 +235,7 @@ export class WidgetCpuTempsComponent extends WidgetChartComponent implements Aft
           data:[]
         }
         for(let i in evt.data.data){
-          chartData.data.push(evt.data.data[i][index]);
+          chartData.data.push(evt.data.data[i][index]/100);
         }
         parsedData.push(chartData);
       }

--- a/src/app/core/services/api.service.ts
+++ b/src/app/core/services/api.service.ts
@@ -306,7 +306,9 @@ export class ApiService {
       },
       preProcessor(def:ApiCall){
         let redef = Object.assign({}, def);
-        redef.responseEvent = "Stats" + def.args.responseEvent;
+        if(redef.responseEvent !== "AllStats"){
+          redef.responseEvent = "Stats" + def.args.responseEvent;
+        }
         redef.args = def.args.args; 
         return redef;
       },

--- a/src/app/pages/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/dashboard.component.ts
@@ -46,6 +46,7 @@ export class DashboardComponent implements OnInit,OnDestroy {
   }
 
   ngOnDestroy(){
+    this.core.emit({name:"StatsKillAll", sender:this});
     this.core.unregister({observerClass:this});
   }
 

--- a/src/app/services/stats.service.ts
+++ b/src/app/services/stats.service.ts
@@ -200,7 +200,7 @@ export class StatsService {
     }
   ];
 
-  private debug:boolean = false;
+  private debug:boolean = true;
   private messages: any[] = [];
   private messagesRealtime: any[] = [];
   private listeners: any[] = [];
@@ -281,7 +281,6 @@ export class StatsService {
     for(let i = 0; i < this.messages.length; i++){
       this.messages[i] = this.mergeMessages(this.messages[i]);
     }
-    console.log(this.messages);
     this.broadcast(this.messages, this.bufferSize); 
     //this.broadcast(this.messagesRealtime, this.bufferSizeRealtime); 
   }
@@ -395,7 +394,6 @@ export class StatsService {
 
   mergeMessages(messages:CoreEvent[]):CoreEvent[]{
     if(messages.length == 1) return messages;
-    console.log(messages);
     let options = {step: '10', start:'now-10m', end:'now-20s'}
     let argsZero = [];
     let responseEvent = messages[0].data.responseEvent;
@@ -407,7 +405,6 @@ export class StatsService {
     let args = [argsZero, options]
 
     let evt:CoreEvent =  {name: "StatsRequest", data: {args: args, responseEvent: responseEvent} };
-    console.log(evt);
 
     return [evt];
   }

--- a/src/app/services/ws.service.ts
+++ b/src/app/services/ws.service.ts
@@ -144,7 +144,6 @@ export class WebSocketService {
 
   send(payload) {
     if (this.socket.readyState == WebSocket.OPEN) {
-      if(payload.method=="stats.get_data")console.log(payload);
       this.socket.send(JSON.stringify(payload));
     } else {
       this.pendingMessages.push(payload);

--- a/src/app/services/ws.service.ts
+++ b/src/app/services/ws.service.ts
@@ -144,6 +144,7 @@ export class WebSocketService {
 
   send(payload) {
     if (this.socket.readyState == WebSocket.OPEN) {
+      if(payload.method=="stats.get_data")console.log(payload);
       this.socket.send(JSON.stringify(payload));
     } else {
       this.pendingMessages.push(payload);


### PR DESCRIPTION
- Fixes "too many concurrent requests" tracebacks
- Merged cpu temp calls into a single call
- Polling adjusted to happen every 4 seconds (was a minute before due to typo)
- All dashboard widgets now load more quickly and reload more often
- dashboard page  sends StatsKillAll message to ensure stats service stops polling once the user has left the page.