### PR TITLE
NAS-104561 Change global var for copyright year

### DIFF
--- a/src/app/helptext/global-helptext.ts
+++ b/src/app/helptext/global-helptext.ts
@@ -1,7 +1,7 @@
 import { T } from '../translate-marker';
 
 export default {
-    copyright_year: '2019',
+    copyright_year: '2020',
     dockerhost: T('Docker Host'),
 
     ctrlr: T('TrueNAS controller'),


### PR DESCRIPTION
Copyright appears on log in / out pages, in breadcrumb, about dialog. Also appears in Shell, w/c isn't updated by this global var