### PR TITLE
NAS-105040 / 12.0 / NAS-105040 Clear support payload on form submit for FN, TN

### DIFF
--- a/src/app/pages/system/support/fn-support/fn-support.component.ts
+++ b/src/app/pages/system/support/fn-support/fn-support.component.ts
@@ -19,7 +19,6 @@ export class FnSupportComponent {
   public screenshot: any;
   public password_fc: any;
   public username_fc: any;
-  public payload = {};
   public subs: any;
   public saveSubmitText = helptext.submitBtn;
   public fieldConfig: FieldConfig[] = []
@@ -73,7 +72,8 @@ export class FnSupportComponent {
           options:[
             {label: 'Bug', value: 'BUG'},
             {label: 'Feature', value: 'FEATURE'}
-          ]
+          ],
+          value: 'BUG'
         },
         {
           type : 'select',
@@ -188,22 +188,23 @@ export class FnSupportComponent {
   }
 
   customSubmit(entityEdit): void {
-    this.payload['username'] = entityEdit.username;
-    this.payload['password'] = entityEdit.password;
-    this.payload['category'] = entityEdit.category;
-    this.payload['title'] = entityEdit.title;
-    this.payload['body'] = entityEdit.body;
-    this.payload['type'] = entityEdit.type;
+    let payload = {};
+    payload['username'] = entityEdit.username;
+    payload['password'] = entityEdit.password;
+    payload['category'] = entityEdit.category;
+    payload['title'] = entityEdit.title;
+    payload['body'] = entityEdit.body;
+    payload['type'] = entityEdit.type;
     if (entityEdit.attach_debug) {
-      this.payload['attach_debug'] = entityEdit.attach_debug;     
+      payload['attach_debug'] = entityEdit.attach_debug;     
     }
-    this.openDialog();
+    this.openDialog(payload);
   };
 
-  openDialog() {
+  openDialog(payload) {
     const dialogRef = this.dialog.open(EntityJobComponent, {data: {"title":"Ticket","CloseOnClickOutside":true}});
     let url;
-    dialogRef.componentInstance.setCall('support.new_ticket', [this.payload]);
+    dialogRef.componentInstance.setCall('support.new_ticket', [payload]);
     dialogRef.componentInstance.submit();
     dialogRef.componentInstance.success.subscribe(res=>{
       if (res.result) {
@@ -214,7 +215,7 @@ export class FnSupportComponent {
           const formData: FormData = new FormData();
           formData.append('data', JSON.stringify({
             "method": "support.attach_ticket",
-            "params": [{'ticket': (res.result.ticket), 'filename': item.file.name, 'username': this.payload['username'], 'password': this.payload['password'] }]
+            "params": [{'ticket': (res.result.ticket), 'filename': item.file.name, 'username': payload['username'], 'password': payload['password'] }]
           }));
           formData.append('file', item.file, item.apiEndPoint);
           dialogRef.componentInstance.wspost(item.apiEndPoint, formData);
@@ -238,6 +239,8 @@ export class FnSupportComponent {
 
   resetForm () {
     this.entityEdit.formGroup.reset();
+    this.entityEdit.formGroup.controls['type'].setValue('BUG');
+    this.subs = [];
   };
 
 

--- a/src/app/pages/system/support/tn-support/tn-support.component.ts
+++ b/src/app/pages/system/support/tn-support/tn-support.component.ts
@@ -20,7 +20,6 @@ import { helptext_system_support as helptext } from 'app/helptext/system/support
 export class TnSupportComponent implements OnInit {
   public entityEdit: any;
   public screenshot: any;
-  public payload = {};
   public subs: any;
   public saveSubmitText = helptext.submitBtn;
   public custActions: Array<any> = [];
@@ -224,24 +223,25 @@ export class TnSupportComponent implements OnInit {
     }
 };
 
-  customSubmit(entityEdit): void{
-    this.payload['name'] = entityEdit.name;
-    this.payload['email'] = entityEdit.email;
-    this.payload['cc'] = _.filter(entityEdit.cc.split(',').map(_.trim));
-    this.payload['phone'] = entityEdit.phone;
-    this.payload['category'] = entityEdit.TNCategory;
-    this.payload['environment'] = entityEdit.environment;
-    this.payload['criticality'] = entityEdit.criticality;
-    this.payload['attach_debug'] = entityEdit.attach_debug || false;
-    this.payload['title'] = entityEdit.title;
-    this.payload['body'] = entityEdit.body;
-    this.openDialog();
+  customSubmit(entityEdit): void {
+    let payload = {};
+    payload['name'] = entityEdit.name;
+    payload['email'] = entityEdit.email;
+    payload['cc'] = _.filter(entityEdit.cc.split(',').map(_.trim));
+    payload['phone'] = entityEdit.phone;
+    payload['category'] = entityEdit.TNCategory;
+    payload['environment'] = entityEdit.environment;
+    payload['criticality'] = entityEdit.criticality;
+    payload['attach_debug'] = entityEdit.attach_debug || false;
+    payload['title'] = entityEdit.title;
+    payload['body'] = entityEdit.body;
+    this.openDialog(payload);
   };
 
-  openDialog() {
+  openDialog(payload) {
     const dialogRef = this.dialog.open(EntityJobComponent, {data: {"title":"Ticket","CloseOnClickOutside":true}});
     let url;
-    dialogRef.componentInstance.setCall('support.new_ticket', [this.payload]);
+    dialogRef.componentInstance.setCall('support.new_ticket', [payload]);
     dialogRef.componentInstance.submit();
     dialogRef.componentInstance.success.subscribe(res=>{
       if (res.result) {
@@ -297,5 +297,6 @@ export class TnSupportComponent implements OnInit {
     this.entityEdit.formGroup.controls['TNCategory'].setValue('BUG');
     this.entityEdit.formGroup.controls['environment'].setValue('production');
     this.entityEdit.formGroup.controls['criticality'].setValue('inquiry');
+    this.subs = [];
   };
 }


### PR DESCRIPTION
Clears out Support form values (inc debug and attachments) on submit by:
- Using a local var for payload that is new for each submit
- clearing out 'subs' which stores the attachment list 
Debug and attachments were hanging around and being resubmitted if the page wasn't refreshed