### PR TITLE
Fix backtrace textbox issue

### DIFF
--- a/src/app/pages/common/error-dialog/error-dialog.component.html
+++ b/src/app/pages/common/error-dialog/error-dialog.component.html
@@ -10,7 +10,7 @@
     <span>More info...</span>
   </div>
   <div class="backtrace-panel" [ngClass]="{'open':!isCloseMoreInfo}" *ngIf="backtrace">
-    <textarea readonly matInput>Error: {{backtrace}}</textarea>
+    <textarea id="bt-text" readonly matInput>Error: {{backtrace}}</textarea>
   </div>  
 </div>
 <div mat-dialog-actions>

--- a/src/app/pages/common/error-dialog/error-dialog.component.ts
+++ b/src/app/pages/common/error-dialog/error-dialog.component.ts
@@ -23,13 +23,13 @@ export class ErrorDialog {
     const dialog = document.getElementsByClassName('mat-dialog-container');
     const content = document.getElementsByClassName('mat-dialog-content');
     const btPanel = document.getElementsByClassName('backtrace-panel');
-    const txtarea = document.getElementsByTagName('textarea');
+    const txtarea = document.getElementById('bt-text');
     this.isCloseMoreInfo = !this.isCloseMoreInfo;
     if (!this.isCloseMoreInfo) {
       dialog[0].setAttribute('style','width : 800px; height: 600px');
       content[0].setAttribute('style', 'min-height: 450px')
       btPanel[0].setAttribute('style', 'width: 750px; max-height: 400px');
-      txtarea[0].setAttribute('style', 'height: 400px')
+      txtarea.setAttribute('style', 'height: 400px')
     } else {
       dialog[0].removeAttribute('style');
       content[0].removeAttribute('style');


### PR DESCRIPTION
Ticket: #83387
Prevents error dialog from expanding a text area behind it