### PR TITLE
Fix 67359 stable

### DIFF
--- a/src/app/pages/system/email/email.component.ts
+++ b/src/app/pages/system/email/email.component.ts
@@ -140,7 +140,7 @@ export class EmailComponent implements OnDestroy {
     },
     {
       type: 'paragraph',
-      name: 'email_form_password_message',
+      name: 'em_pwmessage',
       paraText: T('Matching passwords are REQUIRED to submit the form.'),
     },
     {
@@ -187,11 +187,10 @@ export class EmailComponent implements OnDestroy {
   private em_smtp;
   private em_smtp_subscription;
   private em_user;
-  private em_message;
+  private em_pwmessage;
   private em_pass1;
   private em_pass2;
   
-
   constructor(protected router: Router, protected rest: RestService,
               protected ws: WebSocketService, protected _injector: Injector,
               protected _appRef: ApplicationRef,private dialogservice: DialogService,
@@ -208,21 +207,20 @@ afterInit(entityEdit: any) {
       this.rootEmail = res[0].email;
     });
     this.em_user = _.find(this.fieldConfig, {'name': 'em_user'});
-    this.em_message = _.find(this.fieldConfig, {'name': 'email_form_password_message'});
+    this.em_pwmessage = _.find(this.fieldConfig, {'name': 'em_pwmessage'});
     this.em_pass1 = _.find(this.fieldConfig, {'name': 'em_pass1'});
     this.em_pass2 = _.find(this.fieldConfig, {'name': 'em_pass2'});
 
     this.em_smtp = entityEdit.formGroup.controls['em_smtp'];
     this.em_user.isHidden = !this.em_smtp.value;
-    this.em_pass1.isHidden = !this.em_smtp.value;
-    this.em_message.isHidden = !this.em_smtp.value;
+    this.em_pwmessage.isHidden = !this.em_smtp.value
+    this.em_pass1.isHidden = !this.em_smtp.value;;
     this.em_pass2.isHidden = !this.em_smtp.value;
     this.em_pass2.hideButton = !this.em_smtp.value;
     
-
     this.em_smtp_subscription = this.em_smtp.valueChanges.subscribe((value) => {
       this.em_user.isHidden = !value;
-      this.em_message.isHidden = !value;
+      this.em_pwmessage.isHidden = !value;
       this.em_pass1.isHidden = !value;
       this.em_pass2.isHidden = !value;
       this.em_pass1.hideButton = !value;

--- a/src/app/pages/system/email/email.component.ts
+++ b/src/app/pages/system/email/email.component.ts
@@ -139,6 +139,11 @@ export class EmailComponent implements OnDestroy {
       validation : [ Validators.required ]
     },
     {
+      type: 'paragraph',
+      name: 'email_form_password_message',
+      paraText: T('Matching passwords are REQUIRED to submit the form.'),
+    },
+    {
       type : 'input',
       name : 'em_pass1',
       placeholder : T('Password'),
@@ -182,8 +187,10 @@ export class EmailComponent implements OnDestroy {
   private em_smtp;
   private em_smtp_subscription;
   private em_user;
+  private em_message;
   private em_pass1;
   private em_pass2;
+  
 
   constructor(protected router: Router, protected rest: RestService,
               protected ws: WebSocketService, protected _injector: Injector,
@@ -201,17 +208,21 @@ afterInit(entityEdit: any) {
       this.rootEmail = res[0].email;
     });
     this.em_user = _.find(this.fieldConfig, {'name': 'em_user'});
+    this.em_message = _.find(this.fieldConfig, {'name': 'email_form_password_message'});
     this.em_pass1 = _.find(this.fieldConfig, {'name': 'em_pass1'});
     this.em_pass2 = _.find(this.fieldConfig, {'name': 'em_pass2'});
 
     this.em_smtp = entityEdit.formGroup.controls['em_smtp'];
     this.em_user.isHidden = !this.em_smtp.value;
     this.em_pass1.isHidden = !this.em_smtp.value;
+    this.em_message.isHidden = !this.em_smtp.value;
     this.em_pass2.isHidden = !this.em_smtp.value;
     this.em_pass2.hideButton = !this.em_smtp.value;
+    
 
     this.em_smtp_subscription = this.em_smtp.valueChanges.subscribe((value) => {
       this.em_user.isHidden = !value;
+      this.em_message.isHidden = !value;
       this.em_pass1.isHidden = !value;
       this.em_pass2.isHidden = !value;
       this.em_pass1.hideButton = !value;

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -1252,4 +1252,8 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     height: 52px;
   }
 
+  #email_form_password_message {
+    margin-top: 10px;
+  }
+
  } // end of ix theme

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -1252,8 +1252,8 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     height: 52px;
   }
 
-  #email_form_password_message {
-    margin-top: 10px;
+  #em_pwmessage {
+    margin: 10px 0;
   }
 
  } // end of ix theme


### PR DESCRIPTION
Ticket: #67359
Adds a message to make it clear that password (and matching PW) are always needed to submit the form (if SMTP auth is selected), even when you are just editing.