### PR TITLE
NAS-104495 / 11.3 / NAS-104495b

### DIFF
--- a/src/app/helptext/directoryservice/kerberossettings.ts
+++ b/src/app/helptext/directoryservice/kerberossettings.ts
@@ -4,14 +4,12 @@ export default {
 ks_appdefaults_name: 'ks_appdefaults_aux',
 ks_appdefaults_placeholder: T('Appdefaults Auxiliary Parameters'),
 ks_appdefaults_tooltip: T('Define any additional settings for use by some Kerberos\
- applications. The available settings and syntax is listed in the <a\
- href="http://web.mit.edu/kerberos/krb5-1.12/doc/admin/conf_files/krb5_conf.html#appdefaults"\
- target="_blank">appdefaults section of krb.conf(5).</a>.'),
+ applications. The available settings and syntax is listed in the \
+ <a href="http://web.mit.edu/kerberos/krb5-1.12/doc/admin/conf_files/krb5_conf.html#appdefaults" target="_blank">appdefaults section of krb.conf(5).</a>.'),
 
 ks_libdefaults_name: 'ks_libdefaults_aux',
 ks_libdefaults_placeholder: T('Libdefaults Auxiliary Parameters'),
 ks_libdefaults_tooltip: T('Define any settings used by the Kerberos library. The\
  available settings and their syntax are listed in the\
- <a href="http://web.mit.edu/kerberos/krb5-1.12/doc/admin/conf_files/krb5_conf.html#libdefaults"\
- target="_blank">libdefaults section of krb.conf(5).</a>.')
+ <a href="http://web.mit.edu/kerberos/krb5-1.12/doc/admin/conf_files/krb5_conf.html#libdefaults" target="_blank">libdefaults section of krb.conf(5).</a>.')
 }

--- a/src/app/helptext/storage/volumes/manager/manager.ts
+++ b/src/app/helptext/storage/volumes/manager/manager.ts
@@ -16,16 +16,12 @@ manager_vdevtypeErrorMessage : T("Adding data vdevs of different types is not su
 manager_diskAddWarning : T("The contents of all added disks will be erased."),
 manager_diskExtendWarning : T("Added disks are erased, then the pool is extended onto\
  the new disks with the chosen topology. Existing data on the pool is kept intact."),
-manager_name_tooltip : T('ZFS pools must conform to strict naming <a\
- href="https://docs.oracle.com/cd/E23824_01/html/821-1448/gbcpt.html"\
- target="_blank">conventions</a>. Choose a\
- memorable name.'),
-manager_encryption_tooltip : T('<a href="https://www.freebsd.org/cgi/man.cgi?query=geli&manpath=FreeBSD+11.1-RELEASE+and+Ports"\
- target="_blank">GELI</a> encryption is\
- available for ZFS pools. <b>WARNING:</b>\
- Read the <a\
- href="--docurl--/storage.html#managing-encrypted-pools"\
- target="_blank">Encryption section</a>\
+manager_name_tooltip : T('ZFS pools must conform to strict naming \
+ <a href="https://docs.oracle.com/cd/E23824_01/html/821-1448/gbcpt.html" target="_blank">conventions</a>. \
+ Choose a memorable name.'),
+manager_encryption_tooltip : T('<a href="https://www.freebsd.org/cgi/man.cgi?query=geli&manpath=FreeBSD+11.1-RELEASE+and+Ports" target="_blank">GELI</a> \
+ encryption is available for ZFS pools. <b>WARNING:</b> Read the \
+ <a href="--docurl--/storage.html#managing-encrypted-pools" target="_blank">Encryption section</a> \
  of the guide before activating this option.'),
 manager_suggested_layout_tooltip : T('Create a recommended formation\
  of vdevs in a pool.'),


### PR DESCRIPTION
The two links with local page anchor refs (#) break in production build (A '/' gets inserted into the path), though not necessarily on dev build or localhost. Had to hotpatch to test.