### PR TITLE
NAS-102600 Make tab nav bar on iSCSI page wrap on narrow windows

### DIFF
--- a/src/app/pages/common/entity/entity-table/entity-table.component.scss
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.scss
@@ -72,8 +72,9 @@
 }
 
 #filter .mat-icon{
-  position:absolute;
-  top:24px;
+  position:relative;
+  left:25px;
+  top: 8px;
 }
 
 #filter .mat-form-field{
@@ -118,6 +119,23 @@
 :host {
     ::ng-deep datatable-row-wrapper {
         width: auto;
+    }
+}
+
+
+.entity-table-controls {
+    width: 460px;
+    min-width: 460px;
+}
+
+@media (max-width: 600px) {
+    .entity-table-controls {
+        width: 300px;
+        min-width: 300px;
+        
+        button, #filter {
+        margin-bottom: 5px;
+        }
     }
 }
 

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -1349,4 +1349,12 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     opacity: 0.38;
   }
 
+  iscsi .mat-tab-links {
+    flex-wrap: wrap;
+  }
+
+
+
+
+
  } // end of ix theme


### PR DESCRIPTION
Gets tab nav to wrap in iscsi component. This is not an issue in services-rsync component, the only other place where this seems to be used. Also fixes layout issues with the entity table filter and buttons on smaller viewports.