### PR TITLE
NAS-102339 remove old elements from theme page

### DIFF
--- a/src/app/pages/preferences/page/forms/customtheme/customtheme.component.ts
+++ b/src/app/pages/preferences/page/forms/customtheme/customtheme.component.ts
@@ -1,5 +1,4 @@
-import { ApplicationRef, Input, Output, EventEmitter, Component, Injector, OnInit, ViewContainerRef, OnChanges, OnDestroy } from '@angular/core';
-import { NgModel }   from '@angular/forms';
+import { ApplicationRef, Component, Injector, OnInit, OnChanges, OnDestroy } from '@angular/core';
 import {Router} from '@angular/router';
 import * as _ from 'lodash';
 import { FieldConfig } from 'app/pages/common/entity/entity-form/models/field-config.interface';
@@ -9,7 +8,7 @@ import {RestService, WebSocketService} from 'app/services/';
 import { ThemeService, Theme } from 'app/services/theme/theme.service';
 import { CoreEvent, CoreService } from 'app/core/services/core.service';
 import { Subject } from 'rxjs';
-import { MatDialog, MatDialogRef, MatSnackBar } from '@angular/material';
+import { MatDialog } from '@angular/material';
 import { DialogService } from 'app/services/dialog.service';
 import { T } from 'app/translate-marker';
 
@@ -41,7 +40,7 @@ export class CustomThemeComponent implements OnInit, OnChanges, OnDestroy {
     description:'',
     label:'',
     labelSwatch:'',
-    hasDarkLogo:true,
+    hasDarkLogo:false,
     accentColors:['violet','blue','magenta', 'cyan', 'red','green', 'orange', 'yellow'],
     favorite:false,
     primary:"",
@@ -111,35 +110,13 @@ export class CustomThemeComponent implements OnInit, OnChanges, OnDestroy {
           placeholder: 'Menu Label',
           required:true,
           tooltip: 'Enter a short name for the theme. The Menu Label is \
-                    shown when the theme is registered in the Favorites \
-                    menu.',
-        },
-        {
-          type: 'select',
-          name: 'labelSwatch',
-          width:'100%',
-          placeholder: 'Menu Swatch',
-          required:true,
-          options:this.colorOptions,
-          tooltip: "Choose the color to display next to the Menu Label \
-                    in the Favorites menu.",
-          class:'inline'
+                    shown when the theme is listed in Preferences.'
         },
         { type: 'input',
           name : 'description',
           width:'100%',
           placeholder : 'Description',
           tooltip: 'Enter a short description of the theme.',
-        },
-        {
-          type: 'checkbox',
-          name: 'favorite',
-          width:'100%',
-          placeholder: 'Add to Favorites',
-          tooltip: 'Set to add this theme to the favorites list. \
-                    Favorites are always available on the top navigation \
-                    bar.',
-          class:'inline'
         },
         {
           type: 'checkbox',
@@ -422,7 +399,7 @@ export class CustomThemeComponent implements OnInit, OnChanges, OnDestroy {
           case "FormSubmitted":
             let valid:boolean = this.validateForm(evt.data);
              if(valid){
-              evt.data.labelSwatch = evt.data.labelSwatch.slice(6, -1);
+              evt.data.labelSwatch = evt.data.primary.slice(6, -1);
               evt.data.accentColors = ['blue', 'orange','green', 'violet','cyan', 'magenta', 'yellow','red'];
               this.core.emit({name:"AddCustomThemePreference",data:evt.data});
               this.globalPreview = false;


### PR DESCRIPTION
NAS-102339 - removes from Theme creator the fields for label swatch and Add to Favorites; Automatically sets and saves primary color as swatch (for use in the future), removes default check from Enable Dark Logo, removes some used code