### PR TITLE
Nas 104291a

### DIFF
--- a/src/app/pages/system/CloudCredentials/cloudcredentials-form/cloudcredentials-form.component.ts
+++ b/src/app/pages/system/CloudCredentials/cloudcredentials-form/cloudcredentials-form.component.ts
@@ -903,7 +903,6 @@ export class CloudCredentialsFormComponent {
         if (value.attributes.private_key && value.attributes.private_key === 'NEW') {
           this.makeNewKeyPair(value).then(() => {
             value.attributes.private_key = this.keyID;
-            this.verifyCredentials(value);
           })
         } else {
         this.verifyCredentials(value);
@@ -1059,7 +1058,8 @@ export class CloudCredentialsFormComponent {
             this.keyID = sshKey.id;
             const privateKeySFTPField = _.find(this.fieldConfig, {'name': 'private_key-SFTP'});
             privateKeySFTPField.options.push({ label: payload.name, value: this.keyID});
-            this.entityForm.formGroup.controls['private_key-SFTP'].setValue(this.keyID);          
+            this.entityForm.formGroup.controls['private_key-SFTP'].setValue(this.keyID);
+            this.verifyCredentials(value);
           },
           (sshKey_err) => {
             this.entityForm.loader.close();

--- a/src/app/pages/system/CloudCredentials/cloudcredentials-form/cloudcredentials-form.component.ts
+++ b/src/app/pages/system/CloudCredentials/cloudcredentials-form/cloudcredentials-form.component.ts
@@ -1030,7 +1030,6 @@ export class CloudCredentialsFormComponent {
 
   verifyCredentials(value) {
     delete value['name'];
-    console.log(value)
     this.ws.call('cloudsync.credentials.verify', [value]).subscribe(
       (res) => {
         this.entityForm.loader.close();
@@ -1056,7 +1055,7 @@ export class CloudCredentialsFormComponent {
         };
         await this.ws.call('keychaincredential.create', [payload]).toPromise().then(
           (sshKey) => {
-            value['private_key-SFTP'] = sshKey.id;
+            // value['private_key-SFTP'] = sshKey.id;
             this.keyID = sshKey.id;
             const privateKeySFTPField = _.find(this.fieldConfig, {'name': 'private_key-SFTP'});
             this.ws.call('keychaincredential.query', [[["type", "=", "SSH_KEY_PAIR"]]]).subscribe(
@@ -1092,28 +1091,6 @@ export class CloudCredentialsFormComponent {
     this.entityForm.loader.open();
     const attributes = {};
     let attr_name: string;
-    if (value['private_key-SFTP'] === 'NEW') {
-      await this.replicationService.genSSHKeypair().then(
-        async (res) => {
-          const payload = {
-            name: value['name'] + ' Key',
-            type: 'SSH_KEY_PAIR',
-            attributes: res,
-          };
-          await this.ws.call('keychaincredential.create', [payload]).toPromise().then(
-            (sshKey) => {
-              value['private_key-SFTP'] = sshKey.id;
-            },
-            (sshKey_err) => {
-              this.entityForm.loader.close();
-              new EntityUtils().handleWSError(this, sshKey_err, this.dialog);
-            });
-        },
-        (err) => {
-          this.entityForm.loader.close();
-          new EntityUtils().handleWSError(this, err, this.dialog);
-        });
-    }
     for (let item in value) {
       if (item != 'name' && item != 'provider') {
         if (item != 'preview-GOOGLE_CLOUD_STORAGE' && item != 'advanced-S3' && item !== 'drives-ONEDRIVE' && value[item] != '') {

--- a/src/app/pages/system/CloudCredentials/cloudcredentials-form/cloudcredentials-form.component.ts
+++ b/src/app/pages/system/CloudCredentials/cloudcredentials-form/cloudcredentials-form.component.ts
@@ -1058,15 +1058,18 @@ export class CloudCredentialsFormComponent {
             // value['private_key-SFTP'] = sshKey.id;
             this.keyID = sshKey.id;
             const privateKeySFTPField = _.find(this.fieldConfig, {'name': 'private_key-SFTP'});
-            this.ws.call('keychaincredential.query', [[["type", "=", "SSH_KEY_PAIR"]]]).subscribe(
-              (res) => {
-                privateKeySFTPField.options = [];
-                for (let i = 0; i < res.length; i++) {
-                  privateKeySFTPField.options.push({ label: res[i].name, value: res[i].id});
-                }
-                this.entityForm.formGroup.controls['private_key-SFTP'].setValue(this.keyID);
-              }
-            )
+            privateKeySFTPField.options.push({ label: payload.name, value: this.keyID});
+            this.entityForm.formGroup.controls['private_key-SFTP'].setValue(this.keyID);
+
+
+            // this.ws.call('keychaincredential.query', [[["type", "=", "SSH_KEY_PAIR"]]]).subscribe(
+            //   (res) => {
+            //     // privateKeySFTPField.options = [];
+            //     for (let i = 0; i < res.length; i++) {
+            //       privateKeySFTPField.options.push({ label: res[i].name, value: res[i].id});
+            //     }
+            //   }
+            // )
             
           },
           (sshKey_err) => {

--- a/src/app/pages/system/CloudCredentials/cloudcredentials-form/cloudcredentials-form.component.ts
+++ b/src/app/pages/system/CloudCredentials/cloudcredentials-form/cloudcredentials-form.component.ts
@@ -1059,18 +1059,7 @@ export class CloudCredentialsFormComponent {
             this.keyID = sshKey.id;
             const privateKeySFTPField = _.find(this.fieldConfig, {'name': 'private_key-SFTP'});
             privateKeySFTPField.options.push({ label: payload.name, value: this.keyID});
-            this.entityForm.formGroup.controls['private_key-SFTP'].setValue(this.keyID);
-
-
-            // this.ws.call('keychaincredential.query', [[["type", "=", "SSH_KEY_PAIR"]]]).subscribe(
-            //   (res) => {
-            //     // privateKeySFTPField.options = [];
-            //     for (let i = 0; i < res.length; i++) {
-            //       privateKeySFTPField.options.push({ label: res[i].name, value: res[i].id});
-            //     }
-            //   }
-            // )
-            
+            this.entityForm.formGroup.controls['private_key-SFTP'].setValue(this.keyID);          
           },
           (sshKey_err) => {
             this.entityForm.loader.close();

--- a/src/app/pages/system/CloudCredentials/cloudcredentials-form/cloudcredentials-form.component.ts
+++ b/src/app/pages/system/CloudCredentials/cloudcredentials-form/cloudcredentials-form.component.ts
@@ -1057,9 +1057,6 @@ export class CloudCredentialsFormComponent {
             const privateKeySFTPField = _.find(this.fieldConfig, {'name': 'private_key-SFTP'});
             privateKeySFTPField.options.push({ label: payload.name, value: this.keyID});
             this.entityForm.formGroup.controls['private_key-SFTP'].setValue(this.keyID);
-            console.log(value)
-            
-            console.log(submitting)
             if (submitting) {
               value['private_key-SFTP'] = sshKey.id;
               this.finishSubmit(value)


### PR DESCRIPTION
When verifying or saving cloud credentials, SFTP needs to make a key and store it first. This PR routes verifying and saving for SFTP through that process, and hopefully leaves other cloud providers alone. I tested this with ssh connection to a vm, and also with my S3 and Google Drive accounts