### PR TITLE
NAS-100807 match error format on pool unlcok to msg from MW

### DIFF
--- a/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
@@ -309,7 +309,7 @@ export class VolumesListTableConfig implements InputTableConf {
           localSnackBar.open(row1.name + " has been unlocked.", 'close', { duration: 5000 });
         }, (res) => {
           localLoader.close();
-          localDialogService.errorReport(T("Error Unlocking"), res.error, res.stack);
+          localDialogService.errorReport(T("Error Unlocking"), res.error.error_message, res.error.traceback);
         });
       }
     }


### PR DESCRIPTION
NAS-100807
Re-works the err message on error dialog in Unlock Pool action to make use of MW error message (currently shows Object Object)