### PR TITLE
Correct spelling mistake in System/General

### DIFF
--- a/src/app/helptext/system/general.ts
+++ b/src/app/helptext/system/general.ts
@@ -126,7 +126,7 @@ export const helptext_system_general = {
   },
 
   poolkeys: {
-    placeholder: T("Export Pool Ecryption Keys"),
+    placeholder: T("Export Pool Encryption Keys"),
     tooltip: T('')
   },
 


### PR DESCRIPTION
Correction typo in Save Configuration from "Export Pool Ecryption Keys" to "Export Pool Encryption Keys".