### PR TITLE
NAS-105566 / 12.0 / NAS-105566 Force topbar to present eula on license enter

### DIFF
--- a/src/app/components/common/topbar/topbar.component.ts
+++ b/src/app/components/common/topbar/topbar.component.ts
@@ -85,7 +85,7 @@ export class TopbarComponent extends ViewControllerComponent implements OnInit, 
       });
     }
 
-  ngOnInit() {
+  ngOnInit() { console.log(window.localStorage.getItem('product_type'))
     if (window.localStorage.getItem('product_type') === 'ENTERPRISE') {
       this.checkEULA();
       this.ws.call('failover.licensed').subscribe((is_ha) => {
@@ -104,7 +104,7 @@ export class TopbarComponent extends ViewControllerComponent implements OnInit, 
         if (!this.updateNotificationSent) {
           this.updateInProgress();
           this.updateNotificationSent = true;
-        }      
+        }
       }
     })
     let theme = this.themeService.currentTheme();
@@ -166,7 +166,7 @@ export class TopbarComponent extends ViewControllerComponent implements OnInit, 
     }).subscribe((evt: CoreEvent) => {
       this.hostname = evt.data.hostname;
     });
- 
+
     this.core.emit({name: "SysInfoRequest", sender:this});
   }
 
@@ -257,10 +257,12 @@ export class TopbarComponent extends ViewControllerComponent implements OnInit, 
 
   checkEULA() {
     this.ws.call('truenas.is_eula_accepted').subscribe(eula_accepted => {
-      if (!eula_accepted) {
-        this.ws.call('truenas.get_eula').subscribe(eula => {
-          this.dialogService.confirm(T("End User License Agreement - TrueNAS"), eula, true, T("I Agree"), false, null, '', null, null, true).subscribe(accept_eula => {
+      if (!eula_accepted || window.localStorage.getItem('upgrading_status') === 'upgrading') {
+        this.ws.call('truenas.get_eula').subscribe(eula => { console.log(eula)
+          this.dialogService.confirm(T("End User License Agreement - TrueNAS"), eula, true,
+          T("I Agree"), false, null, '', null, null, true).subscribe(accept_eula => {
             if (accept_eula) {
+              window.localStorage.removeItem('upgrading_status');
               this.ws.call('truenas.accept_eula')
                 .subscribe(),
                 err => { console.error(err)};
@@ -331,13 +333,13 @@ export class TopbarComponent extends ViewControllerComponent implements OnInit, 
   }
 
   showResilveringDetails() {
-    this.dialogService.Info(T('Resilvering Status'), 
+    this.dialogService.Info(T('Resilvering Status'),
       `Resilvering ${this.resilveringDetails.name} - ${Math.ceil(this.resilveringDetails.scan.percentage)}%`);
   }
 
   onGoToLegacy() {
     this.dialogService.confirm(T("Warning"),
-      helptext.legacyUIWarning, 
+      helptext.legacyUIWarning,
       true, T("Continue to Legacy UI")).subscribe((res) => {
       if (res) {
         window.location.href = '/legacy/';
@@ -404,7 +406,7 @@ export class TopbarComponent extends ViewControllerComponent implements OnInit, 
           this.checkUpgradePending();
         }
       }
-      
+
       this.core.emit({name: "HA_Status", data: this.ha_status_text, sender:this});
       window.sessionStorage.setItem('ha_status', ha_enabled.toString());
     });
@@ -466,7 +468,7 @@ export class TopbarComponent extends ViewControllerComponent implements OnInit, 
       });
   }
 
-  getDirServicesStatus() { 
+  getDirServicesStatus() {
     this.ws.call('directoryservices.get_state').subscribe((res) => {
       for (let i in res) {
         this.dirServicesStatus.push(res[i])
@@ -485,8 +487,8 @@ export class TopbarComponent extends ViewControllerComponent implements OnInit, 
   showDSIcon() {
     this.showDirServicesIcon = false;
     this.dirServicesStatus.forEach((item) => {
-      if (item !== 'DISABLED') { 
-        this.showDirServicesIcon = true; 
+      if (item !== 'DISABLED') {
+        this.showDirServicesIcon = true;
       };
     });
   }
@@ -496,11 +498,11 @@ export class TopbarComponent extends ViewControllerComponent implements OnInit, 
     if (!this.updateNotificationSent) {
       this.showUpdateDialog();
       this.updateNotificationSent = true;
-    }      
+    }
   };
 
   showUpdateDialog() {
-    this.dialogService.confirm(helptext.updateRunning_dialog.title, 
+    this.dialogService.confirm(helptext.updateRunning_dialog.title,
       helptext.updateRunning_dialog.message,
       true, T('Close'), false, '', '', '', '', true);
   };

--- a/src/app/components/common/topbar/topbar.component.ts
+++ b/src/app/components/common/topbar/topbar.component.ts
@@ -85,7 +85,7 @@ export class TopbarComponent extends ViewControllerComponent implements OnInit, 
       });
     }
 
-  ngOnInit() { console.log(window.localStorage.getItem('product_type'))
+  ngOnInit() {
     if (window.localStorage.getItem('product_type') === 'ENTERPRISE') {
       this.checkEULA();
       this.ws.call('failover.licensed').subscribe((is_ha) => {
@@ -258,7 +258,7 @@ export class TopbarComponent extends ViewControllerComponent implements OnInit, 
   checkEULA() {
     this.ws.call('truenas.is_eula_accepted').subscribe(eula_accepted => {
       if (!eula_accepted || window.localStorage.getItem('upgrading_status') === 'upgrading') {
-        this.ws.call('truenas.get_eula').subscribe(eula => { console.log(eula)
+        this.ws.call('truenas.get_eula').subscribe(eula => {
           this.dialogService.confirm(T("End User License Agreement - TrueNAS"), eula, true,
           T("I Agree"), false, null, '', null, null, true).subscribe(accept_eula => {
             if (accept_eula) {

--- a/src/app/pages/system/support/fn-sys-info/fn-sys-info.component.ts
+++ b/src/app/pages/system/support/fn-sys-info/fn-sys-info.component.ts
@@ -39,11 +39,13 @@ export class FnSysInfoComponent {
       customSubmit: function (entityDialog) {
         const value = entityDialog.formValue.license;
         self.loader.open();
-        self.ws.call('system.license_update', [value]).subscribe((res) => {
+        self.ws.call('system.license_update', [value]).subscribe(() => {
           entityDialog.dialogRef.close(true);
           self.loader.close();
-          self.dialogService.confirm(helptext.update_license.reload_dialog_title, 
-            helptext.update_license.reload_dialog_message, true, helptext.update_license.reload_dialog_action)
+          window.localStorage.setItem('upgrading_status', 'upgrading');
+          self.dialogService.confirm(helptext.update_license.reload_dialog_title,
+            helptext.update_license.reload_dialog_message, true, helptext.update_license.reload_dialog_action,
+            false, '','', '','', true, '', true)
             .subscribe((res) => {
               if (res) {
                 document.location.reload(true);
@@ -59,5 +61,5 @@ export class FnSysInfoComponent {
     }
     this.dialogService.dialogForm(licenseForm);
   }
- 
+
 }


### PR DESCRIPTION
TN Core returns true for 'is_eula_accepted' so this PR forces the eula to be presented when a new license is entered in core. PS - truenas.get_eula is returning null right now on 12