### PR TITLE
NAS-102015

### DIFF
--- a/src/app/pages/sharing/afp/afp-list/afp-list.component.ts
+++ b/src/app/pages/sharing/afp/afp-list/afp-list.component.ts
@@ -9,7 +9,7 @@ import { T } from '../../../../translate-marker';
 export class AFPListComponent {
 
   public title = "AFP (Apple File Protocol)";
-  protected resource_name: string = 'sharing/afp/';
+  protected queryCall: string = 'sharing.afp.query';
   protected wsDelete = 'sharing.afp.delete';
   protected route_add: string[] = [ 'sharing', 'afp', 'add' ];
   protected route_add_tooltip: string = "Add Apple (AFP) Share";
@@ -17,15 +17,15 @@ export class AFPListComponent {
   protected route_delete: string[] = [ 'sharing', 'afp', 'delete' ];
 
   public columns: any[] = [
-    {name : T('Name'), prop : 'afp_name', always_display: true},
-    {name : T('Path'), prop : 'afp_path'},
+    {name : T('Name'), prop : 'name', always_display: true},
+    {name : T('Path'), prop : 'path'},
   ];
   public config: any = {
     paging : true,
     sorting : {columns : this.columns},
     deleteMsg: {
       title: 'Apple (AFP) Share',
-      key_props: ['afp_name']
+      key_props: ['name']
     },
   };
 
@@ -33,6 +33,6 @@ export class AFPListComponent {
     message: delete_share_message,
     isMessageComplete: true,
     button: T('Unshare'),
-    buildTitle: share => `${T('Unshare')} ${share.afp_name}`
+    buildTitle: share => `${T('Unshare')} ${share.name}`
   }
 }

--- a/src/app/pages/sharing/nfs/nfs-list/nfs-list.component.ts
+++ b/src/app/pages/sharing/nfs/nfs-list/nfs-list.component.ts
@@ -9,7 +9,7 @@ import { T } from 'app/translate-marker';
 export class NFSListComponent {
 
   public title = "NFS";
-  protected resource_name: string = 'sharing/nfs/';
+  protected queryCall: string = 'sharing.nfs.query';
   protected wsDelete = 'sharing.nfs.delete';
   protected route_add: string[] = [ 'sharing', 'nfs', 'add' ];
   protected route_add_tooltip: string = "Add Unix (NFS) Share";
@@ -17,15 +17,15 @@ export class NFSListComponent {
   protected route_delete: string[] = [ 'sharing', 'nfs', 'delete' ];
 
   public columns: any[] = [
-    {name: helptext_sharing_nfs.column_path, prop: 'nfs_paths', always_display: true },
-    {name: helptext_sharing_nfs.column_comment, prop: 'nfs_comment'},
+    {name: helptext_sharing_nfs.column_path, prop: 'paths', always_display: true },
+    {name: helptext_sharing_nfs.column_comment, prop: 'comment'},
   ];
   public config: any = {
     paging : true,
     sorting : {columns : this.columns},
     deleteMsg: {
       title: 'Unix (NFS) Share',
-      key_props: ['nfs_paths']
+      key_props: ['paths']
     },
   };
 
@@ -33,6 +33,6 @@ export class NFSListComponent {
     message: delete_share_message,
     isMessageComplete: true,
     button: T('Unshare'),
-    buildTitle: share => `${T('Unshare')} ${share.nfs_paths.join(', ')}`
+    buildTitle: share => `${T('Unshare')} ${share.paths.join(', ')}`
   }
 }

--- a/src/app/pages/sharing/smb/smb-list/smb-list.component.ts
+++ b/src/app/pages/sharing/smb/smb-list/smb-list.component.ts
@@ -14,7 +14,7 @@ import { map } from 'rxjs/operators';
 export class SMBListComponent {
 
   public title = "Samba";
-  protected resource_name: string = 'sharing/cifs/';
+  protected queryCall: string = 'sharing.smb.query';
   protected wsDelete = 'sharing.smb.delete';
   protected route_add: string[] = [ 'sharing', 'smb', 'add' ];
   protected route_add_tooltip: string = "Add Windows (SMB) Share";
@@ -23,15 +23,15 @@ export class SMBListComponent {
   private entityList: EntityTableComponent;
 
   public columns: any[] = [
-    {name: helptext_sharing_smb.column_name, prop: 'cifs_name', always_display: true },
-    {name: helptext_sharing_smb.column_path, prop: 'cifs_path'},
+    {name: helptext_sharing_smb.column_name, prop: 'name', always_display: true },
+    {name: helptext_sharing_smb.column_path, prop: 'path'},
   ];
   public config: any = {
     paging : true,
     sorting : {columns : this.columns},
     deleteMsg: {
       title: 'Windows (SMB) Share',
-      key_props: ['cifs_name']
+      key_props: ['name']
     },
   };
 
@@ -39,7 +39,7 @@ export class SMBListComponent {
     message: delete_share_message,
     isMessageComplete: true,
     button: T('Unshare'),
-    buildTitle: share => `${T('Unshare')} ${share.cifs_name}`
+    buildTitle: share => `${T('Unshare')} ${share.name}`
   }
 
   constructor(private ws: WebSocketService, private router: Router, private dialogService: DialogService) {}
@@ -51,19 +51,19 @@ export class SMBListComponent {
   getActions(row): any[] {
     return [
       {
-        id: row.cifs_name,
+        id: row.name,
         icon: 'edit',
         name: "edit",
         label: "Edit",
         onClick: row => this.entityList.doEdit(row.id)
       },
       {
-        id: row.cifs_name,
+        id: row.name,
         icon: 'security',
         name: "edit_acl",
         label: helptext_sharing_smb.action_edit_acl,
         onClick: row => {
-          const datasetId = row.cifs_path.replace("/mnt/", "");
+          const datasetId = row.path.replace("/mnt/", "");
           this.ws
             .call("pool.dataset.query", [[["id", "=", datasetId]]])
             .pipe(map(datasets => datasets[0]))
@@ -77,7 +77,7 @@ export class SMBListComponent {
         }
       },
       {
-        id: row.cifs_name,
+        id: row.name,
         icon: 'delete',
         name: "delete",
         label: "Delete",

--- a/src/app/pages/sharing/webdav/webdav-list/webdav-list.component.ts
+++ b/src/app/pages/sharing/webdav/webdav-list/webdav-list.component.ts
@@ -12,7 +12,7 @@ import { helptext_sharing_webdav } from 'app/helptext/sharing';
 export class WebdavListComponent {
 
     public title = "WebDAV";
-    protected resource_name: string = 'sharing/webdav';
+    protected queryCall: string = 'sharing.webdav.query';
     public busy: Subscription;
     public sub: Subscription;
 
@@ -22,11 +22,11 @@ export class WebdavListComponent {
     protected route_delete: string[] = [ 'sharing', 'webdav', 'delete'];
 
     public columns: Array<any> = [
-        {prop: 'webdav_name', name: helptext_sharing_webdav.column_name, always_display: true },
-        {prop: 'webdav_comment', name: helptext_sharing_webdav.column_comment},
-        {prop: 'webdav_path', name:  helptext_sharing_webdav.column_path},
-        {prop: 'webdav_ro', name:  helptext_sharing_webdav.column_ro},
-        {prop: 'webdav_perm', name:  helptext_sharing_webdav.column_perm},
+        {prop: 'name', name: helptext_sharing_webdav.column_name, always_display: true },
+        {prop: 'comment', name: helptext_sharing_webdav.column_comment},
+        {prop: 'path', name:  helptext_sharing_webdav.column_path},
+        {prop: 'ro', name:  helptext_sharing_webdav.column_ro},
+        {prop: 'perm', name:  helptext_sharing_webdav.column_perm},
     ];
 
     public config: any = {
@@ -34,7 +34,7 @@ export class WebdavListComponent {
         sorting : {columns : this.columns},
         deleteMsg: {
             title: 'WebDAV Share',
-            key_props: ['webdav_name']
+            key_props: ['name']
         },
     };
 


### PR DESCRIPTION
 Change from rest to ws calls on some sharing lists.
The ticket cited a problem with the associated target list, which has already been updated in 11.3 but not yet in 11.2.
In testing with QE, we saw the 1000 record barrier on the nfs list when using the rest call, and switching to WS fixed this. The PR changes the remaining rest calls in Sharing to ws.

