### PR TITLE
NAS-104740 / 12.0 / NAS-104740 Limit height of form explorer, thanks to Damian S

### DIFF
--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -1693,4 +1693,9 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     max-height: 60vh !important;
   }
 
+  tree-viewport {
+    max-height: 300px;
+    overflow: auto;
+  }
+
  } // end of ix theme


### PR DESCRIPTION
Keeps tooltips from getting pushed into bottom margin on wizards, also limits explorer to a reasonable height throughout the app.