### PR TITLE
NAS-104541 / 11.3 / NAS-104541 Make task manager responsive to time zone change

### DIFF
--- a/src/app/components/common/dialog/task-manager/task-manager.component.css
+++ b/src/app/components/common/dialog/task-manager/task-manager.component.css
@@ -55,3 +55,6 @@ mat-cell.mat-column-expandedDetail {
 mat-row.detail-row {
     padding-bottom: 12px;
 }
+.small-label {
+    font-size: small;
+}

--- a/src/app/components/common/dialog/task-manager/task-manager.component.html
+++ b/src/app/components/common/dialog/task-manager/task-manager.component.html
@@ -33,8 +33,8 @@
         <ng-container matColumnDef="expandedDetail">
             <mat-cell *matCellDef="let element">
                 <span><b>{{ 'Status:' | translate}}</b> {{element.state}}</span>
-                <span *ngIf="element.time_started != null"><b>{{ 'Start Time:' | translate }}</b> {{getReadableDate(element.time_started)}}</span>
-                <span *ngIf="element.time_finished != null"><b>{{ 'Finished Time:' | translate }}</b> {{getReadableDate(element.time_finished)}}</span>
+                <span *ngIf="element.time_started != null"><b>{{ 'Start Time:' | translate }}</b> {{getReadableDate(element.time_started) | date: ' E MMM d, y, H:mm:ss'}} <span class="small-label">({{timeZone}})</span></span>
+                <span *ngIf="element.time_finished != null"><b>{{ 'Finished Time:' | translate }}</b> {{getReadableDate(element.time_finished) | date: ' E MMM d, y, H:mm:ss'}}</span>
                 <span *ngIf="element.error != null"><b>{{ 'Error:' | translate }}</b> {{element.error}}</span>
                 <span *ngIf="element.logs_excerpt != null && element.logs_path != null"><button mat-flat-button color="primary" (click)="showLogs(element)">{{ 'View Logs' | translate }}</button></span>
             </mat-cell>

--- a/src/app/components/common/dialog/task-manager/task-manager.component.ts
+++ b/src/app/components/common/dialog/task-manager/task-manager.component.ts
@@ -5,7 +5,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { Observable, Subscription } from 'rxjs/Rx';
 import { animate, state, style, transition, trigger } from '@angular/animations';
 
-import { WebSocketService, JobService } from '../../../../services/';
+import { WebSocketService, JobService, SystemGeneralService } from '../../../../services/';
 
 @Component({
   selector: 'task-manager',
@@ -28,16 +28,20 @@ export class TaskManagerComponent implements OnInit, OnDestroy{
   displayedColumns = ['state', 'method', 'percent'];
   private subscrition: Subscription;
   public expandedElement: any | null;
+  public timeZone: string;
 
   constructor(
     public dialogRef: MatDialogRef<TaskManagerComponent>,
     private ws: WebSocketService,
     protected translate: TranslateService,
-    protected job: JobService) {
+    protected job: JobService, protected sysGeneralService: SystemGeneralService) {
       this.dataSource = new MatTableDataSource<any>([]);
     }
 
   ngOnInit() {
+    this.sysGeneralService.getSysInfo().subscribe((res) => {
+      this.timeZone = res.timezone;
+    })
     this.ws.call('core.get_jobs', []).subscribe(
       (res)=> {
         for (const i in res) {
@@ -93,7 +97,7 @@ export class TaskManagerComponent implements OnInit, OnDestroy{
 
   getReadableDate(data: any) {
     if (data != null) {
-      return new Date(data.$date);
+      return new Date(data.$date).toLocaleString('en-US', {timeZone: this.timeZone });
     }
     return;
   }


### PR DESCRIPTION
Makes time in task manager respond to timezone changes. Note that there is a related middleware ticket, NAS-10455, that this one needs to get the time right. PS - Fixing for 12 may require a different approach, since 12 will have the local service and choice of formats