### PR TITLE
Added info in the helptext about creating a friendly name in the from email field.

### DIFF
--- a/src/app/helptext/system/email.ts
+++ b/src/app/helptext/system/email.ts
@@ -6,7 +6,7 @@ export const helptext_system_email = {
   em_fromemail: {
     placeholder: T("From E-mail"),
     tooltip: T(
-      'The envelope From address shown in the email.\
+      'The envelope <i>From</i> address shown in the email.\
  This is set to assist with filtering mail on the\
  receiving system. A friendly name can be set using this syntax:\
  "friendly sender name" <<i>email address</i>>'

--- a/src/app/helptext/system/email.ts
+++ b/src/app/helptext/system/email.ts
@@ -9,7 +9,7 @@ export const helptext_system_email = {
       'The envelope <i>From</i> address shown in the email.\
  This can be set to make filtering mail on the\
  receiving system. The friendly name is set like this:\
- "friendly sender name" <<i>email address</i>>'
+ <i>"Friendly Name" <address@example.com></i>'
     )
   },
 

--- a/src/app/helptext/system/email.ts
+++ b/src/app/helptext/system/email.ts
@@ -8,7 +8,7 @@ export const helptext_system_email = {
     tooltip: T(
       'The envelope <i>From</i> address shown in the email.\
  This can be set to make filtering mail on the\
- receiving system. A friendly name can be set using this syntax:\
+ receiving system. The friendly name is set like this:\
  "friendly sender name" <<i>email address</i>>'
     )
   },

--- a/src/app/helptext/system/email.ts
+++ b/src/app/helptext/system/email.ts
@@ -7,7 +7,7 @@ export const helptext_system_email = {
     placeholder: T("From E-mail"),
     tooltip: T(
       'The envelope <i>From</i> address shown in the email.\
- This is set to assist with filtering mail on the\
+ This can be set to make filtering mail on the\
  receiving system. A friendly name can be set using this syntax:\
  "friendly sender name" <<i>email address</i>>'
     )

--- a/src/app/helptext/system/email.ts
+++ b/src/app/helptext/system/email.ts
@@ -6,9 +6,10 @@ export const helptext_system_email = {
   em_fromemail: {
     placeholder: T("From E-mail"),
     tooltip: T(
-      "The envelope From address shown in the email.\
+      'The envelope From address shown in the email.\
  This is set to assist with filtering mail on the\
- receiving system."
+ receiving system. A friendly name can be set using this syntax:\
+ "friendly sender name" <<i>email address</i>>'
     )
   },
 

--- a/src/app/helptext/system/email.ts
+++ b/src/app/helptext/system/email.ts
@@ -8,7 +8,7 @@ export const helptext_system_email = {
     tooltip: T(
       'The envelope <i>From</i> address shown in the email.\
  This can be set to make filtering mail on the\
- receiving system. The friendly name is set like this:\
+ receiving system easier. The friendly name is set like this:\
  <i>"Friendly Name" <address@example.com></i>'
     )
   },


### PR DESCRIPTION
(cherry picked from commit 81a34ca1eb66fa151a52048fa356be1ec376e838)