### PR TITLE
NAS-103854: Update Sharing/iSCSI/Discovery Auth Group help text:

### DIFF
--- a/src/app/helptext/sharing/iscsi/iscsi-wizard.ts
+++ b/src/app/helptext/sharing/iscsi/iscsi-wizard.ts
@@ -45,8 +45,9 @@ export default {
  discovery while CHAP and Mutual CHAP require authentication."),
 
     discovery_authgroup_placeholder: T("Discovery Auth Group"),
-    discovery_authgroup_tooltip: T("Select a user created in Authorized Access if the Discovery Auth Method is set to CHAP\
- or Mutual CHAP."),
+    discovery_authgroup_tooltip: T("Group ID created in Authorized \
+ Access. Required when the Discovery Auth Method is set to CHAP or \
+ Mutual CHAP."),
 
     ip_placeholder: T("IP"),
     ip_tooltip: T("Select the IP address associated with an interface or the wildcard address of 0.0.0.0 (any interface)."),

--- a/src/app/helptext/sharing/iscsi/iscsi.ts
+++ b/src/app/helptext/sharing/iscsi/iscsi.ts
@@ -64,10 +64,9 @@ export const helptext_sharing_iscsi = {
   ),
 
   portal_form_placeholder_discovery_authgroup: T("Discovery Auth Group"),
-  portal_form_tooltip_discovery_authgroup: T(
-    "Select a Group ID created in <b>Authorized Access</b> if the\
- <b>Discovery Auth Method</b> is set to <i>CHAP</i> or\
- <i>Mutual CHAP</i>."
+  portal_form_tooltip_discovery_authgroup: T("Group ID created in \
+ Authorized Access. Required when the Discovery Auth Method is set to \
+ CHAP or Mutual CHAP."
   ),
 
   portal_form_placeholder_ip: T("IP Address"),


### PR DESCRIPTION
- Update identical string in both help text files.
- Yarn testing: no issues.