### PR TITLE
DOCS-116: Update iSCSI/Portals/IP Address help text

### DIFF
--- a/src/app/helptext/sharing/iscsi/iscsi-wizard.ts
+++ b/src/app/helptext/sharing/iscsi/iscsi-wizard.ts
@@ -50,7 +50,9 @@ export default {
  Mutual CHAP."),
 
     ip_placeholder: T("IP"),
-    ip_tooltip: T("Select the IP address associated with an interface or the wildcard address of 0.0.0.0 (any interface)."),
+    ip_tooltip: T("Select the IP addresses associated with an interface \
+ or the wildcard addresses 0.0.0.0 (all IPv4 addresses) and/or :: (all \
+ IPv6 addresses)."),
 
     port_placeholder: T("Port"),
     port_tooltip: T("TCP port used to access the iSCSI target. Default is 3260."),

--- a/src/app/helptext/sharing/iscsi/iscsi-wizard.ts
+++ b/src/app/helptext/sharing/iscsi/iscsi-wizard.ts
@@ -50,9 +50,10 @@ export default {
  Mutual CHAP."),
 
     ip_placeholder: T("IP"),
-    ip_tooltip: T("Select the IP addresses associated with an interface \
- or the wildcard addresses 0.0.0.0 (all IPv4 addresses) and/or :: (all \
- IPv6 addresses)."),
+    ip_tooltip: T("Select the IP addresses to be listened on by the \
+ portal. Click ADD to add IP addresses with a different network port. \
+ The address <i>0.0.0.0</i> can be selected to listen on all IPv4 \
+ addresses, or <i>::</i> to listen on all IPv6 addresses."),
 
     port_placeholder: T("Port"),
     port_tooltip: T("TCP port used to access the iSCSI target. Default is 3260."),

--- a/src/app/helptext/sharing/iscsi/iscsi.ts
+++ b/src/app/helptext/sharing/iscsi/iscsi.ts
@@ -70,9 +70,9 @@ export const helptext_sharing_iscsi = {
   ),
 
   portal_form_placeholder_ip: T("IP Address"),
-  portal_form_tooltip_ip: T(
-    "Select the IP address associated with an interface\
- or the wildcard address of <i>0.0.0.0</i> (any interface)."
+  portal_form_tooltip_ip: T("Select the IP addresses associated with an \
+ interface or the wildcard addresses 0.0.0.0 (all IPv4 addresses) and/or \
+ :: (all IPv6 addresses)."
   ),
   portal_form_validators_ip: [Validators.required],
 

--- a/src/app/helptext/sharing/iscsi/iscsi.ts
+++ b/src/app/helptext/sharing/iscsi/iscsi.ts
@@ -70,9 +70,10 @@ export const helptext_sharing_iscsi = {
   ),
 
   portal_form_placeholder_ip: T("IP Address"),
-  portal_form_tooltip_ip: T("Select the IP addresses associated with an \
- interface or the wildcard addresses 0.0.0.0 (all IPv4 addresses) and/or \
- :: (all IPv6 addresses)."
+  portal_form_tooltip_ip: T("Select the IP addresses to be listened on \
+ by the portal. Click ADD to add IP addresses with a different network \
+ port. The address <i>0.0.0.0</i> can be selected to listen on all IPv4 \
+ addresses, or <i>::</i> to listen on all IPv6 addresses."
   ),
   portal_form_validators_ip: [Validators.required],
 

--- a/src/app/pages/sharing/iscsi/portal/portal-form/portal-form.component.ts
+++ b/src/app/pages/sharing/iscsi/portal/portal-form/portal-form.component.ts
@@ -68,7 +68,7 @@ export class PortalFormComponent {
           multiple: true,
           name: 'ip',
           placeholder: helptext_sharing_iscsi.portal_form_placeholder_ip,
-          tooltip: helptext_sharing_iscsi.portal_form_placeholder_ip,
+          tooltip: helptext_sharing_iscsi.portal_form_tooltip_ip,
           options: [],
           class: 'inline',
           width: '60%',


### PR DESCRIPTION
- Update to include text about IPv6 wildcard.
- Fix bug that was preventing help text from displaying in Sharing/iSCSI/Portals/Add
- Yarn testing: no issues.