### PR TITLE
NAS-102640

### DIFF
--- a/src/app/pages/common/entity/entity-table/entity-table.component.html
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.html
@@ -279,29 +279,25 @@
         </ng-template>
       </ngx-datatable-column>
 
-      <!-- detail toggle -->
-      <ngx-datatable-column *ngIf="hasDetails()"
-        [width]="50"
+      <!-- detail toggle / three-dot menu -->
+      <ngx-datatable-column
+        [width]="60"
         [resizeable]="false"
         [sortable]="false"
         [draggable]="false"
         [canAutoResize]="false">
         <ng-template let-row="row" let-expanded="expanded" ngx-datatable-cell-template>
           <a
+            *ngIf="hasDetails(); else threeDot"
             href="javascript:void(0)"
             [class.datatable-icon-right]="!expanded"
             [class.datatable-icon-down]="expanded"
             title="Expand/Collapse Row"
             (click)="toggleExpandRow(row)">
           </a>
-        </ng-template>
-      </ngx-datatable-column>
-
-      <!-- three-dot actions menu -->
-      <ngx-datatable-column *ngIf="!hasDetails()">
-        <ng-template let-row="row" ngx-datatable-cell-template>
-          <app-entity-table-actions [entity]="this" [row]="row">
-          </app-entity-table-actions>
+          <ng-template #threeDot>
+            <app-entity-table-actions [entity]="this" [row]="row"></app-entity-table-actions>
+          </ng-template>
         </ng-template>
       </ngx-datatable-column>
     </ngx-datatable>

--- a/src/app/pages/common/entity/entity-table/entity-table.component.ts
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.ts
@@ -229,27 +229,26 @@ export class EntityTableComponent implements OnInit, AfterViewInit, OnDestroy {
     }
 
     // Get preferred list of columns from pref service
-    setTimeout(() => {
-      const preferredCols = this.prefService.preferences.tableDisplayedColumns;
+    const preferredCols = this.prefService.preferences.tableDisplayedColumns;
 
-      // No preferences set for any table, show 'default' configuration
-      if (preferredCols.length === 0) {
-        this.conf.columns = this.originalConfColumns;  
-      } else {
-        preferredCols.forEach((i) => {
-          let match = 0;
-          // If preferred columns have been set for THIS table...
-          if (i.title === this.title) {
-            this.conf.columns = i.cols;
-            match++;
-          }
-          // If no preferred columns for THIS table, show 'default' configuration
-          if (match === 0) {
-            this.conf.columns = this.originalConfColumns;
-          }
-        });
-      }
-    }, this.prefService.preferences.tableDisplayedColumns.length === 0 ? 1500 : 0);
+    // No preferences set for any table, show 'default' configuration
+    if (preferredCols.length === 0) {
+      this.conf.columns = this.originalConfColumns;  
+    } else {
+      preferredCols.forEach((i) => {
+        let match = 0;
+        // If preferred columns have been set for THIS table...
+        if (i.title === this.title) {
+          this.conf.columns = i.cols;
+          match++;
+        }
+        // If no preferred columns for THIS table, show 'default' configuration
+        if (match === 0) {
+          this.conf.columns = this.originalConfColumns;
+        }
+      });
+    }
+
 
     this.displayedColumns.push("action");
     if (this.conf.changeEvent) {


### PR DESCRIPTION
* removes setTimeout in entity-table which was causing some tables to not render actions
* note that ive moved the three dot and expand panel arrow button into the same fixed-width column. Are there drawbacks to this approach? Seems like a simple fix to the "action column too wide" tickets.