### PR TITLE
NAS-104115 Change string to number in validator

### DIFF
--- a/src/app/pages/common/entity/entity-form/validators/compare-validation.ts
+++ b/src/app/pages/common/entity/entity-form/validators/compare-validation.ts
@@ -26,8 +26,9 @@ export function greaterThan(otherControlName: string, fieldPlaceholers: [string]
     if (!otherControl) {
       return null;
     }
-
-    if (otherControl.value > thisControl.value) {
+    let otherVal = parseFloat(otherControl.value);
+    let thisVal =  parseFloat(thisControl.value);
+    if (otherVal > thisVal) {
       return {greaterThan: true, fields: fieldPlaceholers};
     }
 

--- a/src/app/pages/common/entity/entity-form/validators/compare-validation.ts
+++ b/src/app/pages/common/entity/entity-form/validators/compare-validation.ts
@@ -26,9 +26,9 @@ export function greaterThan(otherControlName: string, fieldPlaceholers: [string]
     if (!otherControl) {
       return null;
     }
-    let otherVal = parseFloat(otherControl.value);
-    let thisVal =  parseFloat(thisControl.value);
-    if (otherVal > thisVal) {
+    let otherVal = Number(otherControl.value);
+    let thisVal =  Number(thisControl.value);
+    if (otherVal >= thisVal) {
       return {greaterThan: true, fields: fieldPlaceholers};
     }
 


### PR DESCRIPTION
inputs (even when inputType = number) send strings to greaterThan validator when we edit values, so the validator tries to compare them alphabetically; This changes them to numbers before they are compared. Only the NTP servers forms and the SMB service form use this validator right now, and this seems to work on all of those cases.

![Screenshot from 2019-12-04 10-02-31](https://user-images.githubusercontent.com/9504493/70154564-b2392000-167e-11ea-8927-67eae084f5ba.png)
![Screenshot from 2019-12-04 10-01-49](https://user-images.githubusercontent.com/9504493/70154569-b36a4d00-167e-11ea-877c-f001c4054322.png)
