### PR TITLE
Feat 78438 master

### DIFF
--- a/src/app/pages/storage/volumes/volumes-list/volumes-list.component.html
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list.component.html
@@ -18,6 +18,11 @@
             {{row.name}}
           </mat-panel-title>
           <mat-panel-description>
+              <span [style.margin-right.px]="5">
+                <i class="material-icons" *ngIf="row.status==='HEALTHY'" [style.color]="'green'">check_circle</i>
+                <i class="material-icons" *ngIf="row.status==='DEGRADED'" [style.color]="'orange'">warning</i>
+                <i class="material-icons" *ngIf="row.status!=='HEALTHY' && row.status!=='DEGRADED'" [style.color]="'red'">cancel</i>
+              </span>
             {{row.status}}<span *ngIf="row.usedStr && row.availStr">{{row.usedStr}} Used / {{row.availStr}} Free</span>
           </mat-panel-description>
         </mat-expansion-panel-header>

--- a/src/app/pages/storage/volumes/volumes-list/volumes-list.component.html
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list.component.html
@@ -18,7 +18,7 @@
             {{row.name}}
           </mat-panel-title>
           <mat-panel-description>
-            {{row.status}} <span *ngIf="row.usedStr && row.availStr">({{row.usedStr}} Used / {{row.availStr}} Free)</span>
+            {{row.status}}<span *ngIf="row.usedStr && row.availStr">{{row.usedStr}} Used / {{row.availStr}} Free</span>
           </mat-panel-description>
         </mat-expansion-panel-header>
         <div fxLayoutAlign="end start" class="icon-row">

--- a/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
@@ -806,7 +806,7 @@ export class VolumesListComponent extends EntityTableComponent implements OnInit
 
             try {
               let used_pct =  volume.children[0].used / (volume.children[0].used + volume.children[0].avail);
-              volume.usedStr = (<any>window).filesize(volume.children[0].used, { standard: "iec" }) + " (" + Math.round(used_pct * 100) + "%)";
+              volume.usedStr = ": " + (<any>window).filesize(volume.children[0].used, { standard: "iec" }) + " (" + Math.round(used_pct * 100) + "%)";
             } catch (error) {
               volume.usedStr = "" + volume.children[0].used;
             }


### PR DESCRIPTION
Ticket: #78438
Add colored icons for pool status, reformat text. In pic, pools all say 'healthy' but are actually keyed to Healthy (green), degraded (yellow) and other (red)
![screenshot from 2019-03-06 11-33-47](https://user-images.githubusercontent.com/9504493/53898805-d0e28b80-4006-11e9-9e71-c73927159009.png)
