### PR TITLE
Console fix for pool list

### DIFF
--- a/src/app/pages/storage/volumes/volumes-list/volumes-list.component.html
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list.component.html
@@ -54,11 +54,13 @@
       </mat-expansion-panel>
     </mat-accordion>
   </div>
+  <div [style.margin-bottom.px]="50" *ngIf="isFooterConsoleOpen"></div>
   <div *ngIf="zfsPoolRows.length < 1 && showDefaults">
     <mat-card>
       <mat-card-content name="no_pools">
         {{"No pools" | translate}}
       </mat-card-content>
     </mat-card>
+    <div [style.height.px]="50" *ngIf="isFooterConsoleOpen"></div>
   </div>
 </div>

--- a/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
@@ -850,7 +850,6 @@ export class VolumesListComponent extends EntityTableComponent implements OnInit
     this.ws.call('system.advanced.config').subscribe((res)=> {
       if (res) {
         this.isFooterConsoleOpen = res.consolemsg;
-        console.log(this.isFooterConsoleOpen)
       }
     });
 

--- a/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
@@ -776,7 +776,7 @@ export class VolumesListComponent extends EntityTableComponent implements OnInit
 
   expanded = false;
   public paintMe = true;
-
+  public isFooterConsoleOpen: boolean;
 
   constructor(protected core: CoreService ,protected rest: RestService, protected router: Router, protected ws: WebSocketService,
     protected _eRef: ElementRef, protected dialogService: DialogService, protected loader: AppLoaderService,
@@ -845,6 +845,13 @@ export class VolumesListComponent extends EntityTableComponent implements OnInit
       this.showSpinner = false;
 
       this.dialogService.errorReport(T("Error getting pool data."), res.message, res.stack);
+    });
+
+    this.ws.call('system.advanced.config').subscribe((res)=> {
+      if (res) {
+        this.isFooterConsoleOpen = res.consolemsg;
+        console.log(this.isFooterConsoleOpen)
+      }
     });
 
   }


### PR DESCRIPTION
Adds dynamic space on pool list page if footer console is open (failed test previously)