### PR TITLE
Allow underscores in group names similar to how we allow them in user names

### DIFF
--- a/src/app/helptext/account/groups.ts
+++ b/src/app/helptext/account/groups.ts
@@ -16,7 +16,7 @@ bsdgrp_gid_validation: [ Validators.required, regexValidator(/^\d+$/) ],
 
 bsdgrp_group_placeholder: T('Name'),
 bsdgrp_group_tooltip: T('Enter an alphanumeric name for the group.'),
-bsdgrp_group_validation: [ Validators.required, regexValidator(/^\w[\w.-]*$/) ],
+bsdgrp_group_validation: [ Validators.required, regexValidator(/^[\w\_][\w\.-\_]*$/) ],
 
 bsdgrp_sudo_placeholder: T('Permit Sudo'),
 bsdgrp_sudo_tooltip: T('Allow group members to use <a\


### PR DESCRIPTION
Ticket: #71147
(cherry picked from commit f6bee5c92260a30e0685d8d3f1212a63b03a4d7f)