### PR TITLE
FIX: 76747-stable

### DIFF
--- a/src/app/pages/common/error-dialog/error-dialog.component.ts
+++ b/src/app/pages/common/error-dialog/error-dialog.component.ts
@@ -19,7 +19,22 @@ export class ErrorDialog {
   }
 
   public toggleOpen (data) {
+    const dialogWrapper = document.getElementById('errordialog-wrapper');
+    const dialog = document.getElementsByClassName('mat-dialog-container');
+    const content = document.getElementsByClassName('mat-dialog-content');
+    const btPanel = document.getElementsByClassName('backtrace-panel');
+    const txtarea = document.getElementsByTagName('textarea');
     this.isCloseMoreInfo = !this.isCloseMoreInfo;
+    if (!this.isCloseMoreInfo) {
+      dialog[0].setAttribute('style','width : 800px; height: 600px');
+      content[0].setAttribute('style', 'min-height: 450px')
+      btPanel[0].setAttribute('style', 'width: 750px; max-height: 400px');
+      txtarea[0].setAttribute('style', 'height: 400px')
+    } else {
+      dialog[0].removeAttribute('style');
+      content[0].removeAttribute('style');
+      btPanel[0].removeAttribute('style');
+    }
   }
 
 }


### PR DESCRIPTION
Ticket: 76747
Makes dialog larger when it displays backtrace. Dialog is still a fixed size, and scroll appears when BT is larger than capacity of the box.

![screenshot from 2019-02-28 11-29-10](https://user-images.githubusercontent.com/9504493/53582010-ac8d3780-3b4c-11e9-910f-c4a8d41c7144.png)
![screenshot from 2019-02-28 11-29-20](https://user-images.githubusercontent.com/9504493/53582011-adbe6480-3b4c-11e9-9e32-9d9e7f57ceae.png)
