### PR TITLE
NAS-104598 Filter by label, ignore space and period

### DIFF
--- a/src/app/pages/services/services.component.html
+++ b/src/app/pages/services/services.component.html
@@ -4,7 +4,8 @@
       <mat-icon role="img">search</mat-icon>
       <div class="card-filter-field">
         <mat-form-field floatPlaceholder="Filter Service">
-          <input matInput #filter placeholder="Filter Service" [ngModel]="searchTerm" (ngModelChange)="displayFilter('title',$event)">
+          <input matInput #filter placeholder="Filter Service" [ngModel]="searchTerm" 
+          (ngModelChange)="displayFilter('label',$event)">
         </mat-form-field>
       </div>
     </div>

--- a/src/app/pages/services/services.component.ts
+++ b/src/app/pages/services/services.component.ts
@@ -101,7 +101,8 @@ export class Services implements OnInit {
       this.displayAll();
     } else {
       this.cards = this.cache.filter((card) => {
-        const result = card[key].toLowerCase().indexOf(query.toLowerCase()) > -1;
+        const result = card[key].toLowerCase().replace(/[.]/g, '').replace(/[ ]/g, '')
+          .indexOf(query.toLowerCase().replace(/[.]/g, '').replace(/[ ]/g, '')) > -1;
         return result;
       });
     }


### PR DESCRIPTION
Fixes filter on services page for SMB (which has a different name from its label), also ignores spaces (for two-word Services) and periods (for 'smart' or S.M.A.R.T.)