### PR TITLE
NAS-105395 / 11.3 / NAS-105395 Fix validation for netbios aliases on 11

### DIFF
--- a/src/app/helptext/services/components/service-smb.ts
+++ b/src/app/helptext/services/components/service-smb.ts
@@ -19,7 +19,7 @@ cifs_srv_netbiosname_b_validation : [ Validators.required, Validators.maxLength(
 cifs_srv_netbiosalias_placeholder: T('NetBIOS Alias'),
 cifs_srv_netbiosalias_tooltip: T('Enter any aliases, separated by spaces.\
  Each alias can be up to 15 characters long.'),
-cifs_srv_netbiosalias_validation: [ Validators.maxLength(15) ],
+cifs_srv_netbiosalias_errmsg: T('Aliases must be 15 characters or less.'),
 
 cifs_srv_workgroup_placeholder: T('Workgroup'),
 cifs_srv_workgroup_tooltip: T('Must match Windows workgroup\

--- a/src/app/pages/services/components/service-smb/service-smb.component.ts
+++ b/src/app/pages/services/components/service-smb/service-smb.component.ts
@@ -2,7 +2,7 @@ import { ApplicationRef, Component, Injector } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import * as _ from 'lodash';
 import { MatDialog } from '@angular/material';
-
+import { ValidationErrors, FormControl } from '@angular/forms';
 import { IdmapService, ServicesService, RestService, WebSocketService, UserService } from '../../../../services/';
 import { FieldConfig } from '../../../common/entity/entity-form/models/field-config.interface';
 import { AppLoaderService } from '../../../../services/app-loader/app-loader.service';
@@ -51,7 +51,31 @@ export class ServiceSMBComponent {
       name: 'cifs_srv_netbiosalias',
       placeholder: helptext.cifs_srv_netbiosalias_placeholder,
       tooltip: helptext.cifs_srv_netbiosalias_tooltip,
-      validation: helptext.cifs_srv_netbiosalias_validation
+      validation: [
+        (control: FormControl): ValidationErrors => {
+          const config = this.fieldConfig.find(c => c.name === 'cifs_srv_netbiosalias');
+          const aliasArr = control.value ? _.filter(control.value.split(' ').map(_.trim)) : [];
+          let counter = 0;
+          aliasArr.forEach(alias => {
+            if (alias.length > 15) {
+              counter++;
+            }
+          })
+          const errors = control.value && counter > 0
+            ? { error: true }
+            : null
+
+          if (errors) {
+            config.hasErrors = true;
+            config.errors = helptext.cifs_srv_netbiosalias_errmsg;
+          } else {
+            config.hasErrors = false;
+            config.errors = '';
+          }
+
+          return errors;
+        }
+      ]
     },
     {
       type: 'input',
@@ -106,7 +130,7 @@ export class ServiceSMBComponent {
       options: [],
       tooltip: helptext.cifs_srv_guest_tooltip,
     },
-    { 
+    {
       type: 'combobox',
       name: 'cifs_srv_admin_group',
       placeholder: helptext.cifs_srv_admin_group_placeholder,


### PR DESCRIPTION
Adds custom validation for a list of strings for netbios aliases. the REST call submits and receives a space-separated string rather than an array, so the other changes in the PR for v 12 aren't needed here.