### PR TITLE
NAS-102850 Add instructions for keypairs

### DIFF
--- a/src/app/helptext/system/ssh-keypairs.ts
+++ b/src/app/helptext/system/ssh-keypairs.ts
@@ -14,5 +14,8 @@ export default {
     public_key_tooltip: T('See <i>Public key authentication</i> in <a href="https://www.freebsd.org/cgi/man.cgi?query=ssh"\
  target="_blank">SSH/Authentication</a>.'),
 
-    generate_key_button: T('Generate Keypair')
+    generate_key_button: T('Generate Keypair'),
+
+    key_instructions: T('Use this form to create a keypair or import a keypair by pasting it in. \
+ Imported keypairs must be UNENCRYPTED (created WITHOUT a passphrase).')
 }

--- a/src/app/pages/system/ssh-keypairs/ssh-keypairs-form/ssh-keypairs-form.component.ts
+++ b/src/app/pages/system/ssh-keypairs/ssh-keypairs-form/ssh-keypairs-form.component.ts
@@ -24,6 +24,10 @@ export class SshKeypairsFormComponent {
 
     protected fieldConfig: FieldConfig[] = [
         {
+            type: 'paragraph',
+            name: 'key_instructions',
+            paraText: helptext.key_instructions
+        }, {
             type: 'input',
             name: 'name',
             placeholder: helptext.name_placeholder,


### PR DESCRIPTION
Talked to William about this. We aren't going to support encrypted keys, so I have added a label; also, since the UI's error message is from middleware, I'll make a ticket asking for that message to fit our situation.