### PR TITLE
Email pw warning

### DIFF
--- a/src/app/helptext/system/email.ts
+++ b/src/app/helptext/system/email.ts
@@ -56,7 +56,7 @@ export const helptext_system_email = {
   },
 
   em_pwmessage: {
-    paraText: T('Matching passwords must be entered to submit the form, even when editing settings.')
+    paraText: T('Enter the password to submit settings changes.')
   },
 
   em_pass1: {
@@ -65,12 +65,6 @@ export const helptext_system_email = {
       "Enter the password if the SMTP server requires\
  authentication."
     ),
-    validation: [matchOtherValidator("em_pass2"), Validators.required]
-  },
-
-  em_pass2: {
-    placeholder: T("Confirm Password"),
-    tooltip: T(""),
     validation: [Validators.required]
   }
 };

--- a/src/app/helptext/system/email.ts
+++ b/src/app/helptext/system/email.ts
@@ -59,7 +59,7 @@ export const helptext_system_email = {
     paraText: T('Enter the password to submit settings changes.')
   },
 
-  em_pass1: {
+  em_pass: {
     placeholder: T("Password"),
     tooltip: T(
       "Enter the password if the SMTP server requires\

--- a/src/app/helptext/system/email.ts
+++ b/src/app/helptext/system/email.ts
@@ -55,6 +55,10 @@ export const helptext_system_email = {
     validation: [Validators.required]
   },
 
+  em_pwmessage: {
+    paraText: T('Matching passwords must be entered to submit the form, even when editing settings.')
+  },
+
   em_pass1: {
     placeholder: T("Password"),
     tooltip: T(

--- a/src/app/pages/system/email/email.component.ts
+++ b/src/app/pages/system/email/email.component.ts
@@ -117,6 +117,11 @@ export class EmailComponent implements OnDestroy {
       validation : helptext_system_email.em_user.validation
     },
     {
+      type: 'paragraph',
+      name: 'em_pwmessage',
+      paraText: helptext_system_email.em_pwmessage.paraText,
+    },
+    {
       type : 'input',
       name : 'em_pass1',
       placeholder : helptext_system_email.em_pass1.placeholder,
@@ -159,6 +164,7 @@ export class EmailComponent implements OnDestroy {
   private em_smtp;
   private em_smtp_subscription;
   private em_user;
+  private em_pwmessage;
   private em_pass1;
   private em_pass2;
 
@@ -178,17 +184,20 @@ afterInit(entityEdit: any) {
       this.rootEmail = res[0].email;
     });
     this.em_user = _.find(this.fieldConfig, {'name': 'em_user'});
+    this.em_pwmessage = _.find(this.fieldConfig, {'name': 'em_pwmessage'});
     this.em_pass1 = _.find(this.fieldConfig, {'name': 'em_pass1'});
     this.em_pass2 = _.find(this.fieldConfig, {'name': 'em_pass2'});
 
     this.em_smtp = entityEdit.formGroup.controls['em_smtp'];
     this.em_user['isHidden'] = !this.em_smtp.value;
+    this.em_pwmessage['isHidden'] = !this.em_smtp.value;
     this.em_pass1['isHidden'] = !this.em_smtp.value;
     this.em_pass2['isHidden'] = !this.em_smtp.value;
     this.em_pass2.hideButton = !this.em_smtp.value;
 
     this.em_smtp_subscription = this.em_smtp.valueChanges.subscribe((value) => {
       this.em_user['isHidden'] = !value;
+      this.em_pwmessage['isHidden'] = !value;
       this.em_pass1['isHidden'] = !value;
       this.em_pass2['isHidden'] = !value;
       this.em_pass1.hideButton = !value;

--- a/src/app/pages/system/email/email.component.ts
+++ b/src/app/pages/system/email/email.component.ts
@@ -139,25 +139,7 @@ export class EmailComponent implements OnDestroy {
       required: true,
       togglePw : true,
       validation : helptext_system_email.em_pass1.validation
-    },
-    {
-      type : 'input',
-      name : 'em_pass2',
-      placeholder : helptext_system_email.em_pass2.placeholder,
-      tooltip : helptext_system_email.em_pass2.tooltip,
-      inputType : 'password',
-      relation : [
-        {
-          action : 'DISABLE',
-          when : [ {
-            name : 'em_smtp',
-            value : false,
-          } ]
-        },
-      ],
-      required : true,
-      validation : helptext_system_email.em_pass2.validation
-    },
+    }
   ];
   protected dialogRef: any;
 
@@ -166,7 +148,6 @@ export class EmailComponent implements OnDestroy {
   private em_user;
   private em_pwmessage;
   private em_pass1;
-  private em_pass2;
 
   constructor(protected router: Router, protected rest: RestService,
               protected ws: WebSocketService, protected _injector: Injector,
@@ -186,20 +167,16 @@ afterInit(entityEdit: any) {
     this.em_user = _.find(this.fieldConfig, {'name': 'em_user'});
     this.em_pwmessage = _.find(this.fieldConfig, {'name': 'em_pwmessage'});
     this.em_pass1 = _.find(this.fieldConfig, {'name': 'em_pass1'});
-    this.em_pass2 = _.find(this.fieldConfig, {'name': 'em_pass2'});
 
     this.em_smtp = entityEdit.formGroup.controls['em_smtp'];
     this.em_user['isHidden'] = !this.em_smtp.value;
     this.em_pwmessage['isHidden'] = !this.em_smtp.value;
     this.em_pass1['isHidden'] = !this.em_smtp.value;
-    this.em_pass2['isHidden'] = !this.em_smtp.value;
-    this.em_pass2.hideButton = !this.em_smtp.value;
 
     this.em_smtp_subscription = this.em_smtp.valueChanges.subscribe((value) => {
       this.em_user['isHidden'] = !value;
       this.em_pwmessage['isHidden'] = !value;
       this.em_pass1['isHidden'] = !value;
-      this.em_pass2['isHidden'] = !value;
       this.em_pass1.hideButton = !value;
     });
   }

--- a/src/app/pages/system/email/email.component.ts
+++ b/src/app/pages/system/email/email.component.ts
@@ -43,7 +43,7 @@ export class EmailComponent implements OnDestroy {
           mail_form_payload['security']= security_table[value.em_security]
           mail_form_payload['smtp']= value.em_smtp
           mail_form_payload['user']= value.em_user
-          mail_form_payload['pass']= value.em_pass1 || this.entityEdit.data.em_pass
+          mail_form_payload['pass']= value.em_pass || this.entityEdit.data.em_pass
           mailObj['subject'] += " hostname: " + res['hostname'];
           this.dialogRef = this.dialog.open(EntityJobComponent, { data: { "title": "EMAIL" }, disableClose: true });
           this.dialogRef.componentInstance.setCall('mail.send', [mailObj, mail_form_payload]);
@@ -123,9 +123,9 @@ export class EmailComponent implements OnDestroy {
     },
     {
       type : 'input',
-      name : 'em_pass1',
-      placeholder : helptext_system_email.em_pass1.placeholder,
-      tooltip : helptext_system_email.em_pass1.tooltip,
+      name : 'em_pass',
+      placeholder : helptext_system_email.em_pass.placeholder,
+      tooltip : helptext_system_email.em_pass.tooltip,
       inputType : 'password',
       relation : [
         {
@@ -138,7 +138,7 @@ export class EmailComponent implements OnDestroy {
       ],
       required: true,
       togglePw : true,
-      validation : helptext_system_email.em_pass1.validation
+      validation : helptext_system_email.em_pass.validation
     }
   ];
   protected dialogRef: any;
@@ -147,7 +147,7 @@ export class EmailComponent implements OnDestroy {
   private em_smtp_subscription;
   private em_user;
   private em_pwmessage;
-  private em_pass1;
+  private em_pass;
 
   constructor(protected router: Router, protected rest: RestService,
               protected ws: WebSocketService, protected _injector: Injector,
@@ -166,18 +166,18 @@ afterInit(entityEdit: any) {
     });
     this.em_user = _.find(this.fieldConfig, {'name': 'em_user'});
     this.em_pwmessage = _.find(this.fieldConfig, {'name': 'em_pwmessage'});
-    this.em_pass1 = _.find(this.fieldConfig, {'name': 'em_pass1'});
+    this.em_pass = _.find(this.fieldConfig, {'name': 'em_pass'});
 
     this.em_smtp = entityEdit.formGroup.controls['em_smtp'];
     this.em_user['isHidden'] = !this.em_smtp.value;
     this.em_pwmessage['isHidden'] = !this.em_smtp.value;
-    this.em_pass1['isHidden'] = !this.em_smtp.value;
+    this.em_pass['isHidden'] = !this.em_smtp.value;
 
     this.em_smtp_subscription = this.em_smtp.valueChanges.subscribe((value) => {
       this.em_user['isHidden'] = !value;
       this.em_pwmessage['isHidden'] = !value;
-      this.em_pass1['isHidden'] = !value;
-      this.em_pass1.hideButton = !value;
+      this.em_pass['isHidden'] = !value;
+      this.em_pass.hideButton = !value;
     });
   }
 

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -1064,4 +1064,8 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     @include variable(color, --red, $red);
   }
 
+  #em_pwmessage {
+    margin: 10px 0;
+  }
+
  } // end of ix theme


### PR DESCRIPTION
Ticket: #67359
This PR replaces #1979
Adds a message to make it clear that password (and matching PW) are always needed to submit the form (if SMTP auth is selected), even when you are just editing.

Incorporates requested change: T('Matching passwords must be entered to submit the form, even when editing settings.')