### PR TITLE
NAS-105070 / 11.3 / NAS-105070 put link on one line to avoid slash being inserted

### DIFF
--- a/src/app/helptext/system/certificates.ts
+++ b/src/app/helptext/system/certificates.ts
@@ -24,9 +24,8 @@ export const helptext_system_certificates = {
     signedby: {
       placeholder: T("Signing Certificate Authority"),
       tooltip: T(
-        'Select a previously imported or created <a\
- href="--docurl--/system.html#cas"\
- target="_blank">CA</a>.'
+        'Select a previously imported or created \
+ <a href="--docurl--/system.html#cas" target="_blank">CA</a>.'
       ),
       validation: [Validators.required]
     },


### PR DESCRIPTION
Similar to #3430 - slashes seem to get inserted sometimes on multiline links; tested this with a hot-patched 11.3 release system