### PR TITLE
NAS-102853

### DIFF
--- a/src/app/pages/common/entity/entity-form/entity-form.component.scss
+++ b/src/app/pages/common/entity/entity-form/entity-form.component.scss
@@ -44,6 +44,7 @@
   padding:0 ;
   width:100%;
   height:100%;
+  overflow: visible;
 }
 
 .mat-card-actions{


### PR DESCRIPTION
Fixes condition where tooltips on entity form 'slide under' the border after visiting a page with expansion headers