### PR TITLE
NAS-104740 / 11.3 / Nas 104740 stable imit height of form explorer, thanks to Damian S

### DIFF
--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -1678,4 +1678,9 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     text-decoration: underline;
   }
 
+  tree-viewport {
+    max-height: 300px;
+    overflow: auto;
+  }
+
  } // end of ix theme


### PR DESCRIPTION
Keeps tooltips from getting pushed into bottom margin on wizards, also limits explorer to a reasonable height throughout the app.