### PR TITLE
NAS-103465: Update rename tooltip to include allowable chars

### DIFF
--- a/src/app/helptext/system/bootenv.ts
+++ b/src/app/helptext/system/bootenv.ts
@@ -30,8 +30,8 @@ export const helptext_system_bootenv = {
   rename_name_placeholder: T("Name"),
   rename_name_tooltip: T(
     "Rename the existing boot environment.\
-  Allowed characters are alphanumeric, as well as\
-  dashes (*-*), underscores (*_*), and periods (*.*)"
+ Alphanumeric characters, dashes (*-*), underscores (*_*),\
+ and periods (*.*) are allowed.)"
   ),
 
   replace_name_placeholder: T("Member Disk"),

--- a/src/app/helptext/system/bootenv.ts
+++ b/src/app/helptext/system/bootenv.ts
@@ -30,7 +30,7 @@ export const helptext_system_bootenv = {
   rename_name_placeholder: T("Name"),
   rename_name_tooltip: T(
     "Rename the existing boot environment.\
-  Names may include alphanumeric characters as well as\
+  Allowed characters are alphanumeric, as well as\
   dashes (*-*), underscores (*_*), and periods (*.*)"
   ),
 

--- a/src/app/helptext/system/bootenv.ts
+++ b/src/app/helptext/system/bootenv.ts
@@ -28,7 +28,11 @@ export const helptext_system_bootenv = {
   list_dialog_scrub_action: T("Start Scrub"),
 
   rename_name_placeholder: T("Name"),
-  rename_name_tooltip: T("Rename the existing boot environment."),
+  rename_name_tooltip: T(
+    "Rename the existing boot environment.\
+  Names may include alphanumeric characters as well as\
+  dashes (*-*), underscores (*_*), and periods (*.*)"
+  ),
 
   replace_name_placeholder: T("Member Disk"),
 


### PR DESCRIPTION
Add information in the tooltip to inform users of valid characters.