### PR TITLE
Fix 76773 stable

### DIFF
--- a/src/app/components/common/layouts/admin-layout/admin-layout.template.html
+++ b/src/app/components/common/layouts/admin-layout/admin-layout.template.html
@@ -49,7 +49,6 @@
     <app-breadcrumb></app-breadcrumb>
     <div class="rightside-content-hold" [ngClass]="{'has-footer':isShowFooterConsole}">
       <router-outlet></router-outlet>
-      <div class="temp" [style.height.px]="50" *ngIf="isShowFooterConsole"></div>
     </div>
     <div class="footer-console-bar" *ngIf="isShowFooterConsole">
       <pre #footerBarScroll class="message" (click)="onShowConsolePanel()">{{consoleMsg}}</pre>

--- a/src/app/pages/common/entity/entity-form/entity-form.component.html
+++ b/src/app/pages/common/entity/entity-form/entity-form.component.html
@@ -50,3 +50,4 @@
         <mat-error *ngIf="error" type="danger" id="error_message"><div [innerHTML]="error"></div></mat-error>
     </div>
 </mat-card>
+<div class="temp" [style.height.px]="50" *ngIf="isFooterOpen" ></div>

--- a/src/app/pages/common/entity/entity-form/entity-form.component.ts
+++ b/src/app/pages/common/entity/entity-form/entity-form.component.ts
@@ -116,6 +116,7 @@ export class EntityFormComponent implements OnInit, OnDestroy, OnChanges, AfterV
   public queryResponse;
   public saveSubmitText = "Save";
   public showPassword = false;
+  public isFooterOpen: boolean;
 
   get controls() {
     return this.fieldConfig.filter(({type}) => type !== 'button');
@@ -355,6 +356,17 @@ export class EntityFormComponent implements OnInit, OnDestroy, OnChanges, AfterV
     // ...but for entity forms that don't make a data request, this kicks in 
     setTimeout(() => { this.setShowDefaults(); }, 500);
 
+    this.checkIfConsoleMsgShows();
+
+  }
+
+  checkIfConsoleMsgShows() {
+    setTimeout(() => {
+      this.rest.get('system/advanced', { limit: 0 }).subscribe((res) => {
+        this.isFooterOpen = res.data['adv_consolemsg'];   
+      });
+    }, 500)
+
   }
 
   setShowDefaults() {
@@ -418,7 +430,7 @@ export class EntityFormComponent implements OnInit, OnDestroy, OnChanges, AfterV
     return this.rest.post(resource, {body}, this.conf.route_usebaseUrl); 
   }
 
-  onSubmit(event: Event) {
+  onSubmit(event: Event) {   
     if (this.conf.confirmSubmit && this.conf.confirmSubmitDialog) {
       this.dialog.confirm(this.conf.confirmSubmitDialog['title'],
                           this.conf.confirmSubmitDialog['message'], 
@@ -438,6 +450,7 @@ export class EntityFormComponent implements OnInit, OnDestroy, OnChanges, AfterV
   }
 
   doSubmit(event: Event) {  
+    this.checkIfConsoleMsgShows();
     event.preventDefault();
     event.stopPropagation();
     this.error = null;

--- a/src/app/pages/common/entity/entity-table/entity-table.component.ts
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.ts
@@ -234,7 +234,7 @@ export class EntityTableComponent /*extends ViewControllerComponent*/ implements
   }
 
   setTableHeight() {
-    let rowNum = 6, n;
+    let rowNum = 6, n, addRows = 4;
     if (this.title === 'Boot Environments') {
       n = 6;
     } else if (this.title === 'Jails') {
@@ -247,7 +247,7 @@ export class EntityTableComponent /*extends ViewControllerComponent*/ implements
     window.onresize = () => {
       let x = window.innerHeight;
       let y = x - 830;
-      this.paginationPageSize = rowNum - n + Math.floor(y/50) + 4 ;
+      this.paginationPageSize = rowNum - n + Math.floor(y/50) + addRows ;
 
       if (this.paginationPageSize < 2) {
         this.paginationPageSize = 2;

--- a/src/app/pages/common/entity/entity-table/entity-table.component.ts
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.ts
@@ -234,24 +234,23 @@ export class EntityTableComponent /*extends ViewControllerComponent*/ implements
   }
 
   setTableHeight() {
-    let rowNum = 10, n;
+    let rowNum = 6, n;
     if (this.title === 'Boot Environments') {
-      n = 5;
+      n = 6;
     } else if (this.title === 'Jails') {
-      n = 3;
+      n = 4;
     } else if (this.title === 'Available Plugins' || this.title === 'Installed Plugins') {
-      n = 2;
+      n = 3;
     } else {
       n = 0;
     }
     window.onresize = () => {
       let x = window.innerHeight;
-      if (x <=780) {
-        this.paginationPageSize = rowNum - n;
-      } else {
-        let y = x - 800;
-        y >= 0 ? this.paginationPageSize = rowNum - n + Math.floor(y/50) : 
-          this.paginationPageSize = rowNum - n;
+      let y = x - 830;
+      this.paginationPageSize = rowNum - n + Math.floor(y/50) + 4 ;
+
+      if (this.paginationPageSize < 2) {
+        this.paginationPageSize = 2;
       }
       this.setPaginationInfo();
     }

--- a/src/assets/styles/egret_overrides.css
+++ b/src/assets/styles/egret_overrides.css
@@ -70,6 +70,7 @@ app-breadcrumb{
   bottom: 0px;
   width: 100%;
   height: 45px;
+  background-color: #000;
 
   -webkit-animation-name: silde_to_top;
   -webkit-animation-duration: 1s;


### PR DESCRIPTION
Ticket: #76773
Adjust entity tables to prevent a vert scroll from appearing on the main window. Gets rid of double vert scrollbars, except when tables are compressed to two rows.
![screenshot from 2019-03-01 13-32-18](https://user-images.githubusercontent.com/9504493/53658337-7ae89f00-3c26-11e9-9f9b-c5db6411512e.png)
