### PR TITLE
NAS-102624a No, this is the way

### DIFF
--- a/src/app/pages/network/interfaces/interfaces-list/interfaces-list.component.css
+++ b/src/app/pages/network/interfaces/interfaces-list/interfaces-list.component.css
@@ -1,3 +1,11 @@
 .buttons {
     margin-left: 1px;
 }
+.disabled-notice {
+    font-size: small;
+    margin-top: -10px;
+}
+.pseudolink {
+    text-decoration: underline;
+    cursor: pointer;
+}

--- a/src/app/pages/network/interfaces/interfaces-list/interfaces-list.component.html
+++ b/src/app/pages/network/interfaces/interfaces-list/interfaces-list.component.html
@@ -2,7 +2,7 @@
     <div *ngIf="!checkinWaiting;else checkIn">
       <p> {{pending_changes_text}} </p>
       <p> {{checkin_text }}
-      <mat-form-field floatPlaceholder="never">
+      <mat-form-field floatPlaceholder="never" id="timeout-field">
         <input matInput [(ngModel)]="checkin_timeout" [pattern]="checkin_timeout_pattern">
       </mat-form-field>
         {{ checkin_text_2 }}

--- a/src/app/pages/network/interfaces/interfaces-list/interfaces-list.component.html
+++ b/src/app/pages/network/interfaces/interfaces-list/interfaces-list.component.html
@@ -12,9 +12,10 @@
       <p> {{pending_checkin_text}} {{checkin_remaining}}</p>
     </ng-template>
     <mat-card-actions class="buttons">
-      <button *ngIf="!checkinWaiting" mat-button type="button" (click)="commitPendingChanges()" class="btn btn-block btn-warning mat-primary" mat-button color="primary">{{"Commit" | translate}}</button>
-      <button *ngIf="checkinWaiting" mat-button type="button" (click)="checkInNow()" class="btn btn-block btn-warning mat-primary" mat-button color="primary">{{"Check-in" | translate}}</button>
-      <button mat-button type="button" (click)="rollbackPendingChanges()" class="btn  btn-block btn-lg mat-accent" mat-button color="accent">{{"Discard" | translate}}</button>
+      <button *ngIf="!checkinWaiting" [disabled]="ha_enabled" mat-button type="button" (click)="commitPendingChanges()" class="btn btn-block btn-warning mat-primary" mat-button color="primary">{{"Commit" | translate}}</button>
+      <button *ngIf="checkinWaiting" [disabled]="ha_enabled" mat-button type="button" (click)="checkInNow()" class="btn btn-block btn-warning mat-primary" mat-button color="primary">{{"Check-in" | translate}}</button>
+      <button mat-button type="button" [disabled]="ha_enabled" (click)="rollbackPendingChanges()" class="btn  btn-block btn-lg mat-accent" mat-button color="accent">{{"Discard" | translate}}</button>
     </mat-card-actions>
+    <div class="disabled-notice" *ngIf="ha_enabled">Cannot edit while HA is enabled. (<span class="pseudolink" (click)="goToHA()">Go to HA settings</span>).</div>
 </mat-card>
 <entity-table [title]="title" [conf]="this"></entity-table>

--- a/src/app/pages/network/interfaces/interfaces-list/interfaces-list.component.ts
+++ b/src/app/pages/network/interfaces/interfaces-list/interfaces-list.component.ts
@@ -32,8 +32,8 @@ export class InterfacesListComponent implements OnDestroy {
   public checkinWaiting = false;
   pending_changes_text: string;
   pending_checkin_text: string;
-  checkin_text: string = T("Changes will revert after ");
-  checkin_text_2: string = T(" seconds unless kept permanently.");
+  checkin_text: string = T("Once applied, changes will revert after ");
+  checkin_text_2: string = T(" seconds unless kept permanently. Adjust this amount to allow for testing.");
   public checkin_timeout = 60;
   public checkin_timeout_pattern = /\d+/;
   public checkin_remaining = null;

--- a/src/app/pages/network/interfaces/interfaces-list/interfaces-list.component.ts
+++ b/src/app/pages/network/interfaces/interfaces-list/interfaces-list.component.ts
@@ -273,7 +273,10 @@ export class InterfacesListComponent implements OnDestroy {
       }
     )
   }*/
-
+  goToHA() {
+    this.router.navigate(new Array('/').concat('system', 'failover'));
+  }
+  
   ngOnDestroy() {
     this.checkChangesSubscription.unsubscribe();
   }

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -1384,5 +1384,9 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
   general-preferences-form #userTheme {
     width: 400px;
   }
+  app-interfaces-list #timeout-field {
+    width: 50px;
+    text-align: center;
+  }
 
  } // end of ix theme


### PR DESCRIPTION
I think the main problem addressed in this ticket, the sliding network icon not going away, is b/c you can click on action buttons that throw an error that never displays. Also,it's easy to take the 60 seconds at the top of the interfaces page (when you make a change) for a countdown timer that isn't working. Instead, it is a setting for the user to choose their own time limit for the next step. I have  tried to make that clear in text and styling. And have disabled buttons when HA is avaialble (and changes can't be made)