### PR TITLE
NAS-103712 Remove entity form snackbar etc

### DIFF
--- a/src/app/helptext/account/user-change-pw.ts
+++ b/src/app/helptext/account/user-change-pw.ts
@@ -16,5 +16,5 @@ pw_confirm_pw_placeholder : T('Confirm Password'),
 pw_confirm_pw_validation : [ matchOtherValidator('password') ],
 pw_invalid_title: T('Incorrect Password'),
 pw_invalid_msg: T('The administrator password is incorrect.'),
-pw_updated_title: T("Password updated.")
+pw_updated: T("Password updated.")
 }

--- a/src/app/helptext/system/advanced.ts
+++ b/src/app/helptext/system/advanced.ts
@@ -98,10 +98,5 @@ export const helptext_system_advanced = {
   swapondrive_warning: T("A swap size of 0 is STRONGLY DISCOURAGED."),
 
   debug_download_failed_title: T("Error Downloading File"),
-  debug_download_failed_message: T("Debug could not be downloaded."),
-
-  submit_dialog: {
-    title: T('Success'), 
-    message: T('Settings saved.')
-  }
+  debug_download_failed_message: T("Debug could not be downloaded."),  
 };

--- a/src/app/pages/account/users/change-password/change-password.component.ts
+++ b/src/app/pages/account/users/change-password/change-password.component.ts
@@ -1,13 +1,11 @@
-import {Component, OnInit} from '@angular/core';
-import {Router} from "@angular/router";
-import {WebSocketService, DialogService} from "../../../../services/";
-import {AppLoaderService} from "../../../../services/app-loader/app-loader.service";
-import {MatSnackBar} from "@angular/material";
+import { Component } from '@angular/core';
+import { Router } from "@angular/router";
+import { WebSocketService, DialogService } from "../../../../services/";
+import { AppLoaderService } from "../../../../services/app-loader/app-loader.service";
 import { FieldConfig } from '../../../common/entity/entity-form/models/field-config.interface';
 import { FieldSet } from '../../../common/entity/entity-form/models/fieldset.interface';
 import helptext from '../../../../helptext/account/user-change-pw';
 import { EntityUtils } from '../../../common/entity/utils';
-import { T } from '../../../../translate-marker';
 
 @Component({
   template: `<entity-form [conf]="this"></entity-form>`,
@@ -53,8 +51,7 @@ export class ChangePasswordComponent {
   }]
 
   constructor(protected ws: WebSocketService, protected router: Router,
-              protected loader: AppLoaderService, protected dialog: DialogService,
-              public snackBar: MatSnackBar) {
+              protected loader: AppLoaderService, protected dialog: DialogService) {
   }
 
   preInit(entityForm) {
@@ -69,7 +66,9 @@ export class ChangePasswordComponent {
         delete body.curr_password;
         this.ws.call('user.update', [1, body]).subscribe((res) => {
           this.loader.close();
-          this.dialog.Info(helptext.pw_updated_title, '', '300px', 'info', true);
+          this.entityForm.success = true;
+          this.entityForm.successMessage = helptext.pw_updated;
+          this.entityForm.formGroup.markAsPristine();
         }, (res) => {
           this.loader.close();
           new EntityUtils().handleWSError(this.entityForm, res);

--- a/src/app/pages/common/entity/entity-form/entity-form.component.html
+++ b/src/app/pages/common/entity/entity-form/entity-form.component.html
@@ -45,8 +45,8 @@
             </mat-card-actions>
           </div>
             <!-- <div class="btn-group btn-group-justified"> -->
+          <p *ngIf="success && entityForm.form.dirty === false" type="success" id="successfully_updated">{{successMessage | translate}}</p>
         </form>
-        <p *ngIf="success" type="success" id="successfully_updated">{{"Successfully updated." | translate}}</p>
         <span *ngIf="conf.form_message" id="form_message" class="form-message" [ngClass]="conf.form_message.type" [innerHTML]="conf.form_message.content"></span>
         <mat-error *ngIf="error" type="danger" id="error_message"><div [innerHTML]="error"></div></mat-error>
     </div>

--- a/src/app/pages/common/entity/entity-form/entity-form.component.ts
+++ b/src/app/pages/common/entity/entity-form/entity-form.component.ts
@@ -15,7 +15,6 @@ import {FormBuilder, FormControl, FormGroup, FormArray, Validators} from '@angul
 import {ActivatedRoute, Router} from '@angular/router';
 import * as _ from 'lodash';
 import {Subscription} from 'rxjs/Rx';
-import { MatSnackBar } from '@angular/material';
 import { TranslateService } from '@ngx-translate/core';
 
 import {RestService, WebSocketService} from '../../../../services/';
@@ -122,6 +121,7 @@ export class EntityFormComponent implements OnInit, OnDestroy, OnChanges, AfterV
   public saveSubmitText = "Save";
   public showPassword = false;
   public isFooterConsoleOpen: boolean;
+  public successMessage = T('Settings saved.')
 
   get controls() {
     return this.fieldConfig.filter(({type}) => type !== 'button');
@@ -151,7 +151,6 @@ export class EntityFormComponent implements OnInit, OnDestroy, OnChanges, AfterV
               protected entityFormService: EntityFormService,
               protected fieldRelationService: FieldRelationService,
               protected loader: AppLoaderService,
-              public snackBar: MatSnackBar,
               public adminLayout: AdminLayoutComponent,
               private dialog:DialogService,
               public translate: TranslateService) {
@@ -505,8 +504,8 @@ export class EntityFormComponent implements OnInit, OnDestroy, OnChanges, AfterV
                               this.router.navigate(new Array('/').concat(
                                   this.conf.route_success));
                             } else {
-                              this.snackBar.open("Settings saved.", 'close', { duration: 5000 })
                               this.success = true;
+                              this.formGroup.markAsPristine();
                             }
 
                             if (this.conf.afterSubmit) {

--- a/src/app/pages/system/advanced/advanced.component.ts
+++ b/src/app/pages/system/advanced/advanced.component.ts
@@ -296,8 +296,8 @@ export class AdvancedComponent implements OnDestroy {
     this.load.open();
     return this.ws.call('system.advanced.update', [body]).subscribe((res) => {
       this.load.close();
-      this.dialog.Info(helptext_system_advanced.submit_dialog.title, 
-        helptext_system_advanced.submit_dialog.message, '300px', 'info', true)
+      this.entityForm.success = true;
+      this.entityForm.formGroup.markAsPristine();
       this.adminLayout.onShowConsoleFooterBar(body['consolemsg']);
     }, (res) => {
       this.load.close();

--- a/src/app/pages/system/dataset/dataset.component.ts
+++ b/src/app/pages/system/dataset/dataset.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 
 import * as _ from 'lodash';
-import { RestService, WebSocketService, SnackbarService, DialogService } from '../../../services/';
+import { RestService, WebSocketService, DialogService } from '../../../services/';
 import { FieldConfig } from '../../common/entity/entity-form/models/field-config.interface';
 import { helptext_system_dataset } from 'app/helptext/system/dataset';
 import { EntityUtils } from '../../common/entity/utils';
@@ -12,13 +12,14 @@ import { T } from '../../../translate-marker';
 @Component({
   selector: 'app-system-dataset',
   template : `<entity-form [conf]="this"></entity-form>`,
-  providers: [SnackbarService]
+  providers: []
 })
 export class DatasetComponent implements OnInit{
 
   protected resource_name: string = 'storage/dataset';
   protected volume_name: string = 'storage/volume';
   public formGroup: FormGroup;
+  public entityForm: any;
 
   public fieldConfig: FieldConfig[] = [
     {
@@ -42,8 +43,7 @@ export class DatasetComponent implements OnInit{
   private pool: any;
   private syslog: any;
   constructor(private rest: RestService, private ws: WebSocketService,
-              private loader: AppLoaderService, private snackbarService: SnackbarService,
-              private dialogService: DialogService) {}
+              private loader: AppLoaderService, private dialogService: DialogService) {}
 
   ngOnInit() {
     this.rest.get(this.volume_name, {}).subscribe( res => {
@@ -57,6 +57,7 @@ export class DatasetComponent implements OnInit{
   }
 
   afterInit(entityForm: any) {
+    this.entityForm = entityForm;
     this.ws.call('systemdataset.config').subscribe(res => {
       entityForm.formGroup.controls['pool'].setValue(res.pool);
       entityForm.formGroup.controls['syslog'].setValue(res.syslog);
@@ -97,7 +98,9 @@ export class DatasetComponent implements OnInit{
           new EntityUtils().handleWSError(this, res);
         }
         if (res.state === 'SUCCESS') {
-            this.snackbarService.open(T("Settings saved."), T('Close'), { duration: 5000 });
+          this.loader.close()
+          this.entityForm.success = true;
+          this.entityForm.formGroup.markAsPristine();
         }
       },
       (err) => {

--- a/src/app/pages/system/email/email.component.ts
+++ b/src/app/pages/system/email/email.component.ts
@@ -189,7 +189,10 @@ export class EmailComponent implements OnDestroy {
     this.ws
       .call(this.updateCall, [emailConfig])
       .subscribe(
-        () => {},
+        () => {
+          this.entityEdit.success = true;
+          this.entityEdit.formGroup.markAsPristine();
+        },
         error => {
           this.loader.close();
           new EntityUtils().handleWSError(this, error, this.dialogservice)

--- a/src/app/pages/system/general/general.component.ts
+++ b/src/app/pages/system/general/general.component.ts
@@ -566,7 +566,8 @@ export class GeneralComponent {
     this.loader.open();
     return this.ws.call('system.general.update', [body]).subscribe(() => {
       this.loader.close();
-      this.dialog.Info(T("Settings saved."), '', '300px', 'info', true);
+      this.entityForm.success = true;
+      this.entityForm.formGroup.markAsPristine();
       this.afterSubmit(body);
     }, (res) => {
       this.loader.close();

--- a/src/app/pages/system/reporting/reporting.component.ts
+++ b/src/app/pages/system/reporting/reporting.component.ts
@@ -2,8 +2,7 @@ import { Component } from '@angular/core';
 import * as _ from 'lodash';
 import { AppLoaderService } from "../../../services/app-loader/app-loader.service";
 import { EntityUtils } from '../../common/entity/utils';
-import { RestService, WebSocketService, DialogService } from '../../../services/';
-import { T } from '../../../translate-marker';
+import { RestService, WebSocketService } from '../../../services/';
 import { FieldConfig } from '../../common/entity/entity-form/models/field-config.interface';
 import { helptext } from 'app/helptext/system/reporting';
 
@@ -17,7 +16,6 @@ export class ReportingComponent {
   public job: any = {};
   protected queryCall = 'reporting.config';
   public entityForm: any;
-  private settings_saved = T("Settings saved");
   public rrd_checkbox: any;
   custActions: any[] = [
     {
@@ -73,7 +71,7 @@ export class ReportingComponent {
 
   constructor(private rest: RestService,
     private load: AppLoaderService,
-    private ws: WebSocketService, public dialog: DialogService
+    private ws: WebSocketService
   ) {}
 
   afterInit(entityEdit: any) {
@@ -108,8 +106,9 @@ export class ReportingComponent {
     return this.ws.call('reporting.update', [body]).subscribe((res) => {
       this.load.close();
       this.rrd_checkbox['isHidden'] = true;
-      this.entityForm.formGroup.controls['confirm_rrd_destroy'].setValue(false)
-      this.dialog.Info(this.settings_saved, '', '300px', 'info', true);
+      this.entityForm.formGroup.controls['confirm_rrd_destroy'].setValue(false);
+      this.entityForm.success = true;
+      this.entityForm.formGroup.markAsPristine();
     }, (res) => {
       this.load.close();
       new EntityUtils().handleWSError(this.entityForm, res);

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -1670,4 +1670,9 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     }
   }
 
+  app-active-directory #successfully_updated {
+    position: relative;
+    top: 12px;
+  }
+
  } // end of ix theme


### PR DESCRIPTION
Removes snackbar from entity form. Any forms that submit thru entity form AND that don't have a success route should show 'Settings saved' under the save button until the form is edited. Likewise with entity forms that use a custom submit, though I had to look for these, and might possibly have missed some? 