### PR TITLE
NAS-101524 make sure topmost dialog is selected for resizing

### DIFF
--- a/src/app/pages/common/error-dialog/error-dialog.component.html
+++ b/src/app/pages/common/error-dialog/error-dialog.component.html
@@ -2,14 +2,14 @@
   <mat-icon class="warning-icon">report_problem</mat-icon>
   {{ title | translate }}
 </h1>
-<div mat-dialog-content>
+<div mat-dialog-content id="md-content">
   <span [innerHTML]="message"></span>
   <div class="more-info" (click)="toggleOpen($event)" *ngIf="backtrace">
     <mat-icon *ngIf="isCloseMoreInfo">add_circle_outline</mat-icon>
     <mat-icon *ngIf="!isCloseMoreInfo">remove_circle_outline</mat-icon>
     <span>More info...</span>
   </div>
-  <div class="backtrace-panel" [ngClass]="{'open':!isCloseMoreInfo}" *ngIf="backtrace">
+  <div id="bt-panel" class="backtrace-panel" [ngClass]="{'open':!isCloseMoreInfo}" *ngIf="backtrace">
     <textarea id="bt-text" readonly matInput>Error: {{backtrace}}</textarea>
   </div>  
 </div>

--- a/src/app/pages/common/error-dialog/error-dialog.component.html
+++ b/src/app/pages/common/error-dialog/error-dialog.component.html
@@ -2,15 +2,15 @@
   <mat-icon class="warning-icon">report_problem</mat-icon>
   {{ title | translate }}
 </h1>
-<div mat-dialog-content id="md-content">
-  <span [innerHTML]="message"></span>
+<div mat-dialog-content id="err-md-content">
+  <div id="err-message-wrapper"><span [innerHTML]="message"></span></div>
   <div class="more-info" (click)="toggleOpen($event)" *ngIf="backtrace">
     <mat-icon *ngIf="isCloseMoreInfo">add_circle_outline</mat-icon>
     <mat-icon *ngIf="!isCloseMoreInfo">remove_circle_outline</mat-icon>
     <span>More info...</span>
   </div>
-  <div id="bt-panel" class="backtrace-panel" [ngClass]="{'open':!isCloseMoreInfo}" *ngIf="backtrace">
-    <textarea id="bt-text" readonly matInput>Error: {{backtrace}}</textarea>
+  <div id="err-bt-panel" class="backtrace-panel" [ngClass]="{'open':!isCloseMoreInfo}" *ngIf="backtrace">
+    <textarea id="err-bt-text" readonly matInput>Error: {{backtrace}}</textarea>
   </div>  
 </div>
 <div mat-dialog-actions>

--- a/src/app/pages/common/error-dialog/error-dialog.component.html
+++ b/src/app/pages/common/error-dialog/error-dialog.component.html
@@ -1,4 +1,4 @@
-<h1 mat-dialog-title>
+<h1 mat-dialog-title id="err-title">
   <mat-icon class="warning-icon">report_problem</mat-icon>
   {{ title | translate }}
 </h1>

--- a/src/app/pages/common/error-dialog/error-dialog.component.ts
+++ b/src/app/pages/common/error-dialog/error-dialog.component.ts
@@ -1,7 +1,6 @@
-import { MatDialog, MatDialogRef } from '@angular/material';
+import { MatDialogRef } from '@angular/material';
 import { Component } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
-import { DialogService } from 'app/services';
 
 @Component({
   selector: 'error-dialog',
@@ -17,9 +16,10 @@ export class ErrorDialog {
 
   constructor(public dialogRef: MatDialogRef < ErrorDialog >, public translate: TranslateService ) {}
 
-  public toggleOpen (data) {
+  public toggleOpen () {
     const messageWrapper = document.getElementById('err-message-wrapper');
     const dialog = document.getElementsByClassName('mat-dialog-container');
+    const title = document.getElementById('err-title');
     const content = document.getElementById('err-md-content');
     const btPanel = document.getElementById('err-bt-panel');
     const txtarea = document.getElementById('err-bt-text');
@@ -27,11 +27,12 @@ export class ErrorDialog {
     this.isCloseMoreInfo = !this.isCloseMoreInfo;
     if (!this.isCloseMoreInfo) {
       dialog[dialog.length-1].setAttribute('style','width : 800px; height: 600px');
-      let titleHeight = (document.getElementById('err-message-wrapper').offsetHeight)-21;
-      if (titleHeight > 63) {
-        titleHeight = 63;
+      let errMsgHeight = (document.getElementById('err-message-wrapper').offsetHeight)-21;
+      if (errMsgHeight > 63) {
+        errMsgHeight = 63;
       };
-      const tracebackHeight = (400-titleHeight).toString() + 'px';
+      const tracebackHeight = (400-errMsgHeight).toString() + 'px';
+      title.setAttribute('style', 'height: 40px; overflow: hidden');
       content.setAttribute('style', 'height: 450px');
       messageWrapper.setAttribute('style', 'max-height: 63px; overflow: auto');
       btPanel.setAttribute('style', 'width: 750px; max-height: 400px');
@@ -39,6 +40,7 @@ export class ErrorDialog {
       txtarea.style.height = tracebackHeight;
     } else {
       dialog[dialog.length-1].removeAttribute('style');
+      title.removeAttribute('style');
       content.removeAttribute('style');
       btPanel.removeAttribute('style');
       messageWrapper.removeAttribute('style');

--- a/src/app/pages/common/error-dialog/error-dialog.component.ts
+++ b/src/app/pages/common/error-dialog/error-dialog.component.ts
@@ -1,6 +1,7 @@
 import { MatDialog, MatDialogRef } from '@angular/material';
 import { Component } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
+import { DialogService } from 'app/services';
 
 @Component({
   selector: 'error-dialog',
@@ -21,19 +22,19 @@ export class ErrorDialog {
   public toggleOpen (data) {
     const dialogWrapper = document.getElementById('errordialog-wrapper');
     const dialog = document.getElementsByClassName('mat-dialog-container');
-    const content = document.getElementsByClassName('mat-dialog-content');
-    const btPanel = document.getElementsByClassName('backtrace-panel');
+    const content = document.getElementById('md-content');
+    const btPanel = document.getElementById('bt-panel');
     const txtarea = document.getElementById('bt-text');
     this.isCloseMoreInfo = !this.isCloseMoreInfo;
     if (!this.isCloseMoreInfo) {
-      dialog[0].setAttribute('style','width : 800px; height: 600px');
-      content[0].setAttribute('style', 'min-height: 450px')
-      btPanel[0].setAttribute('style', 'width: 750px; max-height: 400px');
+      dialog[dialog.length-1].setAttribute('style','width : 800px; height: 600px');
+      content.setAttribute('style', 'min-height: 450px')
+      btPanel.setAttribute('style', 'width: 750px; max-height: 400px');
       txtarea.setAttribute('style', 'height: 400px')
     } else {
-      dialog[0].removeAttribute('style');
-      content[0].removeAttribute('style');
-      btPanel[0].removeAttribute('style');
+      dialog[dialog.length-1].removeAttribute('style');
+      content.removeAttribute('style');
+      btPanel.removeAttribute('style');
     }
   }
 

--- a/src/app/pages/common/error-dialog/error-dialog.component.ts
+++ b/src/app/pages/common/error-dialog/error-dialog.component.ts
@@ -15,26 +15,34 @@ export class ErrorDialog {
   public backtrace: string;
   public isCloseMoreInfo: Boolean = true;
 
-  constructor(public dialogRef: MatDialogRef < ErrorDialog >, public translate: TranslateService ) {
-    
-  }
+  constructor(public dialogRef: MatDialogRef < ErrorDialog >, public translate: TranslateService ) {}
 
   public toggleOpen (data) {
-    const dialogWrapper = document.getElementById('errordialog-wrapper');
+    const messageWrapper = document.getElementById('err-message-wrapper');
     const dialog = document.getElementsByClassName('mat-dialog-container');
-    const content = document.getElementById('md-content');
-    const btPanel = document.getElementById('bt-panel');
-    const txtarea = document.getElementById('bt-text');
+    const content = document.getElementById('err-md-content');
+    const btPanel = document.getElementById('err-bt-panel');
+    const txtarea = document.getElementById('err-bt-text');
+    
     this.isCloseMoreInfo = !this.isCloseMoreInfo;
     if (!this.isCloseMoreInfo) {
       dialog[dialog.length-1].setAttribute('style','width : 800px; height: 600px');
-      content.setAttribute('style', 'min-height: 450px')
+      let titleHeight = (document.getElementById('err-message-wrapper').offsetHeight)-21;
+      if (titleHeight > 63) {
+        titleHeight = 63;
+      };
+      const tracebackHeight = (400-titleHeight).toString() + 'px';
+      content.setAttribute('style', 'height: 450px');
+      messageWrapper.setAttribute('style', 'max-height: 63px; overflow: auto');
       btPanel.setAttribute('style', 'width: 750px; max-height: 400px');
-      txtarea.setAttribute('style', 'height: 400px')
+      btPanel.style.height = tracebackHeight;
+      txtarea.style.height = tracebackHeight;
     } else {
       dialog[dialog.length-1].removeAttribute('style');
       content.removeAttribute('style');
       btPanel.removeAttribute('style');
+      messageWrapper.removeAttribute('style');
+      txtarea.removeAttribute('style');
     }
   }
 


### PR DESCRIPTION
NAS-101524
Another fix for the resizable error dialog, this time dealing with multiple dialogs being open at once by using ids where possible, and selecting the last one in an array which is hopefully our error dialog.