### PR TITLE
NAS-105738 / 12.0 / NAS-105738 Check advanced.config in component

### DIFF
--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
@@ -477,6 +477,11 @@ export class SMBFormComponent {
       if (entityForm.formGroup.controls['timemachine'].value) { this.isTimeMachineOn = true };
     }, 700)
 
+    this.ws.call('system.advanced.config').subscribe(res => {
+      this.isBasicMode = !res.advancedmode;
+      this.updateForm();
+    })
+
     entityForm.formGroup.controls['purpose'].valueChanges.subscribe((res) => {
       this.clearPresets();
       for (const item in this.presets[res].params) {


### PR DESCRIPTION
Makes SMB Share form show advanced fields if advanced is checked in sys > advanced. This call (system.advanced.config) is already made in entity form, but this particular form gets it too late. Doesn't seem to be a problem in 11.3