### PR TITLE
NAS-105296 / 12.0 / NAS-105296 Use new mw method to fetch bindips

### DIFF
--- a/src/app/helptext/services/components/service-afp.ts
+++ b/src/app/helptext/services/components/service-afp.ts
@@ -56,6 +56,7 @@ afp_srv_map_acls_options : [
 
 afp_srv_bindip_placeholder : T('Bind Interfaces'),
 afp_srv_bindip_tooltip: T('Specify the IP addresses to listen for AFP connections.\
+ Leave blank to bind to all available IPs. \
  If none are specified, advertise the first IP\
  address of the system, but listen for any\
  incoming request.'),

--- a/src/app/pages/services/components/service-afp/service-afp.component.ts
+++ b/src/app/pages/services/components/service-afp/service-afp.component.ts
@@ -124,7 +124,7 @@ export class ServiceAFPComponent {
         );
       }
     });
-    this.iscsiService.getIpChoices().subscribe((res) => {
+    this.ws.call('afp.bindip_choices').subscribe((res) => {
       this.bindip =
         _.find(this.fieldSets, { name: helptext.afp_fieldset_other }).config.find(config => config.name === 'bindip');
       Object.keys(res || {}).forEach(key => {


### PR DESCRIPTION
The mw call is in the stable / master repositories but not yet in a build
New line in helptext is from api doc