### PR TITLE
Fix 59112 stable

### DIFF
--- a/src/app/helptext/sharing/smb/smb.ts
+++ b/src/app/helptext/sharing/smb/smb.ts
@@ -11,7 +11,8 @@ export const helptext_sharing_smb = {
 
     placeholder_name: T('Name'),
     tooltip_name: T('Enter a name for the share.'),
-    errormsg_name: T("'global' is a reserved section name. Please select another one"),
+    errormsg_name: T("<i>global</i> is a reserved name that cannot be used as a share\
+ name. Please enter a different share name."),
 
     placeholder_home: T('Use as home share'),
     tooltip_home: T('Set to allow this share to hold user home\

--- a/src/app/helptext/sharing/smb/smb.ts
+++ b/src/app/helptext/sharing/smb/smb.ts
@@ -11,6 +11,7 @@ export const helptext_sharing_smb = {
 
     placeholder_name: T('Name'),
     tooltip_name: T('Enter a name for the share.'),
+    errormsg_name: T("'global' is a reserved section name. Please select another one"),
 
     placeholder_home: T('Use as home share'),
     tooltip_home: T('Set to allow this share to hold user home\

--- a/src/app/pages/common/entity/entity-form/components/form-input/form-input.component.html
+++ b/src/app/pages/common/entity/entity-form/components/form-input/form-input.component.html
@@ -24,6 +24,6 @@
         <i class="material-icons" matTooltip="Show" *ngIf="!showPassword">visibility_off</i>
 	</button>
 	<tooltip *ngIf="config.tooltip" [message]="config.tooltip"></tooltip>
-	<mat-error *ngIf="config.hasErrors">{{config.errors}}</mat-error>
+	<mat-error *ngIf="config['hasErrors']"><div [innerHTML]="config['errors']"></div></mat-error>
 	<mat-error *ngIf="config.warnings">{{config.warnings | translate}}</mat-error>
 </div>

--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
@@ -5,6 +5,7 @@ import * as _ from 'lodash';
 import { RestService, WebSocketService, DialogService } from '../../../../services/';
 import { FieldConfig } from '../../../common/entity/entity-form/models/field-config.interface';
 import { helptext_sharing_smb } from 'app/helptext/sharing';
+import { FormControl } from '@angular/forms';
 
 @Component({
   selector : 'app-smb-form',
@@ -19,6 +20,7 @@ export class SMBFormComponent implements OnDestroy {
   public cifs_default_permissions: any;
   public cifs_default_permissions_subscription: any;
   public cifs_storage_task: any;
+  public identifier: any;
 
   protected fieldConfig: FieldConfig[] = [
     {
@@ -35,7 +37,10 @@ export class SMBFormComponent implements OnDestroy {
       type: 'input',
       name: 'cifs_name',
       placeholder: helptext_sharing_smb.placeholder_name,
-      tooltip: helptext_sharing_smb.tooltip_name
+      tooltip: helptext_sharing_smb.tooltip_name,
+      validation: this.forbiddenNameValidator.bind(this),
+      hasErrors: false,
+      errors: 'Dang'
     },
     {
       type: 'checkbox',
@@ -243,6 +248,11 @@ export class SMBFormComponent implements OnDestroy {
       entityForm.formGroup.controls['cifs_vfsobjects'].setValue(['zfs_space','zfsacl','streams_xattr']);
       entityForm.formGroup.controls['cifs_browsable'].setValue(true);
     }
+
+    entityForm.formGroup.controls['cifs_name'].statusChanges.subscribe((res) => {
+      let target = _.find(this.fieldConfig, {'name' : 'cifs_name'});
+      res === 'INVALID' ? target.hasErrors = true : target.hasErrors = false;
+    })
   }
 
   resourceTransformIncomingRestData(data) {
@@ -262,6 +272,15 @@ export class SMBFormComponent implements OnDestroy {
     });
 
     return data;
+  }
+
+  forbiddenNameValidator(control: FormControl): {[key: string]: boolean} {
+    if (control.value === 'global') {
+      
+      _.find(this.fieldConfig).hasErrors = true;
+      return {'nameIsForbidden': true}
+    }
+    return null;
   }
 
   ngOnDestroy() {

--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
@@ -20,7 +20,6 @@ export class SMBFormComponent implements OnDestroy {
   public cifs_default_permissions: any;
   public cifs_default_permissions_subscription: any;
   public cifs_storage_task: any;
-  public identifier: any;
 
   protected fieldConfig: FieldConfig[] = [
     {
@@ -40,7 +39,7 @@ export class SMBFormComponent implements OnDestroy {
       tooltip: helptext_sharing_smb.tooltip_name,
       validation: this.forbiddenNameValidator.bind(this),
       hasErrors: false,
-      errors: 'Dang'
+      errors: helptext_sharing_smb.errormsg_name
     },
     {
       type: 'checkbox',
@@ -276,8 +275,6 @@ export class SMBFormComponent implements OnDestroy {
 
   forbiddenNameValidator(control: FormControl): {[key: string]: boolean} {
     if (control.value === 'global') {
-      
-      _.find(this.fieldConfig).hasErrors = true;
       return {'nameIsForbidden': true}
     }
     return null;


### PR DESCRIPTION
Ticket: #59112
Makes a custom validator to prevent 'global' from being used as a SMB share name