### PR TITLE
NAS-100792 / 12.0 / NAS-100792a

### DIFF
--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -1691,4 +1691,8 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     text-decoration: underline;
   }
 
+  .mat-select-panel{
+    max-height: 60vh !important;
+  }
+
  } // end of ix theme


### PR DESCRIPTION
Makes selects (drop-downs) show more content if there is a lot of content, doesn't affect smaller ones. Look at the user form (the groups select menu) and VM wizard zvol location. I tried out many sizes - much larger than this creates problem of hidden options. Also, combobox (and filtering) isn't a great option (for groups) since we need multiselect