### PR TITLE
NAS-105610 / 12.0 / NAS-105610 remove isEntity from Kerb settings form

### DIFF
--- a/src/app/pages/directoryservice/kerberossettings/kerberossettings.component.ts
+++ b/src/app/pages/directoryservice/kerberossettings/kerberossettings.component.ts
@@ -13,7 +13,6 @@ export class KerberosSettingsComponent {
   protected queryCall = 'kerberos.config';
   protected addCall = 'kerberos.update';
   protected editCall = 'kerberos.update';
-  protected isEntity = true;
 
   public fieldConfig: FieldConfig[] = []
   public fieldSets: FieldSet[] = [


### PR DESCRIPTION
I removed this 'isEntity' when switching to ws, but put it back in too. But it doesn't belong. It blocks existing data from loading