### PR TITLE
NAS-103464: Update clone tooltip to include allowable chars

### DIFF
--- a/src/app/helptext/system/bootenv.ts
+++ b/src/app/helptext/system/bootenv.ts
@@ -14,7 +14,7 @@ export const helptext_system_bootenv = {
   clone_name_placeholder: T("Name"),
   clone_name_tooltip: T(
     "Enter a name for the clone of this boot environment.\
- Names may include alphanumeric characters as well as\
+ Allowed characters are alphanumeric, as well as\
  dashes (*-*), underscores (*_*), and periods (*.*)"
   ),
   

--- a/src/app/helptext/system/bootenv.ts
+++ b/src/app/helptext/system/bootenv.ts
@@ -13,9 +13,11 @@ export const helptext_system_bootenv = {
 
   clone_name_placeholder: T("Name"),
   clone_name_tooltip: T(
-    "Enter a name for the clone of this boot\
- environment."
+    "Enter a name for the clone of this boot environment.\
+ Names may include alphanumeric characters as well as\
+ dashes (*-*), underscores (*_*), and periods (*.*)"
   ),
+  
   clone_source_placeholder: T("Source"),
   clone_source_tooltip: T("This is the boot environment to be cloned."),
 

--- a/src/app/helptext/system/bootenv.ts
+++ b/src/app/helptext/system/bootenv.ts
@@ -14,8 +14,8 @@ export const helptext_system_bootenv = {
   clone_name_placeholder: T("Name"),
   clone_name_tooltip: T(
     "Enter a name for the clone of this boot environment.\
- Allowed characters are alphanumeric, as well as\
- dashes (*-*), underscores (*_*), and periods (*.*)"
+ Alphanumeric characters, dashes (*-*), underscores (*_*),\
+ and periods (*.*) are allowed.)"
   ),
   
   clone_source_placeholder: T("Source"),


### PR DESCRIPTION
Add information in the tooltip to inform users of valid characters.