### PR TITLE
NAS-100367 adjust div height in xterm

### DIFF
--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -1139,6 +1139,10 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     overflow-y: auto;
   }
 
+  .xterm-rows > div {
+    height: 15px !important;
+  }
+
   .advanced-date-picker .cron-fields .mat-select-value,
   .advanced-date-picker .cron-fields .mat-select-arrow,
   .advanced-date-picker .cron-fields .mat-form-field.mat-focused.mat-primary .mat-select-arrow  {


### PR DESCRIPTION
reduces div height for each line in xterm. An element with color looks better, works on zoom in and out, but if user adjusts font size, lines without fonts don't look great

![image](https://user-images.githubusercontent.com/9504493/59437309-56709700-8dbf-11e9-99d4-2c87ea511154.png)
