### PR TITLE
Fix an entity detail height update error

### DIFF
--- a/src/app/pages/common/entity/entity-table/entity-table.component.ts
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.ts
@@ -1027,10 +1027,14 @@ export class EntityTableComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   resetTableToStartingHeight() {
-    if (!this.startingHeight) {
-      this.startingHeight = document.getElementsByClassName('ngx-datatable')[0].clientHeight;
-    }
-    document.getElementsByClassName('ngx-datatable')[0].setAttribute('style', `height: ${this.startingHeight}px`);
+    setTimeout(() => {
+      if (!this.startingHeight) {
+        this.startingHeight = document.getElementsByClassName('ngx-datatable')[0].clientHeight;
+      }
+      
+      document.getElementsByClassName('datatable-body')[0].setAttribute('style', `height: ${this.tableHeight}px`);
+      document.getElementsByClassName('ngx-datatable')[0].setAttribute('style', `height: ${this.startingHeight}px`);
+    }, 100);
   }
 
   updateTableHeightAfterDetailToggle() {
@@ -1041,8 +1045,10 @@ export class EntityTableComponent implements OnInit, AfterViewInit, OnDestroy {
       this.expandedRows = document.querySelectorAll('.datatable-row-detail').length;
       const newHeight = this.expandedRows * this.getRowDetailHeight() + this.startingHeight;
       const heightStr = `height: ${newHeight}px`;
+      const tableHeight = this.expandedRows * this.getRowDetailHeight() + this.tableHeight;
+      document.getElementsByClassName('datatable-body')[0].setAttribute('style', `height: ${tableHeight}px`);
       document.getElementsByClassName('ngx-datatable')[0].setAttribute('style', heightStr);
-    }, 0);
+    }, 100);
   }
 
   getButtonClass(prop) {


### PR DESCRIPTION
Test with Chrome  79.0.3945.130 (64-bit) / Firefox 73.0 (64-bit)
Patch: The datatable-body class does not receive height update in Chrome
Potential issue: Cannot have more than one ngx-datatable in single page