### PR TITLE
NAS-103466 Make Activate conditional

### DIFF
--- a/src/app/pages/system/bootenv/bootenv-list/bootenv-list.component.ts
+++ b/src/app/pages/system/bootenv/bootenv-list/bootenv-list.component.ts
@@ -149,6 +149,15 @@ export class BootEnvironmentListComponent {
           )
       });
     }
+    if (!row.active.includes('Reboot')) {
+      actions.push({
+        label : T("Activate"),
+        id: "activate",
+        onClick : (row) => {
+          this.doActivate(row.id);
+        }
+      }); 
+    }
 
     actions.push({
       label : T("Clone"),
@@ -166,13 +175,7 @@ export class BootEnvironmentListComponent {
             [ "system", "boot", "rename", row.id ]));
       }
     });
-    actions.push({
-      label : T("Activate"),
-      id: "activate",
-      onClick : (row) => {
-        this.doActivate(row.id);
-      }
-    });
+
     if (row.keep === true){
       actions.push({
         label : T("Unkeep"),


### PR DESCRIPTION
If boot env 'Active' is 'Now/Reboot' or 'Reboot', the menu item to Activate disappears