### PR TITLE
NAS-105400 / 12.0 / Nas 105400

### DIFF
--- a/src/app/pages/common/entity/entity-table/entity-table.component.html
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.html
@@ -102,8 +102,9 @@
   <!-- END OF CONTROLS SECTION -->
 
   <!-- INSERT DYNAMIC CARDHEADER HERE -->
-  <ng-template dynamicComponent *ngIf="conf.cardHeaderComponent" [component]="conf.cardHeaderComponent" [config]=""
-    [parent]="this"></ng-template>
+  <div id="cardHeaderContainer" *ngIf="conf.cardHeaderComponent">
+    <ng-template dynamicComponent [component]="conf.cardHeaderComponent" [config]="" [parent]="this"></ng-template>
+  </div>
 
   <!-- TABLE START -->
   <div fxLayout="row wrap" fxLayoutAlign="start center" class="multiActionsButton fn-toolbar"

--- a/src/app/pages/common/entity/entity-table/entity-table.component.scss
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.scss
@@ -149,4 +149,7 @@
     }
 }
 
+div#cardHeaderContainer {
+    padding: 0px !important;
+}
 

--- a/src/app/pages/common/entity/entity-table/entity-table.component.ts
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.ts
@@ -115,6 +115,7 @@ export class EntityTableComponent implements OnInit, AfterViewInit, OnDestroy {
   public rowHeight = 50;
   public zoomLevel: number;
   public tableHeight:number = (this.paginationPageSize * this.rowHeight) + 100;
+  public fixedTableHight = false;
   public windowHeight: number;
 
   public allColumns: Array<any> = []; // Need this for the checkbox headings
@@ -796,6 +797,7 @@ export class EntityTableComponent implements OnInit, AfterViewInit, OnDestroy {
   protected setPaginationInfo() {
     const beginIndex = this.paginationPageIndex * this.paginationPageSize;
     const endIndex = beginIndex + this.paginationPageSize ;
+    this.fixedTableHight = true;
 
     if( beginIndex < this.currentRows.length && endIndex >= this.currentRows.length) {
       this.seenRows = this.currentRows.slice(beginIndex, this.currentRows.length);
@@ -804,7 +806,9 @@ export class EntityTableComponent implements OnInit, AfterViewInit, OnDestroy {
     } else {
       this.seenRows = this.currentRows;
     }
-
+    if (this.seenRows.length < this.paginationPageSize && this.paginationPageIndex === 0) {
+      this.fixedTableHight = false;
+    }
     // This section controls page height for infinite scrolling
     if (this.currentRows.length === 0) {
       this.tableHeight = 153;
@@ -817,7 +821,8 @@ export class EntityTableComponent implements OnInit, AfterViewInit, OnDestroy {
       if (this.tableHeight < (160 + this.getRowDetailHeight())) {
         this.tableHeight = 160 + this.getRowDetailHeight();
       }
-    } 
+    }
+    this.startingHeight = this.tableHeight;
 
     // Displays an accurate number for some edge cases
     if (this.paginationPageSize > this.currentRows.length) {
@@ -1024,20 +1029,22 @@ export class EntityTableComponent implements OnInit, AfterViewInit, OnDestroy {
 
   toggleExpandRow(row) {
     this.table.rowDetail.toggleExpandRow(row);
-    this.updateTableHeightAfterDetailToggle();
+    if (!this.fixedTableHight) {
+      this.updateTableHeightAfterDetailToggle();
+    }
   }
 
   resetTableToStartingHeight() {
-    /*setTimeout(() => {
+    setTimeout(() => {
       if (!this.startingHeight) {
         this.startingHeight = document.getElementsByClassName('ngx-datatable')[0].clientHeight;
       }
       document.getElementsByClassName('ngx-datatable')[0].setAttribute('style', `height: ${this.startingHeight}px`);
-    }, 100);*/
+    }, 100);
   }
 
   updateTableHeightAfterDetailToggle() {
-    /*if (!this.startingHeight) {
+    if (!this.startingHeight) {
       this.resetTableToStartingHeight();
     }
     setTimeout(() => {
@@ -1045,7 +1052,7 @@ export class EntityTableComponent implements OnInit, AfterViewInit, OnDestroy {
       const newHeight = this.expandedRows * this.getRowDetailHeight() + this.startingHeight;
       const heightStr = `height: ${newHeight}px`;
       document.getElementsByClassName('ngx-datatable')[0].setAttribute('style', heightStr);
-    }, 100);*/
+    }, 100);
   }
 
   getButtonClass(prop) {

--- a/src/app/pages/common/entity/entity-table/entity-table.component.ts
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.ts
@@ -116,6 +116,7 @@ export class EntityTableComponent implements OnInit, AfterViewInit, OnDestroy {
   public zoomLevel: number;
   public tableHeight:number = (this.paginationPageSize * this.rowHeight) + 100;
   public fixedTableHight = false;
+  public cardHeaderComponentHight = 0;
   public windowHeight: number;
 
   public allColumns: Array<any> = []; // Need this for the checkbox headings
@@ -795,6 +796,8 @@ export class EntityTableComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   protected setPaginationInfo() {
+    this.cardHeaderComponentHight = document.getElementById('cardHeaderContainer') ? document.getElementById('cardHeaderContainer').clientHeight : 0;
+
     const beginIndex = this.paginationPageIndex * this.paginationPageSize;
     const endIndex = beginIndex + this.paginationPageSize ;
     this.fixedTableHight = true;
@@ -817,9 +820,6 @@ export class EntityTableComponent implements OnInit, AfterViewInit, OnDestroy {
         this.tableHeight = (this.currentRows.length * this.rowHeight) + 110;
       } else {
         this.tableHeight = (this.paginationPageSize * this.rowHeight) + 100;
-      }
-      if (this.tableHeight < (160 + this.getRowDetailHeight())) {
-        this.tableHeight = 160 + this.getRowDetailHeight();
       }
     }
     this.startingHeight = this.tableHeight;
@@ -1050,9 +1050,10 @@ export class EntityTableComponent implements OnInit, AfterViewInit, OnDestroy {
     setTimeout(() => {
       this.expandedRows = document.querySelectorAll('.datatable-row-detail').length;
       let newHeight = this.expandedRows * this.getRowDetailHeight() + this.startingHeight;
-      if (newHeight > window.innerHeight - 233) {
-        newHeight = window.innerHeight - 233;
+      if (newHeight > window.innerHeight - 233 - this.cardHeaderComponentHight) {
+        newHeight = window.innerHeight - 233 - this.cardHeaderComponentHight;
       }
+
       document.getElementsByClassName('ngx-datatable')[0].setAttribute('style', `height: ${newHeight}px`);
     }, 100);
   }

--- a/src/app/pages/common/entity/entity-table/entity-table.component.ts
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.ts
@@ -1049,9 +1049,11 @@ export class EntityTableComponent implements OnInit, AfterViewInit, OnDestroy {
     }
     setTimeout(() => {
       this.expandedRows = document.querySelectorAll('.datatable-row-detail').length;
-      const newHeight = this.expandedRows * this.getRowDetailHeight() + this.startingHeight;
-      const heightStr = `height: ${newHeight}px`;
-      document.getElementsByClassName('ngx-datatable')[0].setAttribute('style', heightStr);
+      let newHeight = this.expandedRows * this.getRowDetailHeight() + this.startingHeight;
+      if (newHeight > window.innerHeight - 233) {
+        newHeight = window.innerHeight - 233;
+      }
+      document.getElementsByClassName('ngx-datatable')[0].setAttribute('style', `height: ${newHeight}px`);
     }, 100);
   }
 

--- a/src/app/pages/plugins/available-plugins/available-plugins.component.css
+++ b/src/app/pages/plugins/available-plugins/available-plugins.component.css
@@ -1,5 +1,5 @@
 mat-card-content.plugin-info {
-    padding: 0px 15px 0px 15px;
+    padding: 15px 15px 0px 15px;
 }
 
 mat-button-toggle-group.plugin-buttons {


### PR DESCRIPTION
Make entity-table able to do:
1. if the table container has no more space (which means the table has more than one page), table height will not be updated when expanding/collapsing rows.
2. if the table container has more space (like the situation described in the ticket 105400), table height will be recalculated when expanding/collapsing rows. if table height (include the expanded detail rows) + cardHeaderContainer (the dynamic cardheader component) > TableContainerHeight (window.innerHeight - 233), then the table height will be set fixed which equal to TableContainerHeight.