### PR TITLE
Add a 'buildtime' flag which can be parsed by WebUI to determine

### DIFF
--- a/ports/freenas/freenas-webui/Makefile
+++ b/ports/freenas/freenas-webui/Makefile
@@ -23,6 +23,8 @@ BUILD_DEPENDS=	rsync>0:net/rsync \
 NO_BUILD=	yes
 WRKSRC=		/usr/webui
 
+MTIMEREV!=	stat -f %m /usr/webui
+
 checksum:
 	${ECHO_CMD} ${.TARGET} not needed because building direct
 
@@ -36,6 +38,7 @@ extract:
 do-install:
 	mkdir -p ${STAGEDIR}${PREFIX}/www/webui/
 	rsync -avl --exclude '.git' --exclude 'nas_ports' --exclude 'etc' --exclude 'sbin' ${WRKSRC}/dist/ ${STAGEDIR}${PREFIX}/www/webui/
+	${ECHO} "${MTIMEREV}" > ${STAGEDIR}/${PREFIX}/www/webui/buildtime
 	(cd ${STAGEDIR}${PREFIX}/www/webui; ${FIND} . -type f \
 		| ${SED} -e 's,^\./,,g' \
 		| ${AWK} '{print length, $$0}' | ${SORT} -rn \


### PR DESCRIPTION
if the version of webui on FreeNAS is different from the version
currently loaded into the web-browser. This can trigger a refresh
if the two timestamps do not match.