### PR TITLE
Nas 101244 online url stable

### DIFF
--- a/src/app/components/common/navigation/navigation.component.ts
+++ b/src/app/components/common/navigation/navigation.component.ts
@@ -42,7 +42,7 @@ export class NavigationComponent implements OnInit {
       this.ws.call('system.info').subscribe((res) => {
         if (res.version) {
             window.localStorage.setItem('running_version', res['version']);
-            const docUrl = this.docsService.docReplace("%%docurl%%" + "/" + "%%webversion%%");
+            const docUrl = this.docsService.docReplace("%%docurl%%");
             const guide = _.find(menuItem, {name: 'Guide'});
             guide.state = docUrl;
         }

--- a/src/app/helptext/directoryservice/activedirectory.ts
+++ b/src/app/helptext/directoryservice/activedirectory.ts
@@ -55,10 +55,10 @@ activedirectory_certificate_name: 'ad_certificate',
 activedirectory_certificate_placeholder: T('Certificate'),
 activedirectory_certificate_tooltip: T('Select the certificate of the Active Directory server\
  if SSL connections are used. Add a certificate here by creating a\
- <a href="%%docurl%%/system.html%%webversion%%#cas" target="_blank">CA</a>,\
+ <a href="%%docurl%%/system.html#cas" target="_blank">CA</a>,\
  then creating a certificate on the Active Directory server.\
  Import the certificate on this system with the\
- <a href="%%docurl%%/system.html%%webversion%%#certificates" target="_blank">Certificates</a>\
+ <a href="%%docurl%%/system.html#certificates" target="_blank">Certificates</a>\
  menu.'),
 
 activedirectory_verbose_logging_name: 'ad_verbose_logging',
@@ -116,13 +116,13 @@ activedirectory_gcname_tooltip : T('This holds a full set of attributes for the 
 activedirectory_kerberos_realm_name: 'ad_kerberos_realm',
 activedirectory_kerberos_realm_placeholder : T('Kerberos Realm'),
 activedirectory_kerberos_realm_tooltip : T('Select the realm created in\
- <a href="%%docurl%%/directoryservices.html%%webversion%%#kerberos-realms"\
+ <a href="%%docurl%%/directoryservices.html#kerberos-realms"\
  target="_blank">Kerberos Realms</a>.'),
 
 activedirectory_kerberos_principal_name: 'ad_kerberos_principal',
 activedirectory_kerberos_principal_placeholder : T('Kerberos Principal'),
 activedirectory_kerberos_principal_tooltip : T('Select the keytab created in\
- <a href="%%docurl%%/directoryservices.html%%webversion%%#kerberos-keytabs"\
+ <a href="%%docurl%%/directoryservices.html#kerberos-keytabs"\
  target="_blank">Kerberos Keytabs</a>.'),
 
 activedirectory_timeout_name: 'ad_timeout',
@@ -208,7 +208,7 @@ activedirectory_idmap_change_dialog_message: T('<font color="red">WARNING</font>
  target="_blank">idmap_autorid(8)</a>\, <a\
  href="https://www.freebsd.org/cgi/man.cgi?query=idmap_ad"\
  target="_blank">ad</a>\, <a\
- href="%%docurl%%/directoryservices.html%%webversion%%#id12"\
+ href="%%docurl%%/directoryservices.html#id12"\
  target="_blank">fruit</a>\, <a\
  href="https://www.freebsd.org/cgi/man.cgi?query=idmap_ldap"\
  target="_blank">idmap_ldap(8)</a>\, <a\

--- a/src/app/helptext/directoryservice/ldap.ts
+++ b/src/app/helptext/directoryservice/ldap.ts
@@ -71,14 +71,14 @@ ldap_sudosuffix_tooltip: T('Suffix for LDAP-based users that need superuser acce
 ldap_kerberos_realm_name : 'ldap_kerberos_realm',
 ldap_kerberos_realm_placeholder : T('Kerberos Realm'),
 ldap_kerberos_realm_tooltip: T('Select the realm created using the instructions in <a\
- href="%%docurl%%/directoryservices.html%%webversion%%#kerberos-realms"\
+ href="%%docurl%%/directoryservices.html#kerberos-realms"\
  target="_blank">Kerberos Realms</a>.'),
 
 ldap_kerberos_principal_name : 'ldap_kerberos_principal',
 ldap_kerberos_principal_placeholder : T('Kerberos Principal'),
 ldap_kerberos_principal_tooltip: T('Select the location of the principal in the keytab\
  created as described in <a\
- href="%%docurl%%/directoryservices.html%%webversion%%#kerberos-keytabs"\
+ href="%%docurl%%/directoryservices.html#kerberos-keytabs"\
  target="_blank">Kerberos Keytabs</a>.'),
 
 ldap_ssl_name : 'ldap_ssl',

--- a/src/app/helptext/network/laggs/lagg.ts
+++ b/src/app/helptext/network/laggs/lagg.ts
@@ -8,7 +8,7 @@ lagg_interface_tooltip : T('Description of the lagg interface.'),
 
 lagg_protocol_placeholder : T('Lagg Protocol'),
 lagg_protocol_tooltip : T('Select the <a\
- href="%%docurl%%/network.html%%webversion%%#link-aggregations"\
+ href="%%docurl%%/network.html#link-aggregations"\
  target="_blank">Protocol Type</a>.<br>\
  <i>LACP</i> is the recommended protocol if the network\
  switch is capable of active LACP.<br>\

--- a/src/app/helptext/services/components/service-dc.ts
+++ b/src/app/helptext/services/components/service-dc.ts
@@ -45,7 +45,7 @@ dc_forest_level_options : [
 
 dc_passwd_placeholder : T('Administrator Password'),
 dc_passwd_tooltip: T('Enter the password to be used for the\
- <a href="%%docurl%%/directoryservices.html%%webversion%%#active-directory"\
+ <a href="%%docurl%%/directoryservices.html#active-directory"\
  target=”_blank”>Active Directory</a> administrator account.'),
 dc_passwd_validation :
       [ Validators.minLength(8), matchOtherValidator('dc_passwd2') ],

--- a/src/app/helptext/services/components/service-ftp.ts
+++ b/src/app/helptext/services/components/service-ftp.ts
@@ -106,7 +106,7 @@ anonuserdlbw_validation: [rangeValidator(0), Validators.required],
 tls_placeholder : T('Enable TLS'),
 tls_tooltip: T('Set to enable encrypted connections. Requires a certificate\
  to be created or imported using\
- <a href="%%docurl%%/system.html%%webversion%%#certificates"\
+ <a href="%%docurl%%/system.html#certificates"\
  target="_blank">Certificates</a>'),
 
 tls_policy_placeholder : T('TLS Policy'),

--- a/src/app/helptext/services/components/service-lldp.ts
+++ b/src/app/helptext/services/components/service-lldp.ts
@@ -6,7 +6,7 @@ lldp_intdesc_tooltip: T('Set to enable <i>receive</i> mode. Any received peer\
  information is saved in interface descriptions.'),
 
 lldp_country_placeholder : T('Country Code'),
-lldp_country_tooltip: T('Required for <a href="%%docurl%%/services.html%%webversion%%#lldp"\
+lldp_country_tooltip: T('Required for <a href="%%docurl%%/services.html#lldp"\
  target="_blank">LLDP</a> location support. Enter a\
  two-letter ISO 3166 country code.'),
 

--- a/src/app/helptext/services/components/service-s3.ts
+++ b/src/app/helptext/services/components/service-s3.ts
@@ -6,7 +6,7 @@ import { matchOtherValidator } from '../../../pages/common/entity/entity-form/va
 export default {
 bindip_placeholder : T('IP Address'),
 bindip_tooltip: T('Enter the IP address which runs the <a\
- href="%%docurl%%/services.html%%webversion%%#s3" target="_blank">S3\
+ href="%%docurl%%/services.html#s3" target="_blank">S3\
  service</a>. <i>0.0.0.0</i> tells the server to listen\
  on all addresses.'),
 bindip_options : [
@@ -45,7 +45,7 @@ mode_options : [
 ],
 
 certificate_placeholder : T('Certificate'),
-certificate_tooltip : T('Add an <a href="%%docurl%%/system.html%%webversion%%#certificates"\
+certificate_tooltip : T('Add an <a href="%%docurl%%/system.html#certificates"\
  target="_blank">SSL certificate</a> to be used for\
  secure S3 connections.')
 }

--- a/src/app/helptext/services/components/service-smart.ts
+++ b/src/app/helptext/services/components/service-smart.ts
@@ -40,7 +40,7 @@ smart_critical_validation : [ Validators.required ],
 
 smart_email_placeholder : T('Email'),
 smart_email_tooltip: T('Enter an email address to receive <a\
- href="%%docurl%%/services.html%%webversion%%#s-m-a-r-t"\
+ href="%%docurl%%/services.html#s-m-a-r-t"\
  target="_blank">S.M.A.R.T.</a> alerts; use a space to \
  separate multiple email addresses.')
 }

--- a/src/app/helptext/services/components/service-smb.ts
+++ b/src/app/helptext/services/components/service-smb.ts
@@ -16,9 +16,9 @@ cifs_srv_netbiosalias_validation: [ Validators.maxLength(15) ],
 cifs_srv_workgroup_placeholder: T('Workgroup'),
 cifs_srv_workgroup_tooltip: T('Must match Windows workgroup\
  name. This setting is ignored if the\
- <a href="%%docurl%%/directoryservices.html%%webversion%%#active-directory"\
+ <a href="%%docurl%%/directoryservices.html#active-directory"\
  target="_blank">Active Directory</a> or <a\
- href="%%docurl%%/directoryservices.html%%webversion%%#ldap"\
+ href="%%docurl%%/directoryservices.html#ldap"\
  target="_blank">LDAP</a> service is running.'),
 cifs_srv_workgroup_validation : [ Validators.required ],
 
@@ -111,7 +111,7 @@ cifs_srv_obey_pam_restrictions_placeholder: T('Obey Pam Restrictions'),
 cifs_srv_obey_pam_restrictions_tooltip: T('Unselect this option to allow cross-domain\
  authentication, users and groups to be managed on\
  another forest, and permissions to be delegated from\
- <a href="%%docurl%%/directoryservices.html%%webversion%%#active-directory"\
+ <a href="%%docurl%%/directoryservices.html#active-directory"\
  target="_blank">Active Directory</a>\
  users and groups to domain admins on another forest.'),
 

--- a/src/app/helptext/services/components/service-snmp.ts
+++ b/src/app/helptext/services/components/service-snmp.ts
@@ -10,7 +10,7 @@ location_validation : [ Validators.required ],
 
 contact_placeholder : T('Contact'),
 contact_tooltip: T('Enter an email address to receive messages from the\
- <a href="%%docurl%%/services.html%%webversion%%#snmp"\
+ <a href="%%docurl%%/services.html#snmp"\
  target="_blank">SNMP service</a>.'),
 contact_validation: [Validators.required, Validators.email],
 

--- a/src/app/helptext/services/components/service-ssh.ts
+++ b/src/app/helptext/services/components/service-ssh.ts
@@ -11,7 +11,7 @@ ssh_tcpport_tooltip: 'Open a port for SSH connection requests.',
 ssh_rootlogin_placeholder : T('Log in as root with password'),
 ssh_rootlogin_tooltip: T('<b>Root logins are discouraged.</b> Set to allow root\
  logins. A password must be set for the <i>root</i>\
- user in <a href="%%docurl%%/accounts.html%%webversion%%#users"\
+ user in <a href="%%docurl%%/accounts.html#users"\
  target="_blank">Users</a>.'),
 
 ssh_passwordauth_placeholder : T('Allow password authentication'),
@@ -23,9 +23,9 @@ ssh_passwordauth_tooltip: T('Unset to require key-based authentication for\
 
 ssh_kerberosauth_placeholder : T('Allow Kerberos authentication'),
 ssh_kerberosauth_tooltip: T('Ensure <a\
- href="%%docurl%%/directoryservices.html%%webversion%%#kerberos-realms"\
+ href="%%docurl%%/directoryservices.html#kerberos-realms"\
  target="_blank">Kerberos Realms</a> and <a\
- href="%%docurl%%/directoryservices.html%%webversion%%#kerberos-keytabs"\
+ href="%%docurl%%/directoryservices.html#kerberos-keytabs"\
  target="_blank">Kerberos Keytabs</a> are configured\
  and the system can communicate with the Kerberos\
  Domain Controller before setting.'),

--- a/src/app/helptext/services/components/service-webdav.ts
+++ b/src/app/helptext/services/components/service-webdav.ts
@@ -23,7 +23,7 @@ tcpportssl_tooltip : T('Specify a port for encrypted connections. The\
  a port.'),
 
 certssl_placeholder : T('Webdav SSL Certificate'),
-certssl_tooltip : T('Select the <a href="%%docurl%%/system.html%%webversion%%#certificates"\
+certssl_tooltip : T('Select the <a href="%%docurl%%/system.html#certificates"\
  target="_blank">SSL certificate</a> to use for\
  encrypted connections.'),
 certssl_options: [

--- a/src/app/helptext/sharing/iscsi/iscsi.ts
+++ b/src/app/helptext/sharing/iscsi/iscsi.ts
@@ -51,7 +51,7 @@ export const helptext_sharing_iscsi = {
 
   portal_form_placeholder_discovery_authmethod: T("Discovery Auth Method"),
   portal_form_tooltip_discovery_authmethod: T(
-    '<a href="%%docurl%%/sharing.html%%webversion%%#block-iscsi"\
+    '<a href="%%docurl%%/sharing.html#block-iscsi"\
  target="_blank">iSCSI</a> supports multiple\
  authentication methods that are used by the target to\
  discover valid devices. <i>None</i> allows anonymous\
@@ -127,7 +127,7 @@ export const helptext_sharing_iscsi = {
     'Enter the percentage of free space to remain\
  in the pool. When this percentage is reached,\
  the system issues an alert, but only if zvols are used.\
- See <a href="%%docurl%%/vaai.html%%webversion%%#vaai"\
+ See <a href="%%docurl%%/vaai.html#vaai"\
  target="_blank">VAAI Threshold Warning</a> for more\
  information.'
   ),
@@ -200,7 +200,7 @@ export const helptext_sharing_iscsi = {
     'Only appears if a <i>File</i> or zvol is selected. When\
  the specified percentage of free space is reached,\
  the system issues an alert.\
- See <a href="%%docurl%%/vaai.html%%webversion%%#vaai"\
+ See <a href="%%docurl%%/vaai.html#vaai"\
  target="_blank">VAAI</a> Threshold Warning.'
   ),
 

--- a/src/app/helptext/sharing/smb/smb.ts
+++ b/src/app/helptext/sharing/smb/smb.ts
@@ -63,7 +63,7 @@ export const helptext_sharing_smb = {
 
     placeholder_guestok: T('Allow Guest Access'),
     tooltip_guestok: T('Set to allow access to this share without a password.\
- See the <a href="%%docurl%%/services.html%%webversion%%#smb"\
+ See the <a href="%%docurl%%/services.html#smb"\
  target="_blank">SMB</a> service documentation for more\
  information about guest user permissions.'),
 
@@ -86,7 +86,7 @@ export const helptext_sharing_smb = {
 
     placeholder_vfsobjects: T('VFS Objects'),
     tooltip_vfsobjects: T('Adds <a\
- href="%%docurl%%/sharing.html%%webversion%%#avail-vfs-modules-tab"\
+ href="%%docurl%%/sharing.html#avail-vfs-modules-tab"\
  target="blank">virtual file system modules</a> to\
  enhance functionality.'),
 

--- a/src/app/helptext/storage/disks/disk-form.ts
+++ b/src/app/helptext/storage/disks/disk-form.ts
@@ -38,11 +38,11 @@ disk_form_acousticlevel_tooltip : T('Modify for disks that understand <a\
 disk_form_togglesmart_placeholder : T('Enable S.M.A.R.T.'),
 disk_form_togglesmart_tooltip : T('Set by default if the disk supports S.M.A.R.T.\
  Unset to disable any configured <a\
- href="%%docurl%%/tasks.html%%webversion%%#s-m-a-r-t-tests"\
+ href="%%docurl%%/tasks.html#s-m-a-r-t-tests"\
  target="_blank">S.M.A.R.T. tests</a>.'),
 disk_form_bulk_edit_togglesmart_tooltip : T('Set by default if the disks support S.M.A.R.T.\
  Unset to disable any configured <a\
- href="%%docurl%%/tasks.html%%webversion%%#s-m-a-r-t-tests"\
+ href="%%docurl%%/tasks.html#s-m-a-r-t-tests"\
  target="_blank">S.M.A.R.T. tests</a>.'),
 
 disk_form_smartoptions_placeholder: T('S.M.A.R.T. extra options'),

--- a/src/app/helptext/storage/import-disk/import-disk.ts
+++ b/src/app/helptext/storage/import-disk/import-disk.ts
@@ -11,7 +11,7 @@ import_disk_volume_validation : [ Validators.required ],
 import_disk_fs_type_placeholder : T('Filesystem type'),
 import_disk_fs_type_tooltip: T('Choose the type of filesystem on the disk. Refer to\
  the guide section on <a\
- href="%%docurl%%/storage.html%%webversion%%#import-disk"\
+ href="%%docurl%%/storage.html#import-disk"\
  target="_blank">importing disks</a> for more details.'),
 import_disk_fs_type_validation : [ Validators.required ],
 

--- a/src/app/helptext/storage/volumes/datasets/dataset-form.ts
+++ b/src/app/helptext/storage/volumes/datasets/dataset-form.ts
@@ -18,7 +18,7 @@ dataset_form_sync_tooltip: T('<i>Standard</i> uses the sync settings that have b
 dataset_form_compression_placeholder: T('Compression level'),
 dataset_form_compression_tooltip: T('For more information about the available compression\
  algorithms, refer to the <a\
- href="%%docurl%%/storage.html%%webversion%%#compression"\
+ href="%%docurl%%/storage.html#compression"\
  target="_blank">Compression section</a> of the guide.'),
 
 dataset_form_atime_placeholder: T('Enable Atime'),
@@ -54,7 +54,7 @@ dataset_form_reservation_validation: [Validators.min(0)],
 
 dataset_form_deduplication_label: T('ZFS deduplication'),
 dataset_form_deduplication_placeholder: T('ZFS Deduplication'),
-dataset_form_deduplication_tooltip: T('Please read about <a href="%%docurl%%/storage.html%%webversion%%#deduplication"\
+dataset_form_deduplication_tooltip: T('Please read about <a href="%%docurl%%/storage.html#deduplication"\
  target="_blank">deduplication</a> before considering\
  changing this setting.'),
 

--- a/src/app/helptext/storage/volumes/manager/manager.ts
+++ b/src/app/helptext/storage/volumes/manager/manager.ts
@@ -24,7 +24,7 @@ manager_encryption_tooltip : T('<a href="https://www.freebsd.org/cgi/man.cgi?que
  target="_blank">GELI</a> encryption is\
  available for ZFS pools. <b>WARNING:</b>\
  Read the <a\
- href="%%docurl%%/storage.html%%webversion%%#managing-encrypted-pools"\
+ href="%%docurl%%/storage.html#managing-encrypted-pools"\
  target="_blank">Encryption section</a>\
  of the guide before activating this option.'),
 manager_suggested_layout_tooltip : T('Create a recommended formation\

--- a/src/app/helptext/storage/volumes/manager/vdev.ts
+++ b/src/app/helptext/storage/volumes/manager/vdev.ts
@@ -5,7 +5,7 @@ vdev_diskSizeErrorMsg : T('Mixing disks of different sizes in a VDEV is not reco
 vdev_type_tooltip : T('Choose a <i>Stripe</i>, <i>Mirror</i>,\
  or <i>Raid-Z</i> configuration for the\
  chosen disk layout. See the <a\
- href="%%docurl%%/storage.html%%webversion%%#pool-manager"\
+ href="%%docurl%%/storage.html#pool-manager"\
  target="_blank">Pool Manager</a> section\
  of the guide for more details.')
 }

--- a/src/app/helptext/storage/volumes/zvol-form.ts
+++ b/src/app/helptext/storage/volumes/zvol-form.ts
@@ -29,14 +29,14 @@ zvol_sync_tooltip: T('Sets the data write synchronization. <i>Inherit</i>\
 
 zvol_compression_placeholder: T('Compression level'),
 zvol_compression_tooltip: T('Automatically compress data written to the zvol.\
- Choose a <a href="%%docurl%%/storage.html%%webversion%%#compression"\
+ Choose a <a href="%%docurl%%/storage.html#compression"\
  target="_blank">compression algorithm</a>.'),
 zvol_compression_validation: [Validators.required],
 
 zvol_deduplication_placeholder: T('ZFS Deduplication'),
 zvol_deduplication_tooltip : T('Activates the process for ZFS to transparently reuse\
  a single copy of duplicated data to save space. The\
- <a href="%%docurl%%/storage.html%%webversion%%#deduplication"\
+ <a href="%%docurl%%/storage.html#deduplication"\
  target="_blank">Deduplication section</a> of the Guide\
  describes each option.'),
 zvol_deduplication_validation: [Validators.required],

--- a/src/app/helptext/system/advanced.ts
+++ b/src/app/helptext/system/advanced.ts
@@ -42,7 +42,7 @@ export const helptext_system_advanced = {
  <b>Warning:</b> Autotuning is only used as a temporary\
  measure and is not a permanent fix for system hardware\
  issues. See the\
- <a href="%%docurl%%/system.html%%webversion%%#autotune"\
+ <a href="%%docurl%%/system.html#autotune"\
  target="_blank">Autotune section</a> of the guide for\
  more information.'),
 
@@ -81,7 +81,7 @@ export const helptext_system_advanced = {
   cpu_in_percentage_placeholder: T('Report CPU usage in percentage'),
   cpu_in_percentage_tooltip: T('Set to display CPU usage as percentages in Reporting.'),
 
-  sed_options_message_paragraph: T('<b>SED (<a href="%%docurl%%/system.html%%webversion%%#self-encrypting-drives"\
+  sed_options_message_paragraph: T('<b>SED (<a href="%%docurl%%/system.html#self-encrypting-drives"\
  target="_blank">Self-Encrypting Drives</a>) Options</b>'),
 
   sed_user_placeholder: T('ATA Security User'),

--- a/src/app/helptext/system/ca.ts
+++ b/src/app/helptext/system/ca.ts
@@ -18,7 +18,7 @@ export const helptext_system_ca = {
       placeholder: T("Signing Certificate Authority"),
       tooltip: T(
         'Select a previously imported or created <a\
- href="%%docurl%%/system.html%%webversion%%#cas"\
+ href="%%docurl%%/system.html#cas"\
  target="_blank">CA</a>.'
       ),
       validation: [Validators.required]

--- a/src/app/helptext/system/certificates.ts
+++ b/src/app/helptext/system/certificates.ts
@@ -18,7 +18,7 @@ export const helptext_system_certificates = {
       placeholder: T("Signing Certificate Authority"),
       tooltip: T(
         'Select a previously imported or created <a\
- href="%%docurl%%/system.html%%webversion%%#cas"\
+ href="%%docurl%%/system.html#cas"\
  target="_blank">CA</a>.'
       ),
       validation: [Validators.required]

--- a/src/app/helptext/system/general.ts
+++ b/src/app/helptext/system/general.ts
@@ -19,9 +19,9 @@ export const helptext_system_general = {
       'Required for <i>HTTPS</i>. Browse to the location of\
  the certificate to use for encrypted connections. If\
  there are no certificates, create a <a\
- href="%%docurl%%/system.html%%webversion%%#cas"\
+ href="%%docurl%%/system.html#cas"\
  target="_blank">Certificate Authority (CA)</a> then\
- the <a href="%%docurl%%/system.html%%webversion%%#certificates"\
+ the <a href="%%docurl%%/system.html#certificates"\
  target="_blank">Certificate</a>.'
     ),
     validation: [Validators.required]

--- a/src/app/helptext/task-calendar/resync/resync-form.ts
+++ b/src/app/helptext/task-calendar/resync/resync-form.ts
@@ -25,9 +25,9 @@ export default {
 
     rsync_mode_placeholder: T('Rsync mode'),
     rsync_mode_tooltip: T('Choose <a \
-                href="%%docurl%%/tasks.html%%webversion%%#rsync-module-mode"\
+                href="%%docurl%%/tasks.html#rsync-module-mode"\
                 target="_blank">rsync module mode</a> or <a \
-                href="%%docurl%%/tasks.html%%webversion%%#rsync-over-ssh-mode"\
+                href="%%docurl%%/tasks.html#rsync-over-ssh-mode"\
                 target="_blank">rsync over SSH mode</a>'),
 
     rsync_remotemodule_placeholder: T('Remote Module Name'),

--- a/src/app/helptext/vm/devices/device-add-edit.ts
+++ b/src/app/helptext/vm/devices/device-add-edit.ts
@@ -34,7 +34,7 @@ order_tooltip : '',
 
 zvol_path_placeholder : 'Zvol',
 zvol_path_tooltip : 'Browse to an existing <a\
- href="%%docurl%%/storage.html%%webversion%%#adding-zvols"\
+ href="%%docurl%%/storage.html#adding-zvols"\
  target="_blank">Zvol</a>.',
 zvol_path_validation : [Validators.required],
 options:[],

--- a/src/app/helptext/vm/vm-cards/vm-cards.ts
+++ b/src/app/helptext/vm/vm-cards/vm-cards.ts
@@ -8,7 +8,7 @@ serial_shell_tooltip : '<b>Ctrl+C</b> kills a foreground process.<br>\
  <b>tw_cli</b>, <br><b>MegaCli</b>,\
  <b>freenas-debug</b>, <b>tmux</b>,\
  <b>Dmidecode</b>.<br> Refer to the <a\
- href="%%docurl%%/cli.html%%webversion%%"\
+ href="%%docurl%%/cli.html"\
  target="_blank">Command Line Utilities</a>\
  chapter in the <b>User Guide</b> for usage\
  information and examples.',

--- a/src/app/pages/jails/jail-shell/jail-shell.component.ts
+++ b/src/app/pages/jails/jail-shell/jail-shell.component.ts
@@ -48,7 +48,7 @@ export class JailShellComponent implements OnInit, OnChanges, OnDestroy {
                             <b>tw_cli</b>, <br><b>MegaCli</b>,\
                             <b>freenas-debug</b>, <b>tmux</b>,\
                             <b>Dmidecode</b>.<br> Refer to the <a\
-                            href="%%docurl%%/cli.html%%webversion%%"\
+                            href="%%docurl%%/cli.html"\
                             target="_blank">Command Line Utilities</a>\
                             chapter in the guide for usage information\
                             and examples.');

--- a/src/app/pages/shell/shell.component.ts
+++ b/src/app/pages/shell/shell.component.ts
@@ -47,7 +47,7 @@ export class ShellComponent implements OnInit, OnChanges, OnDestroy {
                             <b>tw_cli</b>, <br><b>MegaCli</b>,\
                             <b>freenas-debug</b>, <b>tmux</b>,\
                             <b>Dmidecode</b>.<br> Refer to the <a\
-                            href="%%docurl%%/cli.html%%webversion%%"\
+                            href="%%docurl%%/cli.html"\
                             target="_blank">Command Line Utilities</a>\
                             chapter in the guide for usage information\
                             and examples.');

--- a/src/app/pages/system/advanced/advanced.component.ts
+++ b/src/app/pages/system/advanced/advanced.component.ts
@@ -194,7 +194,7 @@ export class AdvancedComponent implements OnDestroy {
 // This tooltip wraps to the next line when uncommented.
 // Erin said it's more than likely the CSS. Commented out for now and
 // linking to the user guide from the test instead.
-//  tooltip: T('See the <a href="%%docurl%%/system.html%%webversion%%#self-encrypting-drives"\
+//  tooltip: T('See the <a href="%%docurl%%/system.html#self-encrypting-drives"\
 //                target="_blank"> Self Encrypting Drives</a> section of\
 //                the user guide for more information.'),
 //

--- a/src/app/services/docs.service.ts
+++ b/src/app/services/docs.service.ts
@@ -1,3 +1,4 @@
+
 import urls from '../helptext/urls';
 import { WebSocketService } from './ws.service';
 import {Injectable} from '@angular/core';
@@ -12,17 +13,16 @@ export class DocsService {
             const replace = new RegExp("%%" + url + "%%", "g");
             message = message.replace(replace, urls[url]);
         }
+
+        // running_version is expected to be in the form FreeNAS-11.2-U4-INTERNAL7
         const running_version = window.localStorage.getItem('running_version');
-        const web_version = "?runningversion=" + running_version;
-        const version = running_version.split('-');
+
+        // split on dashes, rejoin version number and patch level number with dash
+        // result is 11.2-U4
+        const version = running_version.split('-').slice(1,3).join('-');
+
         if (version && version.length > 1) {
-            message = message.replace(/%%version%%/g, version[1]);
-        }
-        if (web_version) {
-            message = message.replace(/%%webversion%%/g, web_version);
-        }
-        if (running_version) {
-            message = message.replace(/%%runningversion%%/g, running_version);
+            message = message.replace(/%%version%%/g, version);
         }
 
         return message;


### PR DESCRIPTION
Remove the running_version portion of the online doc URLs and simplify the version number parsing.  With this, we will have an online doc for each specific version, like 11.2-U4, rather than redirecting doc calls to the latest version of that numbered release.