### PR TITLE
NAS-101749 -- general layout updates to ACL manager form

### DIFF
--- a/src/app/helptext/storage/volumes/datasets/dataset-acl.ts
+++ b/src/app/helptext/storage/volumes/datasets/dataset-acl.ts
@@ -1,7 +1,10 @@
 import { T } from '../../../../translate-marker';
 
 export default {
-dataset_acl_title_name: T('ACL Manager'),
+dataset_acl_title_file: T('File Information'),
+dataset_acl_title_list: T('Access Control List'),
+dataset_acl_title_advanced: T('Advanced'),
+
 dataset_acl_path_placeholder: T('Path'),
 
 dataset_acl_aces_placeholder: T('Access Control Entries'),

--- a/src/app/helptext/storage/volumes/datasets/dataset-acl.ts
+++ b/src/app/helptext/storage/volumes/datasets/dataset-acl.ts
@@ -9,7 +9,7 @@ dataset_acl_path_placeholder: T('Path'),
 
 dataset_acl_aces_placeholder: T('Access Control Entries'),
 
-dataset_acl_tag_placeholder: T('Tag'),
+dataset_acl_tag_placeholder: T('Who'),
 dataset_acl_tag_tooltip: T('Access Control Entry (ACE) user or group.\
  Select a specific <i>User</i> or <i>Group</i> for this entry,\
  <i>owner@</i> to apply this entry to the user that owns the dataset,\

--- a/src/app/helptext/storage/volumes/datasets/dataset-acl.ts
+++ b/src/app/helptext/storage/volumes/datasets/dataset-acl.ts
@@ -25,8 +25,8 @@ dataset_acl_tag_options: [
                          ],
 
 dataset_acl_type_placeholder: T('ACL Type'),
-dataset_acl_type_tooltip: T('How the <b>Permissions</b> are applied to\
- the chosen <b>Tag</b>. Choose <i>Allow</i> to grant the specified\
+dataset_acl_type_tooltip: T('How the <i>Permissions</i> are applied to\
+ the chosen <i>Who</>. Choose <i>Allow</i> to grant the specified\
  permissions and <i>Deny</i> to restrict the specified permissions.'),
 dataset_acl_type_options: [
                            {label: 'Allow', value: 'ALLOW'},
@@ -57,13 +57,13 @@ dataset_acl_uid_tooltip: T('User who controls the dataset. This user\
 
 dataset_acl_gid_placeholder: T('Group'),
 dataset_acl_gid_tooltip: T('The group which controls the dataset. This\
- group has whatever permissions are granted to the <i>@group</i>\
- <b>Tag</b>. Groups created manually or imported from a directory\
+ group has the same permissions as granted to the <i>group@</i>\
+ <i>Who</i>. Groups created manually or imported from a directory\
  service appear in the drop-down menu.'),
 
 dataset_acl_perms_placeholder: T('Permissions'),
 dataset_acl_perms_tooltip: T('Select permissions to apply to the chosen\
- <b>Tag</b>. Choices change depending on the <b>Permissions Type</b>.\
+ <i>Who</i>. Choices change depending on the <i>Permissions Type</i>.\
  See the\
  <a href="--docurl--/storage.html#ace-permissions" target="_blank">ACL permissions list</a>\
  for descriptions of each permission.'),
@@ -96,7 +96,7 @@ dataset_acl_advanced_perms_options: [
 
 dataset_acl_flags_type_placeholder: T('Flags Type'),
 dataset_acl_flags_type_tooltip: T('Select the set of ACE inheritance\
- <b>Flags</b> to display. <i>Basic</i> shows unspecific inheritance\
+ <i>Flags</i> to display. <i>Basic</i> shows nonspecific inheritance\
  options. <i>Advanced</i> shows specific inheritance settings for finer\
  control.'),
 dataset_acl_flags_type_options: [

--- a/src/app/pages/common/entity/entity-form/entity-form.component.scss
+++ b/src/app/pages/common/entity/entity-form/entity-form.component.scss
@@ -34,6 +34,9 @@
     margin-left: 1px;
 }
 
+:host .dataset-acl-editor {
+  margin-right: 16px !important;
+}
 
 /* Imported from embedded */
 /* Embedded Form Styles */

--- a/src/app/pages/storage/volumes/datasets/dataset-acl/dataset-acl.component.ts
+++ b/src/app/pages/storage/volumes/datasets/dataset-acl/dataset-acl.component.ts
@@ -47,7 +47,6 @@ export class DatasetAclComponent implements OnDestroy {
   private aces_fc: any;
   private aces_subscription: any;
   private entityForm: any;
-  private acl: any;
   public sub: Subscription;
   public formGroup: FormGroup;
   public data: Object = {};
@@ -60,175 +59,202 @@ export class DatasetAclComponent implements OnDestroy {
 
   public fieldSetDisplay  = 'default';//default | carousel | stepper
   public fieldConfig: FieldConfig[] = [];
-  public fieldSets: FieldSet[] = [{
-    name: helptext.dataset_acl_title_name,
-    class: "dataset-acl-editor",
-    label: true,
-    config:[
+  public fieldSets: FieldSet[] = [
     {
-      type: 'input',
-      name : 'path',
-      placeholder : helptext.dataset_acl_path_placeholder,
-      readonly: true
-    },
-    {
-      type: 'combobox',
-      name: 'uid',
-      placeholder: helptext.dataset_acl_uid_placeholder,
-      tooltip: helptext.dataset_acl_uid_tooltip,
-      updateLocal: true,
-      options: [],
-      searchOptions: [],
-      parent: this,
-      updater: this.updateUserSearchOptions,
-    },
-    {
-      type: 'combobox',
-      name: 'gid',
-      placeholder: helptext.dataset_acl_gid_placeholder,
-      tooltip: helptext.dataset_acl_gid_tooltip,
-      updateLocal: true,
-      options: [],
-      searchOptions: [],
-      parent: this,
-      updater: this.updateGroupSearchOptions,
-    },
-    {
-      type: 'list',
-      name: 'aces',
-      width: '100%',
-      placeholder: helptext.dataset_acl_aces_placeholder,
-      templateListField: [
+      name: helptext.dataset_acl_title_file,
+      class: "dataset-acl-editor",
+      label: true,
+      width: '50%',
+      config:[
         {
-          type: 'select',
-          name: 'tag',
-          placeholder: helptext.dataset_acl_tag_placeholder,
-          options: helptext.dataset_acl_tag_options,
-          tooltip: helptext.dataset_acl_tag_tooltip,
-          required: true,
+          type: 'input',
+          name : 'path',
+          class: 'hello-mom',
+          placeholder : helptext.dataset_acl_path_placeholder,
+          readonly: true
         },
         {
           type: 'combobox',
-          name: 'user',
-          placeholder: helptext.dataset_acl_user_placeholder,
-          tooltip: helptext.dataset_acl_user_tooltip,
+          name: 'uid',
+          width: '100%',
+          placeholder: helptext.dataset_acl_uid_placeholder,
+          tooltip: helptext.dataset_acl_uid_tooltip,
           updateLocal: true,
           options: [],
           searchOptions: [],
           parent: this,
           updater: this.updateUserSearchOptions,
-          isHidden: true,
-          required: true,
         },
         {
           type: 'combobox',
-          name: 'group',
-          placeholder: helptext.dataset_acl_group_placeholder,
-          tooltip: helptext.dataset_acl_group_tooltip,
+          name: 'gid',
+          placeholder: helptext.dataset_acl_gid_placeholder,
+          tooltip: helptext.dataset_acl_gid_tooltip,
           updateLocal: true,
           options: [],
           searchOptions: [],
           parent: this,
           updater: this.updateGroupSearchOptions,
-          isHidden: true,
-          required: true,
-        },
-        {
-          type: 'select',
-          name: 'type',
-          placeholder: helptext.dataset_acl_type_placeholder,
-          tooltip: helptext.dataset_acl_type_tooltip,
-          options: helptext.dataset_acl_type_options,
-          required: true,
-        },
-        {
-          type: 'select',
-          name: 'perms_type',
-          required: true,
-          placeholder: helptext.dataset_acl_perms_type_placeholder,
-          tooltip: helptext.dataset_acl_perms_type_tooltip,
-          options: helptext.dataset_acl_perms_type_options,
-          value: 'BASIC'
-        },
-        {
-          type: 'select',
-          name: 'basic_perms',
-          required: true,
-          placeholder: helptext.dataset_acl_perms_placeholder,
-          tooltip: helptext.dataset_acl_perms_tooltip,
-          options: helptext.dataset_acl_basic_perms_options,
-        },
-        {
-          type: 'select',
-          multiple: true,
-          isHidden: true,
-          required: true,
-          name: 'advanced_perms',
-          placeholder: helptext.dataset_acl_perms_placeholder,
-          tooltip: helptext.dataset_acl_perms_tooltip,
-          options: helptext.dataset_acl_advanced_perms_options,
-        },
-        {
-          type: 'select',
-          name: 'flags_type',
-          required: true,
-          placeholder: helptext.dataset_acl_flags_type_placeholder,
-          tooltip: helptext.dataset_acl_flags_type_tooltip,
-          options: helptext.dataset_acl_flags_type_options,
-        },
-        {
-          type: 'select',
-          name: 'basic_flags',
-          required: true,
-          isHidden: true,
-          placeholder: helptext.dataset_acl_flags_placeholder,
-          tooltip: helptext.dataset_acl_flags_tooltip,
-          options: helptext.dataset_acl_basic_flags_options,
-        },
-        {
-          type: 'select',
-          multiple: true,
-          isHidden: true,
-          required: true,
-          name: 'advanced_flags',
-          placeholder: helptext.dataset_acl_flags_placeholder,
-          tooltip: helptext.dataset_acl_flags_tooltip,
-          options: helptext.dataset_acl_advanced_flags_options,
         }
-      ],
-      listFields: []
+      ]
     },
     {
-      type: 'checkbox',
-      name: 'recursive',
-      placeholder: helptext.dataset_acl_recursive_placeholder,
-      tooltip: helptext.dataset_acl_recursive_tooltip,
-      value: false
+      name: helptext.dataset_acl_title_list,
+      label: true,
+      width: '50%',
+      config: [
+        {
+          type: 'list',
+          name: 'aces',
+          width: '100%',
+          placeholder: helptext.dataset_acl_aces_placeholder,
+          templateListField: [
+            {
+              type: 'select',
+              name: 'tag',
+              placeholder: helptext.dataset_acl_tag_placeholder,
+              options: helptext.dataset_acl_tag_options,
+              tooltip: helptext.dataset_acl_tag_tooltip,
+              required: true,
+            },
+            {
+              type: 'combobox',
+              name: 'user',
+              placeholder: helptext.dataset_acl_user_placeholder,
+              tooltip: helptext.dataset_acl_user_tooltip,
+              updateLocal: true,
+              options: [],
+              searchOptions: [],
+              parent: this,
+              updater: this.updateUserSearchOptions,
+              isHidden: true,
+              required: true,
+            },
+            {
+              type: 'combobox',
+              name: 'group',
+              placeholder: helptext.dataset_acl_group_placeholder,
+              tooltip: helptext.dataset_acl_group_tooltip,
+              updateLocal: true,
+              options: [],
+              searchOptions: [],
+              parent: this,
+              updater: this.updateGroupSearchOptions,
+              isHidden: true,
+              required: true,
+            },
+            {
+              type: 'select',
+              name: 'type',
+              placeholder: helptext.dataset_acl_type_placeholder,
+              tooltip: helptext.dataset_acl_type_tooltip,
+              options: helptext.dataset_acl_type_options,
+              required: true,
+            },
+            {
+              type: 'select',
+              name: 'perms_type',
+              required: true,
+              placeholder: helptext.dataset_acl_perms_type_placeholder,
+              tooltip: helptext.dataset_acl_perms_type_tooltip,
+              options: helptext.dataset_acl_perms_type_options,
+              value: 'BASIC'
+            },
+            {
+              type: 'select',
+              name: 'basic_perms',
+              required: true,
+              placeholder: helptext.dataset_acl_perms_placeholder,
+              tooltip: helptext.dataset_acl_perms_tooltip,
+              options: helptext.dataset_acl_basic_perms_options,
+            },
+            {
+              type: 'select',
+              multiple: true,
+              isHidden: true,
+              required: true,
+              name: 'advanced_perms',
+              placeholder: helptext.dataset_acl_perms_placeholder,
+              tooltip: helptext.dataset_acl_perms_tooltip,
+              options: helptext.dataset_acl_advanced_perms_options,
+            },
+            {
+              type: 'select',
+              name: 'flags_type',
+              required: true,
+              placeholder: helptext.dataset_acl_flags_type_placeholder,
+              tooltip: helptext.dataset_acl_flags_type_tooltip,
+              options: helptext.dataset_acl_flags_type_options,
+            },
+            {
+              type: 'select',
+              name: 'basic_flags',
+              required: true,
+              isHidden: true,
+              placeholder: helptext.dataset_acl_flags_placeholder,
+              tooltip: helptext.dataset_acl_flags_tooltip,
+              options: helptext.dataset_acl_basic_flags_options,
+            },
+            {
+              type: 'select',
+              multiple: true,
+              isHidden: true,
+              required: true,
+              name: 'advanced_flags',
+              placeholder: helptext.dataset_acl_flags_placeholder,
+              tooltip: helptext.dataset_acl_flags_tooltip,
+              options: helptext.dataset_acl_advanced_flags_options,
+            }
+          ],
+          listFields: []
+        }
+      ]
     },
     {
-      type: 'checkbox',
-      name: 'traverse',
-      placeholder: helptext.dataset_acl_traverse_placeholder,
-      tooltip: helptext.dataset_acl_traverse_tooltip,
-      value: false,
-      isHidden: true,
-      disabled: true,
-      relation: [{
-        action: 'HIDE',
-        when: [{
+      name: 'divider',
+      divider: true
+    },
+    {
+      name: helptext.dataset_acl_title_advanced,
+      label: true,
+      width: '100%',
+      config: [
+        {
+          type: 'checkbox',
           name: 'recursive',
+          placeholder: helptext.dataset_acl_recursive_placeholder,
+          tooltip: helptext.dataset_acl_recursive_tooltip,
+          value: false
+        },
+        {
+          type: 'checkbox',
+          name: 'traverse',
+          placeholder: helptext.dataset_acl_traverse_placeholder,
+          tooltip: helptext.dataset_acl_traverse_tooltip,
           value: false,
-        }]
-      }],
+          isHidden: true,
+          disabled: true,
+          relation: [{
+            action: 'HIDE',
+            when: [{
+              name: 'recursive',
+              value: false,
+            }]
+          }],
+        },
+        {
+          type: 'checkbox',
+          name: 'stripacl',
+          placeholder: helptext.dataset_acl_stripacl_placeholder,
+          tooltip: helptext.dataset_acl_stripacl_tooltip,
+          value: false,
+        }
+      ]
     },
     {
-      type: 'checkbox',
-      name: 'stripacl',
-      placeholder: helptext.dataset_acl_stripacl_placeholder,
-      tooltip: helptext.dataset_acl_stripacl_tooltip,
-      value: false,
-    }
-  ]}
+      name: 'divider',
+      divider: true
+    },
   ];
 
   constructor(protected router: Router, protected route: ActivatedRoute,


### PR DESCRIPTION
* Adds headings to form sections: "File Information," "Access Control List," and "Advanced"
* Moves ACL to the right of the file information, saving a bit of vertical space (at the expense of some horizontal space that appeared unused)
* Renames "Tag" field in ACL to "Who"