### PR TITLE
NAS-101541 fix text-checkbox alignment

### DIFF
--- a/src/app/pages/storage/volumes/manager/manager.component.css
+++ b/src/app/pages/storage/volumes/manager/manager.component.css
@@ -59,3 +59,7 @@ h4 {
 .vdev-h4 {
 	margin-bottom: 0;
 }
+
+#pool-manager__encryption-checkbox {
+	margin-left: 10px;
+}

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -511,10 +511,17 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
       max-height: 256px;
   }
 
+  .mat-checkbox {
+    margin: 4px;
+  }
+
+  .ngx-datatable .mat-checkbox-inner-container {
+    margin-left: 4px;
+  }
+
   .mat-checkbox-inner-container{
     width:16px;
     height:16px;
-    margin:4px;
     overflow: visible;
   }
   .mat-checkbox-ripple{


### PR DESCRIPTION
NAS-101541
Aligns checkboxes with the center of their labels rather than the baseline
Master branch also needed a little more margin on Pools Manager