### PR TITLE
NAS-101524 Make sure the topmost dialog is selected for resizing

### DIFF
--- a/src/app/pages/common/error-dialog/error-dialog.component.html
+++ b/src/app/pages/common/error-dialog/error-dialog.component.html
@@ -2,14 +2,14 @@
   <mat-icon class="warning-icon">report_problem</mat-icon>
   {{ title | translate }}
 </h1>
-<div mat-dialog-content>
+<div mat-dialog-content id="md-content">
   <span [innerHTML]="message"></span>
   <div class="more-info" (click)="toggleOpen($event)" *ngIf="backtrace">
     <mat-icon *ngIf="isCloseMoreInfo">add_circle_outline</mat-icon>
     <mat-icon *ngIf="!isCloseMoreInfo">remove_circle_outline</mat-icon>
     <span>More info...</span>
   </div>
-  <div class="backtrace-panel" [ngClass]="{'open':!isCloseMoreInfo}" *ngIf="backtrace">
+  <div id="bt-panel" class="backtrace-panel" [ngClass]="{'open':!isCloseMoreInfo}" *ngIf="backtrace">
     <textarea id="bt-text"readonly matInput>Error: {{backtrace}}</textarea>
   </div>  
 </div>

--- a/src/app/pages/common/error-dialog/error-dialog.component.ts
+++ b/src/app/pages/common/error-dialog/error-dialog.component.ts
@@ -21,19 +21,19 @@ export class ErrorDialog {
   public toggleOpen (data) {
     const dialogWrapper = document.getElementById('errordialog-wrapper');
     const dialog = document.getElementsByClassName('mat-dialog-container');
-    const content = document.getElementsByClassName('mat-dialog-content');
-    const btPanel = document.getElementsByClassName('backtrace-panel');
+    const content = document.getElementById('md-content');
+    const btPanel = document.getElementById('bt-panel');
     const txtarea = document.getElementById('bt-text');
     this.isCloseMoreInfo = !this.isCloseMoreInfo;
     if (!this.isCloseMoreInfo) {
-      dialog[0].setAttribute('style','width : 800px; height: 600px');
-      content[0].setAttribute('style', 'min-height: 450px')
-      btPanel[0].setAttribute('style', 'width: 750px; max-height: 400px');
+      dialog[dialog.length-1].setAttribute('style','width : 800px; height: 600px');
+      content.setAttribute('style', 'min-height: 450px')
+      btPanel.setAttribute('style', 'width: 750px; max-height: 400px');
       txtarea.setAttribute('style', 'height: 400px')
     } else {
-      dialog[0].removeAttribute('style');
-      content[0].removeAttribute('style');
-      btPanel[0].removeAttribute('style');
+      dialog[dialog.length-1].removeAttribute('style');
+      content.removeAttribute('style');
+      btPanel.removeAttribute('style');
     }
   }
 


### PR DESCRIPTION
NAS-101524
Another fix for the resizable error dialog, this time dealing with multiple dialogs being open at once by using ids where possible, and selecting the last one in an array which is hopefully our error dialog.