### PR TITLE
Nas 101368 stable

### DIFF
--- a/src/app/helptext/system/update.ts
+++ b/src/app/helptext/system/update.ts
@@ -126,6 +126,6 @@ export const helptext_system_update = {
   },
 
   manual_update_error_dialog: {
-    message: T('Error submitting file');
+    message: T('Error submitting file')
   }
 };

--- a/src/app/helptext/system/update.ts
+++ b/src/app/helptext/system/update.ts
@@ -123,5 +123,9 @@ export const helptext_system_update = {
   snackbar_network_error: {
     message: T("Check the network connection"),
     action: T("Failed")
+  },
+
+  manual_update_error_dialog: {
+    message: T('Error submitting file');
   }
 };

--- a/src/app/pages/common/entity/entity-job/entity-job.component.ts
+++ b/src/app/pages/common/entity/entity-job/entity-job.component.ts
@@ -162,7 +162,9 @@ export class EntityJobComponent implements OnInit {
             this.wsshow();
           }
         },
-        () => {},
+        (err) => {
+          this.failure.emit(err)
+        },
         () => {
         });
   }

--- a/src/app/pages/common/entity/entity-job/entity-job.component.ts
+++ b/src/app/pages/common/entity/entity-job/entity-job.component.ts
@@ -28,6 +28,7 @@ export class EntityJobComponent implements OnInit {
   @Output() progress = new EventEmitter();
   @Output() success = new EventEmitter();
   @Output() failure = new EventEmitter();
+  @Output() prefailure = new EventEmitter();
   constructor(public dialogRef: MatDialogRef < EntityJobComponent > ,
     private ws: WebSocketService, public rest: RestService,
     @Inject(MAT_DIALOG_DATA) public data: any, translate: TranslateService, protected http: Http) {}
@@ -163,7 +164,7 @@ export class EntityJobComponent implements OnInit {
           }
         },
         (err) => {
-          this.failure.emit(err)
+          this.prefailure.emit(err)
         },
         () => {
         });

--- a/src/app/pages/system/update/manualupdate/manualupdate.component.ts
+++ b/src/app/pages/system/update/manualupdate/manualupdate.component.ts
@@ -147,11 +147,14 @@ export class ManualUpdateComponent {
           });
         };
       })
+      this.dialogRef.componentInstance.prefailure.subscribe((prefailure)=>{
+        this.dialogRef.close(false);
+        this.dialogService.errorReport("Error submitting file", `${prefailure.status.toString()} ${prefailure.statusText}`)
+      })
       this.dialogRef.componentInstance.failure.subscribe((failure)=>{
         this.dialogRef.close(false);
-        this.dialogService.errorReport("Error submitting file", `${failure.status.toString()} ${failure.statusText}`)
+        this.dialogService.errorReport(failure.error,failure.state,failure.exception)
       })
-
     })
 
 

--- a/src/app/pages/system/update/manualupdate/manualupdate.component.ts
+++ b/src/app/pages/system/update/manualupdate/manualupdate.component.ts
@@ -149,7 +149,8 @@ export class ManualUpdateComponent {
       })
       this.dialogRef.componentInstance.prefailure.subscribe((prefailure)=>{
         this.dialogRef.close(false);
-        this.dialogService.errorReport("Error submitting file", `${prefailure.status.toString()} ${prefailure.statusText}`)
+        this.dialogService.errorReport(helptext.manual_update_error_dialog.message, 
+          `${prefailure.status.toString()} ${prefailure.statusText}`)
       })
       this.dialogRef.componentInstance.failure.subscribe((failure)=>{
         this.dialogRef.close(false);

--- a/src/app/pages/system/update/manualupdate/manualupdate.component.ts
+++ b/src/app/pages/system/update/manualupdate/manualupdate.component.ts
@@ -149,7 +149,7 @@ export class ManualUpdateComponent {
       })
       this.dialogRef.componentInstance.failure.subscribe((failure)=>{
         this.dialogRef.close(false);
-        this.dialogService.errorReport(failure.error,failure.state,failure.exception)
+        this.dialogService.errorReport("Error submitting file", `${failure.status.toString()} ${failure.statusText}`)
       })
 
     })


### PR DESCRIPTION
NAS-101368
Adds new emitter to wspost method in entity-job component to send a custom fail message if the attempt to post is immediately rejected; applied in update component, where there was an issue with manual updates 'hanging'.