### PR TITLE
Preventing UI from linking to nonexisting URL in documentation.

### DIFF
--- a/src/app/helptext/directoryservice/activedirectory.ts
+++ b/src/app/helptext/directoryservice/activedirectory.ts
@@ -207,7 +207,7 @@ activedirectory_idmap_change_dialog_message: T('<font color="red">WARNING</font>
  target="_blank">idmap_autorid(8)</a>\, <a\
  href="https://www.freebsd.org/cgi/man.cgi?query=idmap_ad"\
  target="_blank">ad</a>\, <a\
- href="%%docurl%%/directoryservice.html%%webversion%%#id12"\
+ href="%%docurl%%/directoryservices.html%%webversion%%#id12"\
  target="_blank">fruit</a>\, <a\
  href="https://www.freebsd.org/cgi/man.cgi?query=idmap_ldap"\
  target="_blank">idmap_ldap(8)</a>\, <a\

--- a/src/app/helptext/directoryservice/ldap.ts
+++ b/src/app/helptext/directoryservice/ldap.ts
@@ -71,14 +71,14 @@ ldap_sudosuffix_tooltip: T('Suffix for LDAP-based users that need superuser acce
 ldap_kerberos_realm_name : 'ldap_kerberos_realm',
 ldap_kerberos_realm_placeholder : T('Kerberos Realm'),
 ldap_kerberos_realm_tooltip: T('Select the realm created using the instructions in <a\
- href="%%docurl%%/directoryservice.html%%webversion%%#kerberos-realms"\
+ href="%%docurl%%/directoryservices.html%%webversion%%#kerberos-realms"\
  target="_blank">Kerberos Realms</a>.'),
 
 ldap_kerberos_principal_name : 'ldap_kerberos_principal',
 ldap_kerberos_principal_placeholder : T('Kerberos Principal'),
 ldap_kerberos_principal_tooltip: T('Select the location of the principal in the keytab\
  created as described in <a\
- href="%%docurl%%/directoryservice.html%%webversion%%#kerberos-keytabs"\
+ href="%%docurl%%/directoryservices.html%%webversion%%#kerberos-keytabs"\
  target="_blank">Kerberos Keytabs</a>.'),
 
 ldap_ssl_name : 'ldap_ssl',

--- a/src/app/helptext/services/components/service-dc.ts
+++ b/src/app/helptext/services/components/service-dc.ts
@@ -45,7 +45,7 @@ dc_forest_level_options : [
 
 dc_passwd_placeholder : T('Administrator Password'),
 dc_passwd_tooltip: T('Enter the password to be used for the\
- <a href="%%docurl%%/directoryservice.html%%webversion%%#active-directory"\
+ <a href="%%docurl%%/directoryservices.html%%webversion%%#active-directory"\
  target=”_blank”>Active Directory</a> administrator account.'),
 dc_passwd_validation :
       [ Validators.minLength(8), matchOtherValidator('dc_passwd2') ],

--- a/src/app/helptext/services/components/service-smb.ts
+++ b/src/app/helptext/services/components/service-smb.ts
@@ -16,9 +16,9 @@ cifs_srv_netbiosalias_validation: [ Validators.maxLength(15) ],
 cifs_srv_workgroup_placeholder: T('Workgroup'),
 cifs_srv_workgroup_tooltip: T('Must match Windows workgroup\
  name. This setting is ignored if the\
- <a href="%%docurl%%/directoryservice.html%%webversion%%#active-directory"\
+ <a href="%%docurl%%/directoryservices.html%%webversion%%#active-directory"\
  target="_blank">Active Directory</a> or <a\
- href="%%docurl%%/directoryservice.html%%webversion%%#ldap"\
+ href="%%docurl%%/directoryservices.html%%webversion%%#ldap"\
  target="_blank">LDAP</a> service is running.'),
 cifs_srv_workgroup_validation : [ Validators.required ],
 
@@ -111,7 +111,7 @@ cifs_srv_obey_pam_restrictions_placeholder: T('Obey Pam Restrictions'),
 cifs_srv_obey_pam_restrictions_tooltip: T('Unselect this option to allow cross-domain\
  authentication, users and groups to be managed on\
  another forest, and permissions to be delegated from\
- <a href="%%docurl%%/directoryservice.html%%webversion%%#active-directory"\
+ <a href="%%docurl%%/directoryservices.html%%webversion%%#active-directory"\
  target="_blank">Active Directory</a>\
  users and groups to domain admins on another forest.'),
 

--- a/src/app/helptext/services/components/service-ssh.ts
+++ b/src/app/helptext/services/components/service-ssh.ts
@@ -23,9 +23,9 @@ ssh_passwordauth_tooltip: T('Unset to require key-based authentication for\
 
 ssh_kerberosauth_placeholder : T('Allow Kerberos authentication'),
 ssh_kerberosauth_tooltip: T('Ensure <a\
- href="%%docurl%%/directoryservice.html%%webversion%%#kerberos-realms"\
+ href="%%docurl%%/directoryservices.html%%webversion%%#kerberos-realms"\
  target="_blank">Kerberos Realms</a> and <a\
- href="%%docurl%%/directoryservice.html%%webversion%%#kerberos-keytabs"\
+ href="%%docurl%%/directoryservices.html%%webversion%%#kerberos-keytabs"\
  target="_blank">Kerberos Keytabs</a> are configured\
  and the system can communicate with the Kerberos\
  Domain Controller before setting.'),


### PR DESCRIPTION
The documentation chapter talking about Directory Services lives in `directoryservices.html` but the GUI references file `directoryservice.html`

This PR is trying to fix the above-described issue, by referencing file existing in the documentation.