### PR TITLE
NAS-104762 / 12.0 / NAS-104762 Convert extras to list and back

### DIFF
--- a/src/app/pages/task-calendar/rsync/rsync-form/rsync-form.component.ts
+++ b/src/app/pages/task-calendar/rsync/rsync-form/rsync-form.component.ts
@@ -222,6 +222,7 @@ export class RsyncFormComponent implements OnDestroy {
   }
 
   beforeSubmit(value){
+    value.extra = _.filter(value.extra.split(',').map(_.trim));
     let spl = value.rsync_picker.split(" ");
     delete value.rsync_picker;
     const schedule = {}
@@ -234,6 +235,7 @@ export class RsyncFormComponent implements OnDestroy {
   }
 
   resourceTransformIncomingRestData(data) {
+    data.extra = data.extra.toString();
     data['rsync_picker'] = data.schedule.minute + " " +
                           data.schedule.hour + " " +
                           data.schedule.dom + " " +

--- a/src/app/pages/task-calendar/rsync/rsync-form/rsync-form.component.ts
+++ b/src/app/pages/task-calendar/rsync/rsync-form/rsync-form.component.ts
@@ -222,7 +222,9 @@ export class RsyncFormComponent implements OnDestroy {
   }
 
   beforeSubmit(value){
-    value.extra = _.filter(value.extra.split(',').map(_.trim));
+    if(value.extra) {
+      value.extra = _.filter(value.extra.split(',').map(_.trim));
+    }
     let spl = value.rsync_picker.split(" ");
     delete value.rsync_picker;
     const schedule = {}
@@ -235,7 +237,9 @@ export class RsyncFormComponent implements OnDestroy {
   }
 
   resourceTransformIncomingRestData(data) {
-    data.extra = data.extra.toString();
+    if (data.extra) {
+      data.extra = data.extra.toString();
+    }
     data['rsync_picker'] = data.schedule.minute + " " +
                           data.schedule.hour + " " +
                           data.schedule.dom + " " +


### PR DESCRIPTION
Allows user to enter one or more 'extras' to the rsync form. Extras cannot contain spaces, since mw apparently splits on space. In ui, extras can be split by space or comma or both