### PR TITLE
Avoid empty list for form-select

### DIFF
--- a/src/app/pages/common/entity/entity-form/components/form-select/form-select.component.html
+++ b/src/app/pages/common/entity/entity-form/components/form-select/form-select.component.html
@@ -56,11 +56,11 @@
       </div>
 
       <div *ngIf="!formReady || config.options.length == 0">
-        <!--<ng-container>
+        <ng-container>
           <mat-option disabled style="opacity:0.5">
-              (No Options)
+            {{config.zeroStateMessage ? config.zeroStateMessage : '--'}}
           </mat-option>
-        </ng-container>-->
+        </ng-container>
       </div>
     </mat-select>
 

--- a/src/app/pages/common/entity/entity-form/models/field-config.interface.ts
+++ b/src/app/pages/common/entity/entity-form/models/field-config.interface.ts
@@ -19,5 +19,5 @@ export interface FieldConfig {
   updateLocal?: boolean, isLoading?: boolean, textAreaRows?: number, netmaskPreset?: number,
   isLargeText?: boolean, paragraphIcon?: string,
   customEventMethod?(data:any), onChangeOption?(data:any),
-
+  zeroStateMessage?: string
 }

--- a/src/app/pages/directoryservice/ldap/ldap.component.ts
+++ b/src/app/pages/directoryservice/ldap/ldap.component.ts
@@ -273,6 +273,11 @@ export class LdapComponent {
         this.ldapCertificate.options.push(
           {label : item.name, value : item.id});
       });
+
+      // Handle case when there is no data
+      if(res.length == 0){
+        this.ldapCertificate.zeroStateMessage = 'No Certificates Found';
+      }
     });
 
     this.ws.call('notifier.choices', ['IDMAP_CHOICES']).subscribe((res) => {


### PR DESCRIPTION
Entity-form's form-select component now shows zero state message in disabled state if there are no options. Entity-form's field-config interface augmented with zeroStateMessage property,