### PR TITLE
NAS-102155 

### DIFF
--- a/src/app/helptext/task-calendar/replication/replication.ts
+++ b/src/app/helptext/task-calendar/replication/replication.ts
@@ -46,7 +46,7 @@ export default {
 
     target_dataset_placeholder: T('Target Dataset'),
     target_dataset_tooltip: T('Enter the dataset on the remote or destination system where\
-snapshots will be stored. Example: Poolname/Datasetname, not the mountpoint or filesystem path'),
+ snapshots will be stored. Example: Poolname/Datasetname, not the mountpoint or filesystem path'),
 
     recursive_placeholder: T('Recursive'),
     recursive_tooltip: T('Replicate all child dataset snapshots.'),

--- a/src/app/helptext/task-calendar/replication/replication.ts
+++ b/src/app/helptext/task-calendar/replication/replication.ts
@@ -46,7 +46,7 @@ export default {
 
     target_dataset_placeholder: T('Target Dataset'),
     target_dataset_tooltip: T('Enter the dataset on the remote or destination system where\
- snapshots will be stored. Example: Poolname/Datasetname, not the mountpoint or filesystem path'),
+ snapshots will be stored. Example: Poolname/Datasetname, not the mountpoint or filesystem path.'),
 
     recursive_placeholder: T('Recursive'),
     recursive_tooltip: T('Replicate all child dataset snapshots.'),

--- a/src/app/pages/common/entity/entity-table/entity-table-row-details/entity-table-row-details.component.html
+++ b/src/app/pages/common/entity/entity-table/entity-table-row-details/entity-table-row-details.component.html
@@ -7,15 +7,16 @@
         <h4>{{ column.name }}:</h4>
         <div
             fxLayoutAlign="start center"
-            fxLayoutGap="8px"
+            fxLayoutGap="4px"
         >
             <ng-container *ngIf="column?.widget?.component">
                 <mat-icon
-                    [style.cursor]="'pointer'"
+                    class="widget-icon"
                     [matMenuTriggerFor]="widget"
-                >
-                    {{ column.widget.icon }}
-                </mat-icon>
+                    role="img"
+                    fontSet="mdi-set"
+                    fontIcon="mdi-{{ column.widget.icon }}"
+                ></mat-icon>
                 <mat-menu #widget="matMenu">
                     <!-- column widgets need to be registered with this switch case -->
                     <ng-container [ngSwitch]="column.widget.component">
@@ -42,6 +43,7 @@
 >
     <ng-container *ngFor="let action of actions">
         <button
+            *ngIf="!parent.conf.isActionVisible || parent.conf.isActionVisible.bind(parent.conf)(action.name, row)"
             mat-button
             id="action_button_{{ action?.name }}__{{action.id}}"
             (click)="action.onClick(this.config)"

--- a/src/app/pages/common/entity/entity-table/entity-table-row-details/entity-table-row-details.component.scss
+++ b/src/app/pages/common/entity/entity-table/entity-table-row-details/entity-table-row-details.component.scss
@@ -17,6 +17,12 @@
         margin: 0;
     }
 
+    mat-icon.widget-icon {
+        cursor: pointer;
+        font-size: 24px;
+        line-height: 24px;
+    }
+
     .wrapper__details {
         padding-bottom: 12px;
     }

--- a/src/app/pages/common/entity/entity-table/entity-table.component.html
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.html
@@ -264,9 +264,15 @@
                [minWidth]="col.minWidth"
                [maxWidth]="col.maxWidth">
         <ng-template let-row="row" ngx-datatable-cell-template>
-          <div fxLayoutAlign="start center" fxLayoutGap="8px">
+          <div fxLayoutAlign="start center" fxLayoutGap="4px">
             <ng-container *ngIf="col?.widget?.component">
-                <mat-icon [style.cursor]="'pointer'" [matMenuTriggerFor]="widget">{{ col.widget.icon }}</mat-icon>
+                <mat-icon
+                  [matMenuTriggerFor]="widget"
+                  class="widget-icon"
+                  role="img"
+                  fontSet="mdi-set"
+                  fontIcon="mdi-{{ col.widget.icon }}"
+                ></mat-icon>
                 <mat-menu #widget="matMenu" xPosition="before" yPosition="below">
                   <!-- column widgets need to be registered with this switch case -->
                   <ng-container [ngSwitch]="col.widget.component">

--- a/src/app/pages/common/entity/entity-table/entity-table.component.scss
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.scss
@@ -120,6 +120,12 @@
     ::ng-deep datatable-row-wrapper {
         width: auto;
     }
+
+    mat-icon.widget-icon {
+        cursor: pointer;
+        font-size: 24px;
+        line-height: 24px;
+    }
 }
 
 

--- a/src/app/pages/task-calendar/cloudsync/cloudsync-list/cloudsync-list.component.ts
+++ b/src/app/pages/task-calendar/cloudsync/cloudsync-list/cloudsync-list.component.ts
@@ -30,7 +30,7 @@ export class CloudsyncListComponent implements InputTableConf {
     { name: T('Credential'), prop: 'credential', hidden: true },
     { name: T('Direction'), prop: 'direction', hidden: true},
     { name: T('Path'), prop: 'path', hidden: true},
-    { name: T('Schedule'), prop: 'cron', hidden: true, widget: { icon: 'date_range', component: 'TaskScheduleListComponent' }},
+    { name: T('Schedule'), prop: 'cron', hidden: true, widget: { icon: 'calendar-range', component: 'TaskScheduleListComponent' }},
     { name: T('Next Run'), prop: 'next_run', hidden: true},
     { name: T('Minute'), prop: 'minute', hidden: true },
     { name: T('Hour'), prop: 'hour', hidden: true },

--- a/src/app/pages/task-calendar/replication/replication-list/replication-list.component.ts
+++ b/src/app/pages/task-calendar/replication/replication-list/replication-list.component.ts
@@ -32,7 +32,7 @@ export class ReplicationListComponent {
         { name: 'Auto', prop: 'auto', hidden: true},
         { name: 'Enabled', prop: 'enabled' },
         { name: 'State', prop: 'task_state', state: 'state' },
-        { name: 'Last Snapshot', prop: 'task_last_snapshot' },
+        { name: 'Last Snapshot', prop: 'task_last_snapshot' }
     ];
 
     public config: any = {
@@ -55,15 +55,18 @@ export class ReplicationListComponent {
         this.entityList = entityList;
     }
 
-    dataHandler(entityList) {
-        for (const task of entityList.rows) {
+    resourceTransformIncomingRestData(tasks: any[]): any[] {
+        return tasks.map(task => {
             task.task_state = task.state.state;
             task.ssh_connection = task.ssh_credentials ? task.ssh_credentials.name : '-';
             if (task.state.job && task.state.job.time_finished) {
                 const d = moment(task.state.job.time_finished.$date);
                 task.task_last_snapshot = d.format('MM/D/YYYY h:mma') + ` (${d.fromNow()})`;
+            } else {
+                task.task_last_snapshot = T('No snapshots sent yet');
             }
-        }
+            return task;
+        });
     }
 
     getActions(parentrow) {


### PR DESCRIPTION
* "No snapshots sent yet" if rep task does not have a previous run
* Unfortunately, the column widgets cannot support show/hide on a per-row basis, so future runs cannot be supported at this time. Perhaps we could target for 12?
* Moves task parsing from `dataHandler` to `resourceTransformIncomingRestData` so that the column data updates dynamically as the task runs

QUICK UPDATES:
* Fix for tooltip formatting bug
* Adds support for mdi icons in table widgets
* Make sure that table detail actions are visible at the right times