### PR TITLE
NAS-102213 reformat closed alerts, standardize terms, stop blinking

### DIFF
--- a/src/app/components/common/layouts/admin-layout/admin-layout.component.css
+++ b/src/app/components/common/layouts/admin-layout/admin-layout.component.css
@@ -1,5 +1,6 @@
 .notification-sidenav {
-	min-width: 300px;
+  min-width: 350px;
+	width: 400px;
 	max-width: 30%;
 }
 .app-logo, .app-logo-text {

--- a/src/app/components/common/notifications/notifications.component.css
+++ b/src/app/components/common/notifications/notifications.component.css
@@ -26,3 +26,7 @@ a:hover {
 .mat-list-base .mat-list-item {
     height: unset;
 }
+
+.dismissed {
+  opacity: .6;
+}

--- a/src/app/components/common/notifications/notifications.component.html
+++ b/src/app/components/common/notifications/notifications.component.html
@@ -20,11 +20,11 @@
         </div>
     </mat-list-item>
     <div class="text-center mt-1" *ngIf="notifications.length">
-      <small><a href="#" (click)="closeAll($event)">Clear All Alerts</a></small>
+      <small><a href="#" (click)="closeAll($event)">Dismiss All Alerts</a></small>
     </div>
     <mat-list-item *ngFor="let n of dismissedNotifications" class="notific-item" role="listitem">
-      <span style="font-weight: bolder;">Closed</span>
-        <div class="mat-list-text">
+      <mat-icon class="notific-icon dismissed" matTooltip="DISMISSED">check_circle</mat-icon>
+        <div class="mat-list-text dismissed">
           <h4 class="message" [innerHTML]="n.message"></h4>
           <small class="time">{{n.time_locale | date: 'E, d MMM y hh:mm:ss'}} ({{n.timezone}})</small>
           <a (click)="turnMeOn(n, $event)" class="dismiss">Re-Open</a>

--- a/src/app/components/common/notifications/notifications.component.ts
+++ b/src/app/components/common/notifications/notifications.component.ts
@@ -1,39 +1,28 @@
-import { RestService } from '../../../services';
-import { Component, OnInit, ViewChild, Input, AfterViewInit, OnDestroy } from '@angular/core';
-import { MatSidenav } from '@angular/material';
-import { Router, NavigationEnd } from '@angular/router';
-import { TopbarComponent } from '../topbar/topbar.component';
+import { Component, OnInit, Input } from '@angular/core';
 import { NotificationsService, NotificationAlert } from 'app/services/notifications.service';
-
-
 
 @Component({
   selector: 'app-notifications',
   templateUrl: './notifications.component.html',
   styleUrls: ['./notifications.component.css']
 })
-export class NotificationsComponent implements OnInit, OnDestroy {
-  
+export class NotificationsComponent implements OnInit {
+
   @Input() notificPanel;
 
   notifications: Array<NotificationAlert> = [];
   dismissedNotifications: Array<NotificationAlert> = []
 
-  constructor(private notificationsService: NotificationsService, private router: Router) { 
+  constructor(private notificationsService: NotificationsService) {
   }
-
-  ngOnDestroy(): void {
-    
-  }
- 
 
   ngOnInit() {
     this.initData();
-    
+
     this.notificationsService.getNotifications().subscribe((notifications)=>{
       this.notifications = [];
       this.dismissedNotifications = [];
-      
+
       setTimeout(()=>{
         notifications.forEach((notification: NotificationAlert) => {
           if (notification.dismissed === false) {
@@ -42,7 +31,6 @@ export class NotificationsComponent implements OnInit, OnDestroy {
             this.dismissedNotifications.push(notification);
           }
         });
-    
       }, -1);
     });
   }


### PR DESCRIPTION
NAS-102213
Adds a check-circle icon to closed alerts and makes the alert text and icon a little opaque; makes 'Dismiss' the standard verb, sets width of the alert sidenav to prevent 'blinking' effect on refresh; gets rid of some unused code in notifications component.