### PR TITLE
Nas 104085

### DIFF
--- a/src/app/helptext/system/advanced.ts
+++ b/src/app/helptext/system/advanced.ts
@@ -93,7 +93,6 @@ export const helptext_system_advanced = {
 
   sed_passwd2_placeholder: T('Confirm SED Password'),
   sed_passwd2_tooltip: T(''),
-  sed_passwd2_validation: [ matchOtherValidator('sed_passwd') ],
 
   swapondrive_warning: T("A swap size of 0 is STRONGLY DISCOURAGED."),
 

--- a/src/app/pages/common/entity/entity-form/components/form-errors/form-errors.component.html
+++ b/src/app/pages/common/entity/entity-form/components/form-errors/form-errors.component.html
@@ -14,13 +14,16 @@
     <mat-error *ngIf="control.hasError('forbidden')">
         {{"This name has already been used." | translate}}
     </mat-error>
-    <mat-error *ngIf="control.hasError('matchOther')">
-        {{"The passwords do not match." | translate}}
-    </mat-error>
     <mat-error *ngIf="control.hasError('range')">
         {{"The value is out of range. Enter a value between " | translate}} {{control.errors.rangeValue.min}} {{" and " | translate }} {{control.errors.rangeValue.max}}.
     </mat-error>
     <mat-error *ngIf="control.hasError('regex')">
         {{"Invalid format or character." | translate}}
+    </mat-error>
+</div>
+
+<div class="form-error">
+    <mat-error *ngIf="control.hasError('matchOther')">
+        {{"The passwords do not match." | translate}}
     </mat-error>
 </div>

--- a/src/app/pages/system/advanced/advanced.component.ts
+++ b/src/app/pages/system/advanced/advanced.component.ts
@@ -6,13 +6,12 @@ import { DialogService } from "../../../services/dialog.service";
 import { MatDialog } from '@angular/material';
 import { EntityJobComponent } from '../../common/entity/entity-job/entity-job.component';
 import { EntityUtils } from '../../common/entity/utils';
-import { RestService, WebSocketService, StorageService } from '../../../services/';
+import { RestService, WebSocketService, StorageService, ValidationService } from '../../../services/';
 import {AdminLayoutComponent} from '../../../components/common/layouts/admin-layout/admin-layout.component';
 import { T } from '../../../translate-marker';
 import { FieldConfig } from '../../common/entity/entity-form/models/field-config.interface';
 import { helptext_system_advanced } from 'app/helptext/system/advanced';
 import { Http } from '@angular/http';
-
 
 @Component({
   selector: 'app-system-advanced',
@@ -208,7 +207,7 @@ export class AdvancedComponent implements OnDestroy {
     placeholder: helptext_system_advanced.sed_passwd_placeholder,
     tooltip: helptext_system_advanced.sed_passwd_tooltip,
     inputType: 'password',
-    togglePw: true,
+    togglePw: true
   },
   {
     type: 'input',
@@ -216,8 +215,7 @@ export class AdvancedComponent implements OnDestroy {
     placeholder: helptext_system_advanced.sed_passwd2_placeholder,
     tooltip: helptext_system_advanced.sed_passwd2_tooltip,
     inputType: 'password',
-    validation : helptext_system_advanced.sed_passwd2_validation,
-
+    validation : this.validationService.matchOtherValidator('sed_passwd')
   },
 ];
 
@@ -229,7 +227,8 @@ export class AdvancedComponent implements OnDestroy {
     protected matDialog: MatDialog,
     public datePipe: DatePipe,
     public http: Http,
-    public storage: StorageService) {}
+    public storage: StorageService,
+    public validationService: ValidationService) {}
 
   ngOnDestroy() {
     this.swapondrive_subscription.unsubscribe();

--- a/src/app/services/index.ts
+++ b/src/app/services/index.ts
@@ -22,3 +22,4 @@ export * from './snackbar.service';
 export * from './keychaincredential.services';
 export * from './replication.service';
 export * from './services.service';
+export * from './validation.service';

--- a/src/app/services/validation.service.ts
+++ b/src/app/services/validation.service.ts
@@ -1,0 +1,42 @@
+import {Injectable} from '@angular/core';
+import {FormControl} from '@angular/forms'
+
+@Injectable({providedIn: 'root'})
+export class ValidationService {
+
+  matchOtherValidator(otherControlName: string) {
+
+    let thisControl: FormControl;
+    let otherControl: FormControl;
+  
+    return function matchOtherValidate(control: FormControl) {
+  
+      if (!control.parent) {
+        return null;
+      }
+  
+      // Initializing the validator.
+      if (!thisControl) {
+        thisControl = control;
+        otherControl = control.parent.get(otherControlName) as FormControl;
+        if (!otherControl) {
+          throw new Error(
+              'matchOtherValidator(): other control is not found in parent group');
+        }
+        otherControl.valueChanges.subscribe(
+            () => { thisControl.updateValueAndValidity(); });
+      }
+  
+      if (!otherControl) {
+        return null;
+      }
+  
+      if (otherControl.value !== thisControl.value) {
+        return {matchOther : true};
+      }
+  
+      return null;
+  
+    }
+  }
+}


### PR DESCRIPTION
Keeps the pw-matching validator working on Sys Adv form

Custom validators seem to quit listening to value changes (sometimes after save, almost always when user navigates away and then comes back), until page is refreshed. Custom validators in the component and in a service don't seem to do this. This PR puts the match password validator into a new service. Also makes a slight adjustment to the form-errors component so that errors show immediately on mismatch, a style consideration that I think might be less confusing for the user.