### PR TITLE
NAS-104801 / 12.0 / NAS-104801

### DIFF
--- a/src/app/pages/common/error-dialog/error-dialog.component.ts
+++ b/src/app/pages/common/error-dialog/error-dialog.component.ts
@@ -24,9 +24,9 @@ export class ErrorDialog {
     private ws: WebSocketService, public http: Http, public storage: StorageService) {}
 
   public toggleOpen () {
-    const messageWrapper = document.getElementById('err-message-wrapper');
     const dialogs = document.getElementsByClassName('mat-dialog-container');
     const dialog = dialogs[dialogs.length -1];
+    const messageWrapper = (<HTMLElement>dialog.querySelector('#err-message-wrapper'));
     const title =   (<HTMLElement>dialog.querySelector('#err-title'));
     const content = (<HTMLElement>dialog.querySelector('#err-md-content'));
     const btPanel = (<HTMLElement>dialog.querySelector('#err-bt-panel'));
@@ -35,7 +35,7 @@ export class ErrorDialog {
     this.isCloseMoreInfo = !this.isCloseMoreInfo;
     if (!this.isCloseMoreInfo) {
       dialog.setAttribute('style','width : 800px; height: 600px');
-      let errMsgHeight = (<HTMLElement>dialog.querySelector('#err-message-wrapper')).offsetHeight-21;
+      let errMsgHeight = messageWrapper.offsetHeight-21;
       if (errMsgHeight > 63) {
         errMsgHeight = 63;
       };

--- a/src/app/pages/common/error-dialog/error-dialog.component.ts
+++ b/src/app/pages/common/error-dialog/error-dialog.component.ts
@@ -25,16 +25,17 @@ export class ErrorDialog {
 
   public toggleOpen () {
     const messageWrapper = document.getElementById('err-message-wrapper');
-    const dialog = document.getElementsByClassName('mat-dialog-container');
-    const title = document.getElementById('err-title');
-    const content = document.getElementById('err-md-content');
-    const btPanel = document.getElementById('err-bt-panel');
-    const txtarea = document.getElementById('err-bt-text');
+    const dialogs = document.getElementsByClassName('mat-dialog-container');
+    const dialog = dialogs[dialogs.length -1];
+    const title =   (<HTMLElement>dialog.querySelector('#err-title'));
+    const content = (<HTMLElement>dialog.querySelector('#err-md-content'));
+    const btPanel = (<HTMLElement>dialog.querySelector('#err-bt-panel'));
+    const txtarea = (<HTMLElement>dialog.querySelector('#err-bt-text'));
     
     this.isCloseMoreInfo = !this.isCloseMoreInfo;
     if (!this.isCloseMoreInfo) {
-      dialog[dialog.length-1].setAttribute('style','width : 800px; height: 600px');
-      let errMsgHeight = (document.getElementById('err-message-wrapper').offsetHeight)-21;
+      dialog.setAttribute('style','width : 800px; height: 600px');
+      let errMsgHeight = (<HTMLElement>dialog.querySelector('#err-message-wrapper')).offsetHeight-21;
       if (errMsgHeight > 63) {
         errMsgHeight = 63;
       };
@@ -48,7 +49,7 @@ export class ErrorDialog {
         txtarea.style.height = tracebackHeight;
       }, 215);
     } else {
-      dialog[dialog.length-1].removeAttribute('style');
+      dialog.removeAttribute('style');
       title.removeAttribute('style');
       content.removeAttribute('style');
       btPanel.removeAttribute('style');

--- a/src/app/pages/system/update/manualupdate/manualupdate.component.ts
+++ b/src/app/pages/system/update/manualupdate/manualupdate.component.ts
@@ -14,6 +14,7 @@ import { EntityJobComponent } from '../../../common/entity/entity-job/entity-job
 import { CoreEvent } from 'app/core/services/core.service';
 import { ViewControllerComponent } from 'app/core/components/viewcontroller/viewcontroller.component';
 import { EntityUtils } from '../../../../pages/common/entity/utils';
+import { take } from 'rxjs/operators';
 
 @Component({
   selector: 'app-manualupdate',
@@ -186,9 +187,11 @@ export class ManualUpdateComponent extends ViewControllerComponent {
         this.dialogService.errorReport(helptext.manual_update_error_dialog.message, 
           `${prefailure.status.toString()} ${prefailure.statusText}`)
       })
-      this.dialogRef.componentInstance.failure.subscribe((failure)=>{
-        this.dialogRef.close(false);
-        this.dialogService.errorReport(failure.error,failure.state,failure.exception)
+      this.dialogRef.componentInstance.failure
+        .pipe(take(1))
+        .subscribe((failure)=>{
+          this.dialogRef.close(false);
+          this.dialogService.errorReport(failure.error,failure.state,failure.exception);
       })
     })
   }


### PR DESCRIPTION
Thanks to Aaron Ervin for rxjs help
Makes the resizing selectors for error dialog more specific so it can handle more than one error dialog at a time; also prevents the observable in manual update component from firing twice;