### PR TITLE
NAS-101652: Synchronize field help text with docs

### DIFF
--- a/src/app/helptext/system/cloudcredentials.ts
+++ b/src/app/helptext/system/cloudcredentials.ts
@@ -64,7 +64,7 @@ export const helptext_system_cloudcredentials = {
     placeholder: T("Endpoint URL"),
     tooltip: T(
       '<a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteEndpoints.html"\
- target="_blank">S3 API endpoint URL</a> When using AWS, the endpoint\
+ target="_blank">S3 API endpoint URL</a>. When using AWS, the endpoint\
  field can be left empty to use the default endpoint for the region.\
  Available buckets are automatically fetched.<br>\
  Refer to the AWS Documentation for a list of\

--- a/src/app/helptext/system/cloudcredentials.ts
+++ b/src/app/helptext/system/cloudcredentials.ts
@@ -63,15 +63,13 @@ export const helptext_system_cloudcredentials = {
   endpoint_s3: {
     placeholder: T("Endpoint URL"),
     tooltip: T(
-      'Leave blank when using AWS. The available buckets are fetched \
- dynamically. Enter a \
- <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteEndpoints.html"\
- target="_blank">Endpoint URL</a> if not using AWS. URL \
- general format: <i>bucket-name.s3-website.region.amazonaws.com</i>.\
- Refer to the AWS Documentation for a list of <a\
- href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints"\
- target="_blank">Simple Storage Service Website\
- Endpoints</a>.'
+      '<a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteEndpoints.html"\
+ target="_blank">S3 API endpoint URL</a> When using AWS, the endpoint\
+ field can be left empty to use the default endpoint for the region.\
+ Available buckets are automatically fetched.<br>\
+ Refer to the AWS Documentation for a list of\
+ <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints"\
+ target="_blank">Simple Storage Service Website Endpoints</a>.'
     )
   },
 


### PR DESCRIPTION
- System > Cloud Credentials > Add > Amazon S3 > Endpoint URL.
- Help text now matches docs description.
- Yarn build test: no issues.