### PR TITLE
NAS-102488

### DIFF
--- a/src/app/helptext/system/support.ts
+++ b/src/app/helptext/system/support.ts
@@ -94,7 +94,7 @@ export const helptext_system_support = {
   },
 
   screenshot: {
-  placeholder: T( "Attach screenshot(s)."),
+  placeholder: T( "Attach screenshots."),
   tooltip: T( "Select one or more screenshots that illustrate the problem.")
   },
 

--- a/src/app/pages/system/support/support.component.ts
+++ b/src/app/pages/system/support/support.component.ts
@@ -1,6 +1,5 @@
 import { ApplicationRef, Component, Injector } from '@angular/core';
 import { MatDialog } from '@angular/material';
-import { DomSanitizer } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 import * as _ from 'lodash';
 import { RestService, WebSocketService } from '../../../services/';
@@ -99,15 +98,15 @@ export class SupportComponent {
         {
           type: 'paragraph',
           name: 'support_text',
-          paraText: this.sanitizer.bypassSecurityTrustHtml(
+          paraText: 
             'Search the <a href="https://jira.ixsystems.com/projects/NAS/issues/" \
-              target="_blank" style="text-decoration:underline;">FreeNAS issue tracker</a> \
+              target="_blank">FreeNAS issue tracker</a> \
               to ensure the issue has not already been reported before \
               filing a bug report or feature request. If an issue has \
               already been created, add a comment to the existing issue. \
-              Please visit the <a href="http://www.ixsystems.com/storage/" target="_blank" \
-              style="text-decoration:underline;">iXsystems storage page</a> \
-              for enterprise-grade storage solutions and support.')
+              Please visit the <a href="http://www.ixsystems.com/storage/" target="_blank"> \
+              iXsystems storage page</a> \
+              for enterprise-grade storage solutions and support.'
         }
       ]
     },
@@ -164,9 +163,9 @@ export class SupportComponent {
         {
           type: 'paragraph',
           name: 'FN_jira-info',
-          paraText: this.sanitizer.bypassSecurityTrustHtml('<a href="https://jira.ixsystems.com/secure/Signup!default.jspa" target="_blank" \
-          style="text-decoration:underline;">Create a Jira account</a> to file an issue. Use a valid \
-          email address when registering to receive issue status updates.')
+          paraText: '<a href="https://jira.ixsystems.com/secure/Signup!default.jspa" target="_blank">\
+          Create a Jira account</a> to file an issue. Use a valid \
+          email address when registering to receive issue status updates.'
         },
         {
           type : 'input',
@@ -364,7 +363,7 @@ export class SupportComponent {
   constructor(protected router: Router, protected rest: RestService,
               protected ws: WebSocketService, protected _injector: Injector,
               protected _appRef: ApplicationRef, protected dialog: MatDialog,
-              private sanitizer: DomSanitizer, protected dialogService: DialogService,
+              protected dialogService: DialogService,
               public loader: AppLoaderService, private snackbar: SnackbarService)
               {}
 

--- a/src/app/pages/system/support/support.component.ts
+++ b/src/app/pages/system/support/support.component.ts
@@ -543,7 +543,6 @@ export class SupportComponent {
     dialogRef.componentInstance.setCall('support.new_ticket', [this.payload]);
     dialogRef.componentInstance.submit();
     dialogRef.componentInstance.success.subscribe(res=>{
-      console.log(res)
       if (res.result) {
         url = `<a href="${res.result.url}" target="_blank" style="text-decoration:underline;">${res.result.url}</a>`;
       }

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -1318,4 +1318,8 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     //overflow: hidden; // This clips tooltips
   }
 
+  app-support a {
+    text-decoration: underline;
+  }
+
  } // end of ix theme


### PR DESCRIPTION
Removes DOM Sanitizer bypass from support page and adds underline via CSS.
This bypass, along with recently added (to Paratext) docurl and translate filters, was keeping paratexts from loading on this page. Angular docs say that using the bypass should be rare. I tested this branch on a hotpatch to my mini as well as in VM, and all links continue to work with no errors. This is the only use I found of the bypass in paratext anywhere in the UI.