### PR TITLE
NAS-104636 / 12.0 / NAS-104636

### DIFF
--- a/src/app/core/components/widgets/widgetsysinfo/widgetsysinfo.component.html
+++ b/src/app/core/components/widgets/widgetsysinfo/widgetsysinfo.component.html
@@ -81,8 +81,7 @@
                 </mat-list-item>
   
                 <mat-list-item  *ngIf="data.system_serial && manufacturer == 'ixsystems' ">
-                  <span *ngIf="isHA"><strong>{{"Serial Number" | translate}}:</strong>&nbsp;&nbsp;{{isPassive ? data.license.system_serial_ha : data.license.system_serial}}</span>
-                  <span *ngIf="!isHA"><strong>{{"Serial Number" | translate}}:</strong>&nbsp;&nbsp;{{ data.system_serial}}</span>
+                  <span><strong>{{"Serial Number" | translate}}:</strong>&nbsp;&nbsp;{{ data.system_serial}}</span>
                 </mat-list-item>
               
                 <mat-list-item><strong>{{"HostName" | translate}}:</strong> &nbsp;&nbsp;{{data.hostname}}</mat-list-item>


### PR DESCRIPTION
Always use system_serial instead of license.system.serial

(cherry picked from commit 4a225842dbf0130da88acd497d38f3f1360b6749)