### PR TITLE
Nas 103604

### DIFF
--- a/src/app/pages/common/entity/entity-form/components/form-input/form-input.component.html
+++ b/src/app/pages/common/entity/entity-form/components/form-input/form-input.component.html
@@ -10,6 +10,10 @@
 			id="{{config.name}}_form-input-spinner"
 			*ngIf="config.isLoading">
 		</mat-spinner>
+		<div *ngIf="config.isDoubleConfirm">
+			<p>{{'Enter' | translate}} <strong>{{config.maskValue}}</strong> {{'below to confirm.' | translate}}</p>
+			<p [ngStyle]="{'position': 'relative', 'top':'15px', 'opacity': '.38'}">{{config.maskValue}}</p>
+		</div> 
 		<input matInput [type]="config.inputType ? config.inputType : 'text'"
 			[placeholder]="config.placeholder | translate"
 			[attr.value]="config.value"

--- a/src/app/pages/common/entity/entity-form/models/field-config.interface.ts
+++ b/src/app/pages/common/entity/entity-form/models/field-config.interface.ts
@@ -17,6 +17,7 @@ export interface FieldConfig {
   warnings?: string, hideButton?:boolean, searchOptions?: any[], hideDirs?: any,
   listFields?: Array<FieldConfig>[], templateListField?: FieldConfig[],
   updateLocal?: boolean, isLoading?: boolean, textAreaRows?: number, netmaskPreset?: number,
-  isLargeText?: boolean, paragraphIcon?: string, zeroStateMessage?: string
+  isLargeText?: boolean, paragraphIcon?: string, zeroStateMessage?: string, isDoubleConfirm?:boolean,
+  maskValue?: any
   customEventMethod?(data:any), onChangeOption?(data:any),
 }

--- a/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
@@ -388,7 +388,7 @@ export class VolumesListTableConfig implements InputTableConf {
               paraText: helptext.detachDialog_pool_detach_warning_paratext_a + row1.name +
                 helptext.detachDialog_pool_detach_warning_paratext_b,
               isHidden: false
-            }, {
+            },{
               type: 'paragraph',
               name: 'pool_processes',
               paraText: p1,
@@ -411,17 +411,44 @@ export class VolumesListTableConfig implements InputTableConf {
             },{
               type: 'paragraph',
               name: 'typeName',
-              paraText: 'Enter the name of the pool below to confirm.'
+              paraText: T(`Enter <b>${row1.name}</b> below to confirm.`),
+              relation : [
+                {
+                  action : 'HIDE',
+                  when : [ {
+                    name : 'destroy',
+                    value : false,
+                  } ]
+                },
+              ]
             },
             {
               type: 'paragraph',
               name: 'nameMask',
-              paraText: row1.name
+              paraText: row1.name,
+              relation : [
+                {
+                  action : 'HIDE',
+                  when : [ {
+                    name : 'destroy',
+                    value : false,
+                  } ]
+                },
+              ]
             },{
               type: 'input',
               name: 'nameInput',
               required: true,
-              validation: [Validators.pattern(row1.name)]
+              validation: [Validators.pattern(row1.name)],
+              relation : [
+                {
+                  action : 'HIDE',
+                  when : [ {
+                    name : 'destroy',
+                    value : false,
+                  } ]
+                },
+              ]
             },{
               type: 'checkbox',
               name: 'confirm',

--- a/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
@@ -409,36 +409,11 @@ export class VolumesListTableConfig implements InputTableConf {
               value: true,
               placeholder: helptext.detachDialog_pool_detach_cascade_checkbox_placeholder,
             },{
-              type: 'paragraph',
-              name: 'typeName',
-              paraText: T(`Enter <b>${row1.name}</b> below to confirm.`),
-              relation : [
-                {
-                  action : 'HIDE',
-                  when : [ {
-                    name : 'destroy',
-                    value : false,
-                  } ]
-                },
-              ]
-            },
-            {
-              type: 'paragraph',
-              name: 'nameMask',
-              paraText: row1.name,
-              relation : [
-                {
-                  action : 'HIDE',
-                  when : [ {
-                    name : 'destroy',
-                    value : false,
-                  } ]
-                },
-              ]
-            },{
               type: 'input',
               name: 'nameInput',
               required: true,
+              isDoubleConfirm: true,
+              maskValue: row1.name,
               validation: [Validators.pattern(row1.name)],
               relation : [
                 {

--- a/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
@@ -26,6 +26,7 @@ import { SnackbarService } from '../../../../services/snackbar.service';
 import { Observable } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 import { PreferencesService } from 'app/core/services/preferences.service';
+import { Validators } from '@angular/forms';
 
 export interface ZfsPoolData {
   avail?: number;
@@ -407,6 +408,20 @@ export class VolumesListTableConfig implements InputTableConf {
               name: 'cascade',
               value: true,
               placeholder: helptext.detachDialog_pool_detach_cascade_checkbox_placeholder,
+            },{
+              type: 'paragraph',
+              name: 'typeName',
+              paraText: 'Enter the name of the pool below to confirm.'
+            },
+            {
+              type: 'paragraph',
+              name: 'nameMask',
+              paraText: row1.name
+            },{
+              type: 'input',
+              name: 'nameInput',
+              required: true,
+              validation: [Validators.pattern(row1.name)]
             },{
               type: 'checkbox',
               name: 'confirm',

--- a/src/app/services/dialog.service.ts
+++ b/src/app/services/dialog.service.ts
@@ -150,7 +150,7 @@ export class DialogService {
     public dialogFormWide(conf: any): Observable<boolean> {
         let dialogRef: MatDialogRef<EntityDialogComponent>;
 
-        dialogRef = this.dialog.open(EntityDialogComponent, {maxWidth: '490px', minWidth: '490px'});
+        dialogRef = this.dialog.open(EntityDialogComponent, {maxWidth: '490px', minWidth: '490px', disableClose: true});
         dialogRef.componentInstance.conf = conf;
 
         return dialogRef.afterClosed();

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -1668,15 +1668,4 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     }
   }
 
-  app-entity-dialog {
-    #typeName {
-      margin-bottom: -20px;
-    }
-    #nameMask {
-      top: 35px;
-      position: relative;
-      opacity: .38;
-    }
-  }
-
  } // end of ix theme

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -1668,4 +1668,15 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     }
   }
 
+  app-entity-dialog {
+    #typeName {
+      margin-bottom: -20px;
+    }
+    #nameMask {
+      top: 35px;
+      position: relative;
+      opacity: .38;
+    }
+  }
+
  } // end of ix theme


### PR DESCRIPTION
Adds a double-confirm input to Pool Export dialog and makes it possible to use form-input as a 'masked'  double-confirm input with just two config properties. Also sets disableclose to true on the wide dialog form!!!