### PR TITLE
DOCS-100: Unify "Enable password login" field behavior, description, …

### DIFF
--- a/src/app/helptext/account/user-form.ts
+++ b/src/app/helptext/account/user-form.ts
@@ -84,10 +84,16 @@ user_form_auth_sshkey_placeholder : T('SSH Public Key'),
 user_form_auth_sshkey_tooltip : T('Enter or paste the <b>public</b> SSH key of the\
  user for any key-based authentication. <b>Do not paste the private key.</b>'),
 user_form_auth_pw_enable_name: 'password_disabled',
-user_form_auth_pw_enable_placeholder : T('Enable password login'),
-user_form_auth_pw_enable_tooltip : T('Enable password logins and authentication to SMB\
- shares. Selecting <b>No</b> removes the <b>Lock\
- User</b> and <b>Permit Sudo</b> options.'),
+user_form_auth_pw_enable_placeholder : T('Disable Password'),
+user_form_auth_pw_enable_tooltip : T('<i>Yes:</i> Disables the <b>Password</b> \
+ fields and removes the password from the account. The account cannot \
+ use password-based logins for services. For example, disabling the \
+ password prevents using account credentials to log in to an SMB share \
+ or open an SSH session on the system. The <b>Lock User</b> and \
+ <b>Permit Sudo</b> options are also removed.<br><br> \
+ <i>No:</i> Requires adding a <b>Password</b> to the account. The \
+ account can use the saved <b>Password</b> to authenticate with \
+ password-based services.'),
 user_form_auth_pw_enable_label_yes: T('Yes'),
 user_form_auth_pw_enable_label_no: T('No'),
 user_form_shell_name : 'shell',
@@ -95,11 +101,15 @@ user_form_shell_placeholder : T('Shell'),
 user_form_shell_tooltip : T('Select the shell to use for local and SSH logins.'),
 user_form_lockuser_name : 'locked',
 user_form_lockuser_placeholder : T('Lock User'),
-user_form_lockuser_tooltip : T('Set to disable logging in to this user account.'),
+user_form_lockuser_tooltip : T('Prevent the user from logging in or \
+ using password-based services until this option is unset. Locking an \
+ account is only possible when <b>Disable Password</b> is <i>No</i> and \
+ a <b>Password</b> has been created for the account.'),
 user_form_sudo_name: 'sudo',
 user_form_sudo_placeholder : T('Permit Sudo'),
-user_form_sudo_tooltip : T('Give this user permission to use <a\
- href="https://www.sudo.ws/" target="_blank">sudo</a>.'),
+user_form_sudo_tooltip : T('Give this user permission to use <a \
+ href="https://www.sudo.ws/" target="_blank">sudo</a>. When using sudo, \
+ a user is prompted for their account <b>Password</b>.'),
 user_form_microsoft_name : 'microsoft_account',
 user_form_microsoft_placeholder : T('Microsoft Account'),
 user_form_microsoft_tooltip : T('Set to allow additional username authentication\

--- a/src/app/pages/account/users/user-form/user-form.component.ts
+++ b/src/app/pages/account/users/user-form/user-form.component.ts
@@ -210,8 +210,8 @@ export class UserFormComponent {
           placeholder : helptext.user_form_auth_pw_enable_placeholder,
           tooltip : helptext.user_form_auth_pw_enable_tooltip,
           options : [
-            {label:helptext.user_form_auth_pw_enable_label_yes, value: false },
-            {label: helptext.user_form_auth_pw_enable_label_no, value: true },
+            {label:helptext.user_form_auth_pw_enable_label_yes, value: true },
+            {label: helptext.user_form_auth_pw_enable_label_no, value: false },
           ],
           value: false
         },

--- a/src/app/pages/account/users/user-list/user-list.component.ts
+++ b/src/app/pages/account/users/user-list/user-list.component.ts
@@ -34,7 +34,7 @@ export class UserListComponent implements OnInit {
     { name: 'Builtin', prop: 'builtin', hidden: false  },
     { name: 'Full Name', prop: 'full_name', hidden: false, minWidth: 250 },
     { name: 'Email', prop: 'email', hidden: true, maxWidth: 250 },
-    { name: 'Disable Password Login', prop: 'password_disabled', hidden: true, minWidth: 200 },
+    { name: 'Password Disabled', prop: 'password_disabled', hidden: true, minWidth: 200 },
     { name: 'Lock User', prop: 'locked', hidden: true },
     { name: 'Permit Sudo', prop: 'sudo', hidden: true  },
     { name: 'Microsoft Account', prop: 'microsoft_account', hidden: true, minWidth: 170 },


### PR DESCRIPTION
…and help text

- Change Accounts/Users "Enable password login" field to be "Disable Password" and reverse the behavior of the "Yes" and "No" options.
- Update the column entry in the Accounts/Users list to "Password Disabled"
- Port updated field descriptions for "Disable Password", "Lock User" and "Permit Sudo" into the UI help text.
Yarn build testing: there might be a minor issue with updating the name of the "Password Disabled" column in the Users list, but I've checked with Dennis and it appears to be very minor.