### PR TITLE
NAS-102864 -- unique entity-table cell identifiers

### DIFF
--- a/src/app/pages/account/groups/group-list/group-list.component.ts
+++ b/src/app/pages/account/groups/group-list/group-list.component.ts
@@ -24,6 +24,7 @@ export class GroupListComponent {
     {name : 'Builtin', prop : 'bsdgrp_builtin'},
     {name : 'Permit Sudo', prop : 'bsdgrp_sudo'},
   ];
+  public rowIdentifier = 'bsdgrp_group';
   public config: any = {
     paging : true,
     sorting : {columns : this.columns},

--- a/src/app/pages/account/users/user-list/user-list.component.ts
+++ b/src/app/pages/account/users/user-list/user-list.component.ts
@@ -40,6 +40,7 @@ export class UserListComponent implements OnInit {
     { name: 'Permit Sudo', prop: 'bsdusr_sudo', hidden: true },
     { name: 'Microsoft Account', prop: 'bsdusr_microsoft_account', hidden: true },
   ];
+  public rowIdentifier = 'bsdusr_username';
   public config: any = {
     paging: true,
     sorting: { columns: this.columns },

--- a/src/app/pages/common/entity/entity-table/data-table-cell.directive.ts
+++ b/src/app/pages/common/entity/entity-table/data-table-cell.directive.ts
@@ -1,0 +1,27 @@
+import { Directive, ElementRef, Input, OnChanges } from '@angular/core';
+
+@Directive({
+  // tslint:disable-next-line: directive-selector
+  selector: '[ix-datatable-cell]'
+})
+export class DataTableCellDirective implements OnChanges {
+  public static readonly ATTRIBUTE = 'ix-table-cell';
+
+  @Input('ix-datatable-cell') public column: string;
+
+  // tslint:disable-next-line: no-input-rename
+  @Input('ix-datatable-cell-identifier') public identifier: string;
+
+  public constructor(private el: ElementRef) {}
+
+  public ngOnChanges(): void {
+    try {
+      (this.el.nativeElement as HTMLElement).setAttribute(
+        DataTableCellDirective.ATTRIBUTE,
+        this.identifier ? `${this.identifier}_${this.column}` : this.column
+      );
+    } catch (error) {
+      console.error(`Error in ${DataTableCellDirective.name}:`, error);
+    }
+  }
+}

--- a/src/app/pages/common/entity/entity-table/entity-table-actions.component.html
+++ b/src/app/pages/common/entity/entity-table/entity-table-actions.component.html
@@ -1,5 +1,13 @@
 <div class="panel_container">
-  <mat-icon id="table_actions_menu_button__{{key_prop}}_{{row[key_prop]}}" [matMenuTriggerFor]="appMenu" [style.cursor]="'pointer'">{{icon_name}}</mat-icon>
+  <mat-icon
+    ix-datatable-cell="three-dot"
+    [ix-datatable-cell-identifier]="row[entity?.conf?.rowIdentifier || 'name']"
+    id="table_actions_menu_button__{{key_prop}}_{{row[key_prop]}}"
+    [matMenuTriggerFor]="appMenu"
+    [style.cursor]="'pointer'"
+  >
+    {{icon_name}}
+  </mat-icon>
   <mat-menu #appMenu="matMenu">
     <span *ngFor="let action of actions">
 			<button id="action_button_{{ action?.name }}__{{action.id}}" mat-menu-item *ngIf="!entity.conf.isActionVisible

--- a/src/app/pages/common/entity/entity-table/entity-table-actions.component.ts
+++ b/src/app/pages/common/entity/entity-table/entity-table-actions.component.ts
@@ -16,7 +16,7 @@ import * as _ from 'lodash';
 })
 export class EntityTableActionsComponent implements OnInit {
 
-  @Input('entity') entity: EntityTableComponent;
+  @Input('entity') entity: EntityTableComponent & { conf: any };
   @Input('row') row: any;
   @Input('icon_name') icon_name = "more_vert";
 

--- a/src/app/pages/common/entity/entity-table/entity-table.component.html
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.html
@@ -214,15 +214,25 @@
         </ngx-datatable-footer>
 
       <ngx-datatable-column *ngIf="conf.config && conf.config.multiSelect" [width]="85" [sortable]="false" [canAutoResize]="false" [draggable]="false" [resizeable]="false">
-        <ng-template ngx-datatable-header-template let-value="value" let-allRowsSelected="allRowsSelected" let-selectFn="selectFn">
+        <ng-template ngx-datatable-header-template let-column="column" let-value="value" let-allRowsSelected="allRowsSelected" let-selectFn="selectFn">
           <div class="headerCheckBox">
-            <mat-checkbox [checked]="allRowsSelected" (change)="selectFn(!allRowsSelected)"></mat-checkbox>
+            <mat-checkbox
+              [checked]="allRowsSelected"
+              (change)="selectFn(!allRowsSelected)"
+              ix-datatable-cell="multi-checkbox-all"
+              [ix-datatable-cell-identifier]="title"
+            ></mat-checkbox>
           </div>
         </ng-template>
 
-        <ng-template ngx-datatable-cell-template let-value="value" let-isSelected="isSelected" let-onCheckboxChangeFn="onCheckboxChangeFn">
+        <ng-template ngx-datatable-cell-template let-row="row" let-value="value" let-isSelected="isSelected" let-onCheckboxChangeFn="onCheckboxChangeFn">
           <div>
-            <mat-checkbox [checked]="isSelected" (change)="onCheckboxChangeFn($event)"></mat-checkbox>
+            <mat-checkbox 
+              ix-datatable-cell="multi-checkbox"
+              [ix-datatable-cell-identifier]="row[conf.rowIdentifier || 'name']"
+              [checked]="isSelected"
+              (change)="onCheckboxChangeFn($event)"
+            ></mat-checkbox>
           </div>
         </ng-template>
       </ngx-datatable-column>
@@ -251,7 +261,9 @@
               [checked]="row[col.prop]==='RUNNING'"
             ></mat-slide-toggle>
             <div id="{{col.prop}}_{{row[col.prop]}}" 
-                 title="{{convertDisplayValue(row[col.prop])}}">
+                 title="{{convertDisplayValue(row[col.prop])}}" 
+                 [ix-datatable-cell]="col?.name"
+                 [ix-datatable-cell-identifier]="row[conf.rowIdentifier || 'name']">
               {{convertDisplayValue(row[col.prop])}}
             </div>
           </ng-template>
@@ -264,9 +276,16 @@
                [minWidth]="col.minWidth"
                [maxWidth]="col.maxWidth">
         <ng-template let-row="row" ngx-datatable-cell-template>
-          <div fxLayoutAlign="start center" fxLayoutGap="4px">
+          <div
+            fxLayoutAlign="start center"
+            fxLayoutGap="4px"
+            [ix-datatable-cell]="col?.name"
+            [ix-datatable-cell-identifier]="row[conf.rowIdentifier || 'name']"
+          >
             <ng-container *ngIf="col?.widget?.component">
                 <mat-icon
+                  [ix-datatable-cell]="col?.name + '_widget'"
+                  [ix-datatable-cell-identifier]="row[conf.rowIdentifier || 'name']"
                   [matMenuTriggerFor]="widget"
                   class="widget-icon"
                   role="img"
@@ -313,7 +332,9 @@
             [class.datatable-icon-right]="!expanded"
             [class.datatable-icon-down]="expanded"
             title="Expand/Collapse Row"
-            (click)="toggleExpandRow(row)">
+            (click)="toggleExpandRow(row)"
+            ix-datatable-cell="expander"
+            [ix-datatable-cell-identifier]="row[conf.rowIdentifier || 'name']">
           </a>
           <ng-template #threeDot>
             <app-entity-table-actions [entity]="this" [row]="row"></app-entity-table-actions>

--- a/src/app/pages/common/entity/entity.module.ts
+++ b/src/app/pages/common/entity/entity.module.ts
@@ -78,6 +78,7 @@ import { ToolbarMenuComponent } from './entity-toolbar/components/toolbar-menu/t
 import { ToolbarMultimenuComponent } from './entity-toolbar/components/toolbar-multimenu/toolbar-multimenu.component';
 import { EntityRowDetailsComponent } from './entity-table/entity-row-details.component';
 import { TaskScheduleListComponent } from 'app/pages/task-calendar/components/task-schedule-list/task-schedule-list.component';
+import { DataTableCellDirective } from './entity-table/data-table-cell.directive';
 
 @NgModule({
   imports: [
@@ -137,7 +138,8 @@ import { TaskScheduleListComponent } from 'app/pages/task-calendar/components/ta
     EntityToolbarComponent,
     ToolbarButtonComponent,
     ToolbarMenuComponent,
-    ToolbarMultimenuComponent
+    ToolbarMultimenuComponent,
+    DataTableCellDirective
   ],
   exports: [
     EntityTemplateDirective,
@@ -165,6 +167,7 @@ import { TaskScheduleListComponent } from 'app/pages/task-calendar/components/ta
     ToolbarButtonComponent,
     ToolbarMenuComponent,
     ToolbarMultimenuComponent,
+    DataTableCellDirective
   ],
   entryComponents: [
     FormButtonComponent,

--- a/src/app/pages/directoryservice/kerberoskeytabs/kerberoskeytabs-list/kerberoskeytabs-list.component.ts
+++ b/src/app/pages/directoryservice/kerberoskeytabs/kerberoskeytabs-list/kerberoskeytabs-list.component.ts
@@ -19,6 +19,7 @@ export class KerberosKeytabsListComponent {
   public columns: Array < any > = [
     { name: 'Name', prop: 'keytab_name', always_display: true },
   ];
+  public rowIdentifier = 'keytab_name';
   public config: any = {
     paging: true,
     sorting: { columns: this.columns },

--- a/src/app/pages/directoryservice/kerberosrealms/kerberosrealms-list/kerberosrealms-list.component.ts
+++ b/src/app/pages/directoryservice/kerberosrealms/kerberosrealms-list/kerberosrealms-list.component.ts
@@ -23,6 +23,7 @@ export class KerberosRealmsListComponent {
     { name: T('Admin Server'), prop: 'krb_admin_server' },
     { name: T('Password Server'), prop: 'krb_kpasswd_server' },
   ];
+  public rowIdentifier = 'krb_realm';
   public config: any = {
     paging: true,
     sorting: { columns: this.columns },

--- a/src/app/pages/jails/jail-list/jail-list.component.ts
+++ b/src/app/pages/jails/jail-list/jail-list.component.ts
@@ -46,6 +46,7 @@ export class JailListComponent implements OnInit {
     { name: T("Template"), prop: 'template', hidden: true },
     { name: T("Basejail"), prop: 'basejail_readble', hidden: true }
   ];
+  public rowIdentifier = 'host_hostuuid';
   public config: any = {
     paging: true,
     sorting: { columns: this.columns },

--- a/src/app/pages/jails/storages/storage-list/storage-list.component.ts
+++ b/src/app/pages/jails/storages/storage-list/storage-list.component.ts
@@ -44,6 +44,7 @@ export class StorageListComponent {
     { name: T('Source'), prop: 'source', always_display: true },
     { name: T('Destination'), prop: 'destination' },
   ];
+  public rowIdentifier = 'source';
   public config: any = {
     paging: true,
     sorting: { columns: this.columns },

--- a/src/app/pages/network/staticroutes/staticroute-list/staticroute-list.component.ts
+++ b/src/app/pages/network/staticroutes/staticroute-list/staticroute-list.component.ts
@@ -23,6 +23,7 @@ export class StaticRouteListComponent {
     {name : T('Gateway'), prop : 'sr_gateway'},
     {name : T('Description'), prop : 'sr_description'}
   ];
+  public rowIdentifier = 'sr_destination';
   public config: any = {
     paging : true,
     sorting : {columns : this.columns},

--- a/src/app/pages/sharing/afp/afp-list/afp-list.component.ts
+++ b/src/app/pages/sharing/afp/afp-list/afp-list.component.ts
@@ -20,6 +20,7 @@ export class AFPListComponent {
     {name : T('Name'), prop : 'afp_name', always_display: true},
     {name : T('Path'), prop : 'afp_path'},
   ];
+  public rowIdentifier = 'afp_name';
   public config: any = {
     paging : true,
     sorting : {columns : this.columns},

--- a/src/app/pages/sharing/iscsi/associated-target/associated-target-list/associated-target-list.component.ts
+++ b/src/app/pages/sharing/iscsi/associated-target/associated-target-list/associated-target-list.component.ts
@@ -36,6 +36,7 @@ export class AssociatedTargetListComponent {
       prop : 'extent',
     }
   ];
+  public rowIdentifier = 'target';
   public config: any = {
     paging : true,
     sorting : {columns : this.columns},

--- a/src/app/pages/sharing/iscsi/authorizedaccess/authorizedaccess-list/authorizedaccess-list.component.ts
+++ b/src/app/pages/sharing/iscsi/authorizedaccess/authorizedaccess-list/authorizedaccess-list.component.ts
@@ -30,6 +30,7 @@ export class AuthorizedAccessListComponent {
       prop : 'peeruser',
     },
   ];
+  public rowIdentifier = 'tag';
   public config: any = {
     paging : true,
     sorting : {columns : this.columns},

--- a/src/app/pages/sharing/iscsi/fibre-channel-ports/fibre-channel-ports.component.ts
+++ b/src/app/pages/sharing/iscsi/fibre-channel-ports/fibre-channel-ports.component.ts
@@ -12,7 +12,7 @@ export class FibreChannelPortsComponent {
     protected entityList: any;
 
     public columns: Array<any> = [
-        { name: 'Name', prop: 'name' },
+        { name: 'Name', prop: 'name', always_display: true },
         { name: 'WWPN', prop: 'wwpn' },
         { name: 'State', prop: 'state' },
     ];

--- a/src/app/pages/sharing/iscsi/initiator/initiator-list/initiator-list.component.ts
+++ b/src/app/pages/sharing/iscsi/initiator/initiator-list/initiator-list.component.ts
@@ -34,6 +34,7 @@ export class InitiatorListComponent {
       prop : 'comment',
     },
   ];
+  public rowIdentifier = 'id';
   public config: any = {
     paging : true,
     sorting : {columns : this.columns},

--- a/src/app/pages/sharing/iscsi/portal/portal-list/portal-list.component.ts
+++ b/src/app/pages/sharing/iscsi/portal/portal-list/portal-list.component.ts
@@ -38,6 +38,7 @@ export class PortalListComponent {
       prop : 'discovery_authgroup',
     },
   ];
+  public rowIdentifier = 'tag';
   public config: any = {
     paging : true,
     sorting : {columns : this.columns},

--- a/src/app/pages/sharing/nfs/nfs-list/nfs-list.component.ts
+++ b/src/app/pages/sharing/nfs/nfs-list/nfs-list.component.ts
@@ -20,6 +20,7 @@ export class NFSListComponent {
     {name: helptext_sharing_nfs.column_path, prop: 'nfs_paths', always_display: true },
     {name: helptext_sharing_nfs.column_comment, prop: 'nfs_comment'},
   ];
+  public rowIdentifier = 'nfs_paths';
   public config: any = {
     paging : true,
     sorting : {columns : this.columns},

--- a/src/app/pages/sharing/smb/smb-list/smb-list.component.ts
+++ b/src/app/pages/sharing/smb/smb-list/smb-list.component.ts
@@ -26,6 +26,7 @@ export class SMBListComponent {
     {name: helptext_sharing_smb.column_name, prop: 'cifs_name', always_display: true },
     {name: helptext_sharing_smb.column_path, prop: 'cifs_path'},
   ];
+  public rowIdentifier = 'cifs_name';
   public config: any = {
     paging : true,
     sorting : {columns : this.columns},

--- a/src/app/pages/sharing/webdav/webdav-list/webdav-list.component.ts
+++ b/src/app/pages/sharing/webdav/webdav-list/webdav-list.component.ts
@@ -28,6 +28,7 @@ export class WebdavListComponent {
         {prop: 'webdav_ro', name:  helptext_sharing_webdav.column_ro},
         {prop: 'webdav_perm', name:  helptext_sharing_webdav.column_perm},
     ];
+    public rowIdentifier = helptext_sharing_webdav.column_name;
 
     public config: any = {
         paging : true,

--- a/src/app/pages/storage/VMware-snapshot/VMware-snapshot-list/VMware-snapshot-list.component.ts
+++ b/src/app/pages/storage/VMware-snapshot/VMware-snapshot-list/VMware-snapshot-list.component.ts
@@ -20,6 +20,7 @@ export class VMwareSnapshotListComponent {
     {name : 'Hostname', prop : 'hostname', always_display: true }, {name : 'Username', prop : 'username'},
     {name : 'filesystem', prop : 'filesystem'}, {name : 'datastore', prop : 'datastore'}
   ];
+  public rowIdentifier = 'hostname';
   public config: any = {
     paging : true,
     sorting : {columns : this.columns},

--- a/src/app/pages/storage/snapshots/snapshot-list/snapshot-list.component.ts
+++ b/src/app/pages/storage/snapshots/snapshot-list/snapshot-list.component.ts
@@ -30,6 +30,7 @@ export class SnapshotListComponent {
     {name : 'Dataset', prop : 'dataset', always_display: true, minWidth: 355},
     {name : 'Snapshot', prop : 'snapshot', always_display: true, minWidth: 355},
   ];
+  public rowIdentifier = 'snapshot';
   public config: any = {
     paging: true,
     sorting: { columns: this.columns },

--- a/src/app/pages/system/ntpservers/ntpserver-list/ntpserver-list.component.ts
+++ b/src/app/pages/system/ntpservers/ntpserver-list/ntpserver-list.component.ts
@@ -22,6 +22,7 @@ export class NTPServerListComponent {
     {name : 'Min. Poll', prop : 'ntp_minpoll'},
     {name : 'Max. Poll', prop : 'ntp_maxpoll'},
   ];
+  public rowIdentifier = 'ntp_address';
   public config: any = {
     paging : true,
     sorting : {columns : this.columns},

--- a/src/app/pages/system/tunable/tunable-list/tunable-list.component.ts
+++ b/src/app/pages/system/tunable/tunable-list/tunable-list.component.ts
@@ -33,6 +33,7 @@ export class TunableListComponent {
     { name: 'Comment', prop: 'tun_comment' },
     { name: 'Enabled', prop: 'tun_enabled' },
   ];
+  public rowIdentifier = 'tun_var';
 
   public config: any = {
     paging: true,

--- a/src/app/pages/task-calendar/cloudsync/cloudsync-list/cloudsync-list.component.ts
+++ b/src/app/pages/task-calendar/cloudsync/cloudsync-list/cloudsync-list.component.ts
@@ -26,7 +26,7 @@ export class CloudsyncListComponent implements InputTableConf {
   public asyncView = true;
 
   public columns: Array < any > = [
-    { name: T('Description'), prop: 'description' },
+    { name: T('Description'), prop: 'description', always_display: true },
     { name: T('Credential'), prop: 'credential', hidden: true },
     { name: T('Direction'), prop: 'direction', hidden: true},
     { name: T('Transfer Mode'), prop: 'transfer_mode', hidden: true },
@@ -41,6 +41,7 @@ export class CloudsyncListComponent implements InputTableConf {
     { name: T('Status'), prop: 'status', state: 'state'},
     { name: T('Enabled'), prop: 'enabled' },
   ];
+  public rowIdentifier = 'description';
   public config: any = {
     paging: true,
     sorting: { columns: this.columns },

--- a/src/app/pages/task-calendar/cron/cron-list/cron-list.component.ts
+++ b/src/app/pages/task-calendar/cron/cron-list/cron-list.component.ts
@@ -39,6 +39,7 @@ export class CronListComponent {
     { name: T('Hide Stdout'), prop: 'cron_stdout', hidden: true },
     { name: T('Hide Stderr'), prop: 'cron_stderr', hidden: true }
   ];
+  public rowIdentifier = 'cron_user';
   public config: any = {
     paging: true,
     sorting: { columns: this.columns },

--- a/src/app/pages/task-calendar/initshutdown/initshutdown-list/initshutdown-list.component.ts
+++ b/src/app/pages/task-calendar/initshutdown/initshutdown-list/initshutdown-list.component.ts
@@ -22,6 +22,7 @@ export class InitshutdownListComponent {
     { name: 'Enabled', prop: 'enabled' },
     { name: 'Timeout', prop: 'timeout' },
   ];
+  public rowIdentifier = 'type';
   public config: any = {
     paging: true,
     sorting: { columns: this.columns },

--- a/src/app/pages/task-calendar/replication/replication-list/replication-list.component.ts
+++ b/src/app/pages/task-calendar/replication/replication-list/replication-list.component.ts
@@ -22,7 +22,7 @@ export class ReplicationListComponent {
     protected asyncView = true;
 
     public columns: Array<any> = [
-        { name: 'Name', prop: 'name' },
+        { name: 'Name', prop: 'name', always_display: true },
         { name: 'Direction', prop: 'direction'},
         { name: 'Transport', prop: 'transport', hidden: true},
         { name: 'SSH Connection', prop: 'ssh_connection', hidden: true},

--- a/src/app/pages/task-calendar/rsync/rsync-list/rsync-list.component.ts
+++ b/src/app/pages/task-calendar/rsync/rsync-list/rsync-list.component.ts
@@ -25,7 +25,7 @@ export class RsyncListComponent {
   protected entityList: any;
 
   public columns: Array < any > = [
-    { name: T('Path'), prop: 'path' },
+    { name: T('Path'), prop: 'path', always_display: true },
     { name: T('Remote Host'), prop: 'remotehost' },
     { name: T('Remote SSH Port'), prop: 'remoteport', hidden: true },
     { name: T('Remote Module Name'), prop: 'remotemodule' },
@@ -37,6 +37,7 @@ export class RsyncListComponent {
     { name: T('Delay Updates'), prop: 'delayupdates', hidden: true },
     { name: T('Enabled'), prop: 'enabled', hidden: true },
   ];
+  public rowIdentifier = 'path';
   public config: any = {
     paging: true,
     sorting: { columns: this.columns },

--- a/src/app/pages/task-calendar/scrub/scrub-list/scrub-list.component.ts
+++ b/src/app/pages/task-calendar/scrub/scrub-list/scrub-list.component.ts
@@ -25,13 +25,14 @@ export class ScrubListComponent {
   protected entityList: any;
 
   public columns: Array < any > = [
-    { name: 'Pool', prop: 'scrub_volume' },
+    { name: 'Pool', prop: 'scrub_volume', always_display: true },
     { name: 'Threshold days', prop: 'scrub_threshold' },
     { name: 'Description', prop: 'scrub_description' },
     { name: 'Schedule', prop: 'scrub_schedule', widget: { icon: 'date_range', component: TaskScheduleListComponent } },
     { name: 'Next Run', prop: 'scrub_next_run' },
     { name: 'Enabled', prop: 'scrub_enabled' },
   ];
+  public rowIdentifier = 'scrub_volume';
   public config: any = {
     paging: true,
     sorting: { columns: this.columns },

--- a/src/app/pages/task-calendar/smart/smart-list/smart-list.component.ts
+++ b/src/app/pages/task-calendar/smart/smart-list/smart-list.component.ts
@@ -18,6 +18,7 @@ export class SmartListComponent {
     { name: helptext.smartlist_column_description, prop: 'desc' },
     { name: helptext.smartlist_column_schedule, prop: 'schedule' }
   ];
+  public rowIdentifier = 'type';
   public config: any = {
     paging: true,
     sorting: { columns: this.columns },

--- a/src/app/pages/task-calendar/snapshot/snapshot-list/snapshot-list.component.ts
+++ b/src/app/pages/task-calendar/snapshot/snapshot-list/snapshot-list.component.ts
@@ -22,6 +22,7 @@ export class SnapshotListComponent {
     { name: 'VMware Sync', prop: 'vmware_sync', hidden: true },
     { name: 'Enabled', prop: 'enabled' },
   ];
+  public rowIdentifier = 'dataset';
   public config: any = {
     paging: true,
     sorting: { columns: this.columns },

--- a/src/app/pages/vm/devices/device-list/device-list.component.ts
+++ b/src/app/pages/vm/devices/device-list/device-list.component.ts
@@ -39,6 +39,7 @@ export class DeviceListComponent {
     {name : 'Device', prop : 'dtype'},
     {name : 'Order', prop : 'order'},
   ];
+  public rowIdentifier = 'id';
   public title = "VM ";
   public config: any = {
     paging : true,


### PR DESCRIPTION
* Directive for applying custom attribute/ids to table cell elements.
* Applies `"always_display": true` to a few tables that had not set a default column.

The following should have `ix-table-cell="<row_identifier>_<column | button>"` tags:
* Multi checkboxes (including the "all" checkbox)
* Normal table cells
* Detail expander buttons