### PR TITLE
NAS-101117 adjust height of input elements

### DIFF
--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -361,6 +361,7 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
 
   .mat-input-element {
     @include variable(caret-color, --fg2, $fg2, !important);
+    height: 15px !important;
   }
 
   .mat-input-element:disabled{


### PR DESCRIPTION
NAS-101117
Makes inputs 15px high (previously 14.5px on Chrome, 13.5 on FFx, which hid underscores)