### PR TITLE
Move certificate options out of helptext so they don't get doubled every time the page loads

### DIFF
--- a/src/app/helptext/services/components/service-ftp.ts
+++ b/src/app/helptext/services/components/service-ftp.ts
@@ -60,7 +60,6 @@ masqaddress_tooltip: T('Public IP address or hostname. Set if FTP clients\
 ssltls_certificate_placeholder : T('Certificate'),
 ssltls_certificate_tooltip: T('The SSL certificate to be used for TLS FTP connections.\
  To create a certificate, use <b>System --> Certificates</b>.'),
-ssltls_certificate_options : [{label:'-', value:null}],
 
 filemask_placeholder : T('File Permission'),
 filemask_tooltip: T('Sets default permissions for newly created files.'),

--- a/src/app/pages/services/components/service-ftp/service-ftp.component.ts
+++ b/src/app/pages/services/components/service-ftp/service-ftp.component.ts
@@ -123,7 +123,7 @@ export class ServiceFTPComponent implements OnInit {
       name : 'ssltls_certificate',
       placeholder : helptext.ssltls_certificate_placeholder,
       tooltip: helptext.ssltls_certificate_tooltip,
-      options : helptext.ssltls_certificate_options
+      options : [{label:'-', value:null}],
     },
     {
       type : 'permissions',


### PR DESCRIPTION
NAS-102869

(cherry picked from commit 3cd051cac105da753d4bf66004899c99dbc858ab)