### PR TITLE
NAS-104796 / 11.3 / Nas 104796

### DIFF
--- a/src/app/helptext/account/user-form.ts
+++ b/src/app/helptext/account/user-form.ts
@@ -30,7 +30,6 @@ user_form_password_tooltip : T('Required unless <b>Enable password login</b> is\
 user_form_password_validation : [ Validators.pattern('^[^?]*$'), Validators.required ],
 user_form_password_confirm_name : 'password_conf',
 user_form_password_confirm_placeholder : T('Confirm Password'),
-user_form_password_confirm_validation : [ matchOtherValidator('password'), Validators.pattern('^[^?]*$'), Validators.required ],
 user_form_password_edit_name: 'password_edit',
 user_form_password_edit_placeholder : T('Password'),
 user_form_password_edit_tooltip : T('Required unless <b>Enable password login</b> is\
@@ -38,7 +37,6 @@ user_form_password_edit_tooltip : T('Required unless <b>Enable password login</b
 user_form_password_edit_validation : [ Validators.pattern('^[^?]*$') ],
 user_form_password_edit_confirm_name: 'password_conf_edit',
 user_form_password_edit_confirm_placeholder : T('Confirm Password'),
-user_form_password_edit_confirm_validation : [ matchOtherValidator('password_edit'), Validators.pattern('^[^?]*$') ],
 
 user_form_ids_groups_title: T('ID & Groups'),
 user_form_ids_groups_title_class: 'id-and-groups',

--- a/src/app/helptext/network/ipmi/ipmi.ts
+++ b/src/app/helptext/network/ipmi/ipmi.ts
@@ -10,7 +10,6 @@ password_tooltip : T('Enter the password used to connect to the IPMI\
  interface from a web browser.'),
 
 conf_password_placeholder: T('Confirm Password'),
-conf_password_validation : [ matchOtherValidator('password') ],
 
 dhcp_placeholder : T('DHCP'),
 dhcp_tooltip : T('Use DHCP. Unset to manually configure a static IPv4 connection.'),

--- a/src/app/helptext/services/components/service-dynamic-dns.ts
+++ b/src/app/helptext/services/components/service-dynamic-dns.ts
@@ -53,9 +53,7 @@ username_tooltip: T('Username for logging in to the provider and \
 
 password_placeholder : T('Password'),
 password_tooltip: T('Password for logging in to the provider and \
- updating the record.'),
-password_validation :
-        [ Validators.minLength(8), matchOtherValidator('password2') ],
+ updating the record. '),
 
 password2_placeholder : T('Confirm Password'),
 

--- a/src/app/helptext/services/components/service-snmp.ts
+++ b/src/app/helptext/services/components/service-snmp.ts
@@ -49,7 +49,7 @@ v3_authtype_relation : [ {
 
 v3_password_placeholder : T('Password'),
 v3_password_tooltip: T('Enter a password of at least eight characters.'),
-v3_password_validation : [ Validators.minLength(8), matchOtherValidator('v3_password2'), Validators.required ],
+v3_password_validation : [ Validators.minLength(8), Validators.required ],
 v3_password_relation : [ {
   action : 'HIDE',
   when : [ {name : 'v3', value : false} ]
@@ -77,7 +77,7 @@ v3_privproto_relation : [ {
 v3_privpassphrase_placeholder : T('Privacy Passphrase'),
 v3_privpassphrase_tooltip: T('Enter a separate privacy passphrase. <b>Password</b>\
  is used when this is left empty.'),
-v3_privpassphrase_validation : [ Validators.minLength(8), matchOtherValidator('v3_privpassphrase2') ],
+v3_privpassphrase_validation : [ Validators.minLength(8) ],
 v3_privpassphrase_relation : [ {
   action : 'HIDE',
   when : [ {name : 'v3', value : false} ]

--- a/src/app/helptext/services/components/service-webdav.ts
+++ b/src/app/helptext/services/components/service-webdav.ts
@@ -42,7 +42,6 @@ htauth_options : [
 password_placeholder : T('Webdav Password'),
 password_tooltip : T('The default of <i>davtest</i> is recommended to\
  change. <i>davtest</i> is a known value.'),
-password_validation : [ matchOtherValidator('password2') ],
 
 password2_placeholder : T('Confirm Password')
 }

--- a/src/app/pages/account/users/user-form/user-form.component.ts
+++ b/src/app/pages/account/users/user-form/user-form.component.ts
@@ -8,6 +8,7 @@ import {
   StorageService,
   AppLoaderService,
   UserService,
+  ValidationService
 } from '../../../../services/';
 import { FieldConfig } from '../../../common/entity/entity-form/models/field-config.interface';
 import { FieldSet } from 'app/pages/common/entity/entity-form/models/fieldset.interface';
@@ -90,7 +91,7 @@ export class UserFormComponent {
           placeholder : helptext.user_form_password_confirm_placeholder,
           inputType : 'password',
           required: true,
-          validation : helptext.user_form_password_confirm_validation,
+          validation : this.validationService.matchOtherValidator('password'),
           isHidden: false
         },
         {
@@ -108,7 +109,7 @@ export class UserFormComponent {
           name : helptext.user_form_password_edit_confirm_name,
           placeholder : helptext.user_form_password_edit_confirm_placeholder,
           inputType : 'password',
-          validation : helptext.user_form_password_edit_confirm_validation,
+          validation : this.validationService.matchOtherValidator('password_edit'),
           isHidden: true
         },
       ]
@@ -268,7 +269,7 @@ export class UserFormComponent {
 
   constructor(protected router: Router, protected rest: RestService,
               protected ws: WebSocketService, protected storageService: StorageService,
-              public loader: AppLoaderService
+              public loader: AppLoaderService, protected validationService: ValidationService
               ) {
       this.ws.call('user.query').subscribe(
         (res)=>{

--- a/src/app/pages/network/ipmi/ipmi.component.ts
+++ b/src/app/pages/network/ipmi/ipmi.component.ts
@@ -2,7 +2,8 @@ import { ApplicationRef, Component, Injector, Input, ViewChild, ElementRef} from
 import { Router } from '@angular/router';
 import * as _ from 'lodash';
 import { Subscription } from 'rxjs';
-import {  DialogService, RestService, TooltipsService, WebSocketService, NetworkService, SnackbarService } from '../../../services/';
+import {  DialogService, RestService, TooltipsService, WebSocketService, 
+  NetworkService, SnackbarService, ValidationService } from '../../../services/';
 import { FormGroup } from '@angular/forms';
 import { regexValidator } from '../../common/entity/entity-form/validators/regex-validation';
 import { FieldConfig } from '../../common/entity/entity-form/models/field-config.interface';
@@ -95,7 +96,7 @@ export class IPMIComponent {
       name : 'conf_password',
       inputType: 'password',
       placeholder : helptext.conf_password_placeholder,
-      validation : helptext.conf_password_validation
+      validation : this.validationService.matchOtherValidator('password')
     },
     {
       type : 'checkbox',
@@ -144,7 +145,8 @@ export class IPMIComponent {
               protected _injector: Injector, protected _appRef: ApplicationRef,
               protected tooltipsService: TooltipsService,
               protected networkService: NetworkService, protected dialog: DialogService,
-              protected loader: AppLoaderService, protected snackBar: SnackbarService
+              protected loader: AppLoaderService, protected snackBar: SnackbarService,
+              protected validationService: ValidationService
             ) {}
 
 

--- a/src/app/pages/services/components/service-dynamicdns/service-dynamicdns.component.ts
+++ b/src/app/pages/services/components/service-dynamicdns/service-dynamicdns.component.ts
@@ -2,7 +2,7 @@ import { ApplicationRef, Component, Injector } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import * as _ from 'lodash';
 
-import { RestService, WebSocketService } from '../../../../services/';
+import { RestService, WebSocketService, ValidationService } from '../../../../services/';
 import { FieldConfig } from '../../../common/entity/entity-form/models/field-config.interface';
 import helptext from '../../../../helptext/services/components/service-dynamic-dns';
 
@@ -84,13 +84,13 @@ export class ServiceDDNSComponent {
       tooltip: helptext.password_tooltip,
       inputType : 'password',
       togglePw: true,
-      validation : helptext.password_validation,
     },
     {
       type : 'input',
       name : 'password2',
       placeholder : helptext.password2_placeholder,
       inputType : 'password',
+      validation: this.validationService.matchOtherValidator('password')
     },
     {
       type : 'input',
@@ -105,6 +105,7 @@ export class ServiceDDNSComponent {
   constructor(protected router: Router, protected route: ActivatedRoute,
               protected rest: RestService, protected ws: WebSocketService,
               protected _injector: Injector, protected _appRef: ApplicationRef,
+              protected validationService: ValidationService
               ) {}
 
   afterInit(entityForm: any) {

--- a/src/app/pages/services/components/service-snmp/service-snmp.component.ts
+++ b/src/app/pages/services/components/service-snmp/service-snmp.component.ts
@@ -2,7 +2,7 @@ import { ApplicationRef, Component, Injector } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import * as _ from 'lodash';
 
-import { IdmapService, IscsiService, RestService, WebSocketService } from '../../../../services/';
+import { IdmapService, IscsiService, RestService, WebSocketService, ValidationService } from '../../../../services/';
 import { FieldConfig } from '../../../common/entity/entity-form/models/field-config.interface';
 import helptext from '../../../../helptext/services/components/service-snmp';
 
@@ -77,7 +77,7 @@ export class ServiceSNMPComponent {
       inputType : 'password',
       placeholder : helptext.v3_password2_placeholder,
       required: true,
-      validation: helptext.v3_password2_validation,
+      validation: this.validationService.matchOtherValidator('v3_password'),
       relation : helptext.v3_password2_relation
     },
     {
@@ -103,7 +103,8 @@ export class ServiceSNMPComponent {
       name : 'v3_privpassphrase2',
       inputType : 'password',
       placeholder : helptext.v3_privpassphrase2_placeholder,
-      relation : helptext.v3_privpassphrase2_relation
+      relation : helptext.v3_privpassphrase2_relation,
+      validation: this.validationService.matchOtherValidator('v3_privpassphrase'),
     },
     {
       type : 'textarea',
@@ -130,7 +131,7 @@ export class ServiceSNMPComponent {
               protected rest: RestService, protected ws: WebSocketService,
               protected _injector: Injector, protected _appRef: ApplicationRef,
               protected iscsiService: IscsiService,
-              protected idmapService: IdmapService) {}
+              protected idmapService: IdmapService, protected validationService: ValidationService) {}
 
   afterInit(entityForm: any) {
     entityForm.ws.call('snmp.config').subscribe((res)=>{

--- a/src/app/pages/services/components/service-webdav/service-webdav.component.ts
+++ b/src/app/pages/services/components/service-webdav/service-webdav.component.ts
@@ -2,7 +2,7 @@ import { ApplicationRef, Component, Injector, OnInit, OnDestroy } from '@angular
 import { ActivatedRoute, Router } from '@angular/router';
 import * as _ from 'lodash';
 
-import { RestService, SystemGeneralService, WebSocketService } from '../../../../services/';
+import { RestService, SystemGeneralService, WebSocketService, ValidationService } from '../../../../services/';
 import { FieldConfig } from '../../../common/entity/entity-form/models/field-config.interface';
 import helptext from '../../../../helptext/services/components/service-webdav';
 
@@ -60,13 +60,13 @@ export class ServiceWebdavComponent implements OnInit, OnDestroy {
       togglePw: true,
       tooltip : helptext.password_tooltip,
       inputType : 'password',
-      validation : helptext.password_validation
     },
     {
       type : 'input',
       name : 'password2',
       placeholder : helptext.password2_placeholder,
-      inputType : 'password'
+      inputType : 'password',
+      validation: this.validationService.matchOtherValidator('password')
     },
   ];
 
@@ -89,6 +89,7 @@ export class ServiceWebdavComponent implements OnInit, OnDestroy {
       protected _injector: Injector,
       protected _appRef: ApplicationRef,
       protected systemGeneralService: SystemGeneralService,
+      protected validationService: ValidationService
   ) {}
 
   ngOnInit() {


### PR DESCRIPTION
Moves password comparison validation to the Validation service for user form and four other components. We weren't able to confirm that this fixes the problem in the ticket, but it does fix the issue of the validators that stop listening when the user navigates away from the page, then comes back.

Also please check: It seemed like a mistake that the password for dynamic DNS had a minLength validator of 8, since it's the pw for any number of outside services