### PR TITLE
DOCS-291 helptext for "enable" in iSCSI extents

### DIFF
--- a/src/app/helptext/sharing/iscsi/iscsi.ts
+++ b/src/app/helptext/sharing/iscsi/iscsi.ts
@@ -244,7 +244,7 @@ export const helptext_sharing_iscsi = {
   ),
 
   extent_placeholder_enabled: T('Enabled'),
-  extent_tooltip_enabled: T(''),
+  extent_tooltip_enabled: T('Set to enable the iSCSI extent.'),
 
   authaccess_placeholder_tag: T("Group ID"),
   authaccess_tooltip_tag: T(


### PR DESCRIPTION
I heard that code was frozen. If that's the case, no big deal. This can be pushed to next version release cycle.