### PR TITLE
NAS-105539 / 11.3 / NAS-105539 Match mw validation for email password

### DIFF
--- a/src/app/helptext/system/email.ts
+++ b/src/app/helptext/system/email.ts
@@ -1,6 +1,7 @@
 import { Validators } from "@angular/forms";
 import { T } from "app/translate-marker";
-import { rangeValidator } from 'app/pages/common/entity/entity-form/validators/range-validation'
+import { rangeValidator } from 'app/pages/common/entity/entity-form/validators/range-validation';
+import { regexValidator } from 'app/pages/common/entity/entity-form/validators/regex-validation';
 
 export const helptext_system_email = {
   fromemail: {
@@ -68,6 +69,7 @@ export const helptext_system_email = {
     tooltip: T(
       "Enter the password for the SMTP server. Only plain ASCII\
  characters are accepted."
-    )
+    ),
+    validation: [regexValidator(/^[ -~]+$/)]
   }
 };

--- a/src/app/pages/system/email/email.component.ts
+++ b/src/app/pages/system/email/email.component.ts
@@ -140,7 +140,8 @@ export class EmailComponent implements OnDestroy {
           } ]
         },
       ],
-      togglePw : true
+      togglePw : true,
+      validation: helptext_system_email.pass.validation
     }
   ];
   protected dialogRef: any;


### PR DESCRIPTION
Validates for ASCII characters from 32 to 126 (which includes SPACE, which mw also allows)