### PR TITLE
NAS-104074 Convert num to human readable if no unit is specified

### DIFF
--- a/src/app/pages/vm/vm-wizard/vm-wizard.component.ts
+++ b/src/app/pages/vm/vm-wizard/vm-wizard.component.ts
@@ -647,6 +647,9 @@ blurEvent2(parent){
   const vm_memory_requested = parent.storageService.convertHumanStringToNum(enteredVal);
   if (isNaN(vm_memory_requested)) {
     console.error(vm_memory_requested) // leaves form in previous error state
+  } else if (enteredVal.replace(/\s/g, '').match(/[^0-9]/g) === null) {
+    parent.entityWizard.formArray.get([1]).get('memory')
+      .setValue(parent.storageService.convertBytestoHumanReadable(enteredVal.replace(/\s/g, ''), 0));
   } else {
     parent.entityWizard.formArray.get([1]).get('memory').setValue(parent.storageService.humanReadable);
     _.find(parent.wizardConfig[1].fieldConfig, {'name' : 'memory'})['hasErrors'] = false;


### PR DESCRIPTION
If the memory input contains only numbers (after spaces are stripped out), form displays a human readable equivalent to bytes
Ticket also mentions zvols, but we already turn any zvol number w/o a label into MiB