### PR TITLE
NAS-105113 / 11.3 / NAS-105113: Adjust field names and expand help text in Replication Tasks

### DIFF
--- a/src/app/helptext/task-calendar/replication/replication-wizard.ts
+++ b/src/app/helptext/task-calendar/replication/replication-wizard.ts
@@ -6,11 +6,12 @@ export default {
     exist_replication_placeholder: T('Load Previous Replication Task'),
     exist_replication_tooltip: T('Use settings from a saved replication.'),
 
-    source_datasets_from_placeholder: T('Source Datasets'),
-    source_datasets_from_tooltip: T('Datasets with snapshots to replicate.'),
+    source_datasets_from_placeholder: T('Source Location'),
+    source_datasets_from_tooltip: T('Storage location for the original \
+ snapshots that will be replicated.'),
 
-    target_dataset_from_placeholder: T('Destination Dataset'),
-    target_dataset_from_tooltip: T('Dataset which will store replicated \
+    target_dataset_from_placeholder: T('Destination Location'),
+    target_dataset_from_tooltip: T('Storage location for the replicated \
  snapshots.'),
 
     ssh_credentials_source_placeholder: T('SSH Connections'),
@@ -22,13 +23,30 @@ export default {
     ssh_credentials_target_tooltip: T('Select a saved remote system SSH \
  connection or choose <i>Create New</i> to create a new SSH connection.'),
 
-    source_datasets_placeholder: T('Source Datasets'),
-    source_datasets_tooltip: T('Select dataset snapshots to replicate. \
- Multiple datasets can be selected.'),
+    source_datasets_placeholder: T('Source'),
+    source_datasets_tooltip: T('Define the path to a system location \
+ that has snapshots to replicate. Click the \
+ <i class="material-icons">folder</i> to see all locations on the \
+ source system or click in the field to manually type a location \
+ (Example: <code>pool1/dataset1</code>). Multiple source locations can \
+ be selected or manually defined with a comma (<code>,</code>) separator.\
+ <br><br> Selecting a location displays the number of existing snapshots \
+ that can be replicated. Selecting a location that has no snapshots \
+ configures the replication task to take a manual snapshot of that \
+ location and replicate it to the destination.'),
 
-    target_dataset_placeholder: T('Destination Dataset'),
-    target_dataset_tooltip: T('Select the dataset that will store \
- replicated snapshots.'),
+    target_dataset_placeholder: T('Destination'),
+    target_dataset_tooltip: T('Define the path to a system location that \
+ will store replicated snapshots. Click the \
+ <i class="material-icons">folder</i> to see all locations on the \
+ destination system or click in the field to manually type a location \
+ path (Example: <code>pool1/dataset1</code>). Selecting a location \
+ defines the full path to that location as the destination. Appending a \
+ name to the path will create new zvol at that location.<br><br> \
+ For example, selecting <i>pool1/dataset1</i> will store \
+ snapshots in <i>dataset1</i>, but clicking the path and typing \
+ <code>/zvol1</code> after <i>dataset1</i> will create <i>zvol1</i> for \
+ snapshot storage.'),
 
     recursive_placeholder: T('Recursive'),
     recursive_tooltip: T('Set to also replicate all snapshots contained \

--- a/src/app/helptext/task-calendar/replication/replication.ts
+++ b/src/app/helptext/task-calendar/replication/replication.ts
@@ -58,18 +58,26 @@ export default {
  variable. When the active side is <i>REMOTE</i>, this defaults to the \
  SSH connection hostname.'),
 
-    source_datasets_placeholder: T('Source Datasets'),
-    source_datasets_tooltip: T('Choose datasets on the source system to \
- be replicated. Click the <i class="material-icons">folder</i> to see \
- all datasets on the source system. Each dataset must have an associated \
- periodic snapshot task, or previously-created snapshots for a one-time \
- replication.'),
+    source_datasets_placeholder: T('Source'),
+    source_datasets_tooltip: T('Define the path to a system location \
+ that has snapshots to replicate. Click the \
+ <i class="material-icons">folder</i> to see all locations on the \
+ source system or click in the field to manually type a location \
+ (Example: <code>pool1/dataset1</code>). Multiple source locations can \
+ be selected or manually defined with a comma (<code>,</code>) separator.'),
 
-    target_dataset_placeholder: T('Target Dataset'),
-    target_dataset_tooltip: T('Choose a dataset on the destination \
- system where snapshots are stored. Click the \
- <i class="material-icons">folder</i> to see all datasets on the \
- destination system. Click a dataset to set it as the target.'),
+    target_dataset_placeholder: T('Destination'),
+    target_dataset_tooltip: T('Define the path to a system location that \
+ will store replicated snapshots. Click the \
+ <i class="material-icons">folder</i> to see all locations on the \
+ destination system or click in the field to manually type a location \
+ path (Example: <code>pool1/dataset1</code>). Selecting a location \
+ defines the full path to that location as the destination. Appending a \
+ name to the path will create new zvol at that location.<br><br> \
+ For example, selecting <i>pool1/dataset1</i> will store \
+ snapshots in <i>dataset1</i>, but clicking the path and typing \
+ <code>/zvol1</code> after <i>dataset1</i> will create <i>zvol1</i> for \
+ snapshot storage.'),
 
     recursive_placeholder: T('Recursive'),
     recursive_tooltip: T('Replicate all child dataset snapshots. When \


### PR DESCRIPTION
- Reinvestigate field behavior and update field names and help text for the Replication Task Wizard and Advanced Replication Creation screens.
- Yarn testing: no issues.

Final text changes to be ported to the 12 branch as needed and used as a basis to rewrite or expand text in the 11.3-U2 guide.