### PR TITLE
Responsive support page

### DIFF
--- a/src/app/pages/system/support/support.component.html
+++ b/src/app/pages/system/support/support.component.html
@@ -1,5 +1,5 @@
 <mat-card class="form-card">
-  <div class="mat-content">
+  <div class="mat-content" fxLayout="column">
     <div id="top-row" class="container" fxLayout="row wrap">
       <div id="top-left" fxFlex="55%" fxFlex.xs="100">
           <app-fn-sys-info
@@ -24,7 +24,7 @@
           >
           </app-tn-sys-info>
         </ng-template>
-        <div id="production-status-wrapper" [style.max-width.px]="375">
+        <div id="production-status-wrapper">
           <app-production-status *ngIf="!is_freenas"></app-production-status>
         </div>
       </div>
@@ -37,10 +37,10 @@
         </div>
       </div>
     </div>
-    <div *ngIf="!is_freenas">
+    <div *ngIf="!is_freenas" fxLayout="row">
       <app-proactive></app-proactive>
     </div>
-    <div>
+    <div fxLayout="row">
       <app-fn-support *ngIf="is_freenas; else TNsupport"></app-fn-support>
       <ng-template #TNsupport>
         <app-tn-support></app-tn-support>

--- a/src/app/pages/system/support/support.component.html
+++ b/src/app/pages/system/support/support.component.html
@@ -1,7 +1,7 @@
 <mat-card class="form-card">
   <div class="mat-content">
-    <div id="top-row" class="container" fxLayout="row">
-      <div id="top-left" fxFlex="50%">
+    <div id="top-row" class="container" fxLayout="row wrap">
+      <div id="top-left" fxFlex="55%" fxFlex.xs="100">
           <app-fn-sys-info
           *ngIf="is_freenas; else TNsysinfo"
           [FN_version]='FN_version'
@@ -10,6 +10,7 @@
           [FN_serial]="FN_serial"
           [FN_instructions]="FN_instructions"
           ></app-fn-sys-info>
+          <div id="fn-spacer" *ngIf="is_freenas"></div>
         <ng-template #TNsysinfo>
           <app-tn-sys-info
             [customer_name]='customer_name'
@@ -27,10 +28,11 @@
           <app-production-status *ngIf="!is_freenas"></app-production-status>
         </div>
       </div>
-      <div id="top-right" fxFlex="50%">
+      <div id="top-right" fxFlex="45%" fxFlex.xs="100">
         <div class="sys-image">
             <app-sys-image
             [product_image]="product_image"
+            [ngClass]="[is_freenas ? 'fn-sys-image' : 'tn-sys-image']"
           ></app-sys-image>
         </div>
       </div>

--- a/src/app/pages/system/support/tn-sys-info/tn-sys-info.component.html
+++ b/src/app/pages/system/support/tn-sys-info/tn-sys-info.component.html
@@ -2,17 +2,17 @@
   <p class="support-title"><i class="material-icons">info</i>License Information</p>
   <div id="tn-sys-info" class="container" fxLayout="row">
     <div id=tn-sys-col1 fxFlex="50%">
-        <div class="tn-sys-info-line"><h4>Customer Name:</h4> {{customer_name}}</div>
-        <div class="tn-sys-info-line"><h4>Features:</h4> {{features}}</div>
-        <div class="tn-sys-info-line"><h4>Contract Type:</h4> {{contract_type}}</div>
-        <div class="tn-sys-info-line"><h4>Expiration Date:</h4> {{expiration_date}}
-          <span *ngIf="daysLeftinContract"> (expires in {{daysLeftinContract}} days)</span>
+        <div class="tn-sys-info-line"><h4>Customer Name:</h4> <span class="sys-info-text">{{customer_name}}</span></div>
+        <div class="tn-sys-info-line"><h4>Features:</h4> <span class="sys-info-text">{{features}}</span></div>
+        <div class="tn-sys-info-line"><h4>Contract Type:</h4> <span class="sys-info-text">{{contract_type}}</span></div>
+        <div class="tn-sys-info-line"><h4>Expiration Date:</h4> <span class="sys-info-text">{{expiration_date}}</span>
+          <span *ngIf="daysLeftinContract" class="sys-info-text"> (expires in {{daysLeftinContract}} days)</span>
         </div>
     </div>
     <div id=tn-sys-col2 fxFlex="50%">
-        <div class="tn-sys-info-line"><h4>Model:</h4> {{model}}</div>
-        <div class="tn-sys-info-line"><h4>System Serial:</h4> {{sys_serial}}</div>
-        <div class="tn-sys-info-line"><h4>Additional Hardware:</h4> {{add_hardware}}</div>
+        <div class="tn-sys-info-line"><h4>Model:</h4> <span class="sys-info-text">{{model}}</span></div>
+        <div class="tn-sys-info-line"><h4>System Serial:</h4> <span class="sys-info-text">{{sys_serial}}</span></div>
+        <div class="tn-sys-info-line"><h4>Additional Hardware:</h4> <span class="sys-info-text">{{add_hardware}}</span></div>
         <div><button mat-flat-button id="update-license-btn" (click)="updateLicense()">{{"UPDATE LICENSE" | translate}}</button></div>
     </div>
   </div>

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -1308,14 +1308,17 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
 
   app-production-status {
     .mat-card {
-        top: 12px;
+        top: 25px;
         background-color: rgba(127,127,127,0.1);
-        width: 230px;
+        width: 400px;
+        height: 100px;
         margin: 0 !important;
     }
     .mat-card-actions {
-      top: 5px;
-      position: relative;
+      top: 25px;
+      position: absolute;
+      left: 240px;
+      width: unset;
     }
     .temp {
       height: 0 !important;
@@ -1330,7 +1333,7 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
 
   app-proactive {
     .mat-card {
-      top: 25px;
+      top: 37px;
       background-color: rgba(127,127,127,0.1);
       margin: 0 15px !important;
     }
@@ -1392,7 +1395,7 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
 
   app-tn-support {
     .mat-card {
-      top: 45px;
+      top: 50px;
       background-color: rgba(127,127,127,0.1);
       margin: 0 15px !important;
     }

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -1197,16 +1197,22 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
   app-support {
     .mat-card {
       padding-bottom: 60px;
-      min-width: 720px;
+      // min-width: 720px;
     }
     #top-row {
       margin: 0 15px;
     }
+
     .sys-image {
       display: flex;
       justify-content: center;
       align-items: center;
       height: 350px;
+
+      div {
+        display: flex;
+        justify-content: center;
+      }
     }
 
     .lowerme {
@@ -1233,6 +1239,18 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
       top: -20px;
       right: 45%;
     }
+
+    @media screen and (max-width: 1025px) {
+      #fn-spacer {
+        height: 80px;
+      }
+    }  
+
+    @media screen and (max-width: 400px) {
+      app-sys-image img {
+        max-width: 80%;
+      }
+    }
   }
 
   app-fn-sys-info {
@@ -1252,6 +1270,8 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     }
   }
 
+
+
   app-tn-sys-info {
     .tn-sys-info-line {
       margin-top: 10px;
@@ -1267,19 +1287,31 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
       top: 13px;
     }
 
+    #tn-sys-col1 {
+      min-width: 184px;
+    }
   }
 
-  app-sys-image img {
-    max-width: 90%;
-    height: auto;
+  app-sys-image {
+    img {
+      max-width: 90%;
+      height: auto;
+    }
+  }
+
+  @media screen and (min-width: 601px) and (max-width: 750px)  {
+    .tn-sys-image {
+      position: relative;
+      left: 25px;
+    }
   }
 
   app-production-status {
     .mat-card {
         top: 12px;
         background-color: rgba(127,127,127,0.1);
-        max-width: 460px !important;
-        min-width: 300px;
+        width: 230px;
+        margin: 0 !important;
     }
     .mat-card-actions {
       top: 5px;
@@ -1287,6 +1319,12 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     }
     .temp {
       height: 0 !important;
+    }
+
+    @media screen and (max-width: 599px) {
+      .mat-card {
+        top: 25px;
+      }
     }
   }
 
@@ -1315,6 +1353,12 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
       margin-bottom: 20px;
 
     }
+
+    @media screen and (max-width: 599px) {
+      .mat-card {
+        top: -35px;
+      }
+    }
   }
 
   app-fn-support {
@@ -1331,6 +1375,19 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     form {
       margin-bottom: -40px;
     }
+
+    @media screen and (max-width: 599px) {
+      .mat-card-actions {
+        top: 0;
+      }
+      .lowerme {
+        margin-top: 0 !important;
+      }
+      form {
+        margin-bottom: 4px;
+      }
+    }
+      
   }
 
   app-tn-support {
@@ -1343,6 +1400,19 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
       height: 0px;
       top: -55px;
       position: relative;
+    }
+
+    @media screen and (max-width: 599px) {
+      .mat-card-actions {
+        top: 0;
+        height: 25px !important;
+      }
+      .lowerme {
+        margin-top: 0 !important;
+      }
+      .mat-card {
+        top: -15px;
+      }
     }
   }
 // End support section //////////////

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -1270,12 +1270,9 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     }
   }
 
-
-
   app-tn-sys-info {
     .tn-sys-info-line {
       margin-top: 10px;
-      height: 40px;
 
       h4 {
         margin-bottom: 3px;
@@ -1299,10 +1296,11 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     }
   }
 
-  @media screen and (min-width: 601px) and (max-width: 750px)  {
+  @media screen and (min-width: 600px) and (max-width: 749px)  {
     .tn-sys-image {
       position: relative;
-      left: 25px;
+      left: 35px;
+      // max-width: 75%;
     }
   }
 
@@ -1327,6 +1325,7 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     @media screen and (max-width: 599px) {
       .mat-card {
         top: 25px;
+        width: auto;
       }
     }
   }

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -1197,7 +1197,7 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
   app-support {
     .mat-card {
       padding-bottom: 60px;
-      // min-width: 720px;
+      min-width: 320px;
     }
     #top-row {
       margin: 0 15px;
@@ -1249,6 +1249,15 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     @media screen and (max-width: 400px) {
       app-sys-image img {
         max-width: 80%;
+      }
+      .mat-card {
+        margin-left: -10px;
+      }
+    }
+
+    @media screen and (max-width: 350px) {
+      .mat-card {
+        margin-left: -20px;
       }
     }
   }
@@ -1328,6 +1337,18 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
         width: auto;
       }
     }
+
+    @media screen and (max-width: 460px) {
+      .mat-card {
+        top: 25px;
+        height: auto;
+      }
+      .mat-card-actions {
+        position: relative;
+        top: unset;
+        left: unset;
+      }
+    }
   }
 
   app-proactive {
@@ -1359,6 +1380,17 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     @media screen and (max-width: 599px) {
       .mat-card {
         top: -35px;
+      }
+    }
+
+    @media screen and (max-width: 460px) {
+      .mat-card-actions {
+        top: 25px;
+        height: auto;
+        position: relative;
+        left: unset;
+        height: auto;
+        top: unset;
       }
     }
   }


### PR DESCRIPTION
Makes both FN and TN support pages display well down to 375px width (iPhone 6) and fairly well down to 325px, the width of the iPhone 5