### PR TITLE
NAS-102385 fix display of code in naming schema tooltip

### DIFF
--- a/src/app/helptext/task-calendar/snapshot/snapshot-form.ts
+++ b/src/app/helptext/task-calendar/snapshot/snapshot-form.ts
@@ -22,7 +22,7 @@ export default {
  been replicated to other systems are not affected.'),
 
     naming_schema_placeholder: T('Naming Schema'),
-    naming_schema_tooltip: T('Snapshot name format string. The default is <i>snap-%Y-%m-%d-%H-%M</i>.\
+    naming_schema_tooltip: T('Snapshot name format string. The default is <i><textarea disabled>snap-%Y-%m-%d-%H-%M</textarea></i>.\
  Must include the strings <i>%Y</i>, <i>%m</i>, <i>%d</i>, <i>%H</i>, and <i>%M</i>, which are replaced with the four-digit year,\
  month, day of month, hour, and minute as defined in <a href="https://www.freebsd.org/cgi/man.cgi?query=strftime" target="_blank">strftime(3)</a>. A string showing the snapshot\
  lifetime is appended to the name. For example, snapshots of <i>pool1</i> with a Naming Schema of\


### PR DESCRIPTION
I grepped through the code looking for other occurrences of this and found no likely places. If you happen to know of any, let's fix them.

![Screenshot from 2019-07-11 09-34-27](https://user-images.githubusercontent.com/9504493/61055323-37195980-a3bf-11e9-80fb-00c36d988d30.png)
