### PR TITLE
NAS-102635

### DIFF
--- a/src/app/pages/task-calendar/cloudsync/cloudsync-form/cloudsync-form.component.ts
+++ b/src/app/pages/task-calendar/cloudsync/cloudsync-form/cloudsync-form.component.ts
@@ -97,6 +97,7 @@ export class CloudsyncFormComponent implements OnInit {
     placeholder: helptext.folder_placeholder,
     tooltip: helptext.folder_tooltip,
     initial: '/',
+    value: '/',
     explorerType: 'directory',
     customTemplateStringOptions: {
       displayField: 'Path',


### PR DESCRIPTION
* After user selects a "Credential," the destination folder will default to '/'
* Need to be sure this is the default behavior we're looking for.

Difference in default API message to `cloudsync.create`:
```
{
  ...
  attributes: {}
}
```

becomes

```
{
  ...
  attributes: { folder: '/' }
}
```