### PR TITLE
Fix Detail Display Issue

### DIFF
--- a/src/app/pages/common/entity/entity-table/entity-table.component.ts
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.ts
@@ -812,11 +812,16 @@ export class EntityTableComponent implements OnInit, AfterViewInit, OnDestroy {
     // This section controls page height for infinite scrolling
     if (this.currentRows.length === 0) {
       this.tableHeight = 153;
-    } else if (this.currentRows.length > 0 && this.currentRows.length < this.paginationPageSize) {
-      this.tableHeight = (this.currentRows.length * this.rowHeight) + 110;
     } else {
-      this.tableHeight = (this.paginationPageSize * this.rowHeight) + 100;
-    }
+      if (this.currentRows.length > 0 && this.currentRows.length < this.paginationPageSize) {
+          this.tableHeight = (this.currentRows.length * this.rowHeight) + 110 
+      } else {
+          this.tableHeight = (this.paginationPageSize * this.rowHeight) + 100
+      }
+      if (this.tableHeight < (160 + this.getRowDetailHeight())) {
+          this.tableHeight = 160 + this.getRowDetailHeight();
+      }
+  } 
 
     // Displays an accurate number for some edge cases
     if (this.paginationPageSize > this.currentRows.length) {
@@ -1027,14 +1032,14 @@ export class EntityTableComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   resetTableToStartingHeight() {
-    if (!this.startingHeight) {
+    /*if (!this.startingHeight) {
       this.startingHeight = document.getElementsByClassName('ngx-datatable')[0].clientHeight;
     }
-    document.getElementsByClassName('ngx-datatable')[0].setAttribute('style', `height: ${this.startingHeight}px`);
+    document.getElementsByClassName('ngx-datatable')[0].setAttribute('style', `height: ${this.startingHeight}px`);*/
   }
 
   updateTableHeightAfterDetailToggle() {
-    if (!this.startingHeight) {
+    /*if (!this.startingHeight) {
       this.resetTableToStartingHeight();
     }
     setTimeout(() => {
@@ -1042,7 +1047,7 @@ export class EntityTableComponent implements OnInit, AfterViewInit, OnDestroy {
       const newHeight = this.expandedRows * this.getRowDetailHeight() + this.startingHeight;
       const heightStr = `height: ${newHeight}px`;
       document.getElementsByClassName('ngx-datatable')[0].setAttribute('style', heightStr);
-    }, 0);
+    }, 0);*/
   }
 
   getButtonClass(prop) {


### PR DESCRIPTION
Pre allocate the space to avoid manually changing height which is not proerly handled.
Another solution is to directly set tableHeight value rather than directly edit the style. Set tableHeight value can properly trigger ngx-table componement recalculation.