### PR TITLE
NAS-105927 / 12.0 / NAS-105927: Replace all guide links with detailed text.

### DIFF
--- a/src/app/helptext/directoryservice/activedirectory.ts
+++ b/src/app/helptext/directoryservice/activedirectory.ts
@@ -56,13 +56,10 @@ activedirectory_ssl_tooltip: T('Choose between <i>Off</i>, <a\
 
 activedirectory_certificate_name: 'certificate',
 activedirectory_certificate_placeholder: T('Certificate'),
-activedirectory_certificate_tooltip: T('Select the certificate of the Active Directory server\
- if SSL connections are used. Add a certificate here by creating a\
- <a href="--docurl--/system.html#cas" target="_blank">CA</a>,\
- then creating a certificate on the Active Directory server.\
- Import the certificate on this system with the\
- <a href="--docurl--/system.html#certificates" target="_blank">Certificates</a>\
- menu.'),
+activedirectory_certificate_tooltip: T('Select the certificate of the Active Directory server \
+ if SSL connections are used. Add a certificate here by creating a Certificate Authority (CA) \
+ then creating a certificate on the Active Directory server. Import the certificate to this \
+ system using the <b>System > Certificates</b> menu.'),
 
 ad_validate_certificates_placeholder: T('Validate Certificates'),
 ad_validate_certificates_tooltip: T('Check server certificates in a TLS session.'),
@@ -108,15 +105,13 @@ activedirectory_site_tooltip : T('Enter the relative distinguished name of the\
 
 activedirectory_kerberos_realm_name: 'kerberos_realm',
 activedirectory_kerberos_realm_placeholder : T('Kerberos Realm'),
-activedirectory_kerberos_realm_tooltip : T('Select the realm created in\
- <a href="--docurl--/directoryservices.html#kerberos-realms"\
- target="_blank">Kerberos Realms</a>.'),
+activedirectory_kerberos_realm_tooltip : T('Select an existing realm that was added \
+ in <b>Directory Services > Kerberos Realms</b>.'),
 
 activedirectory_kerberos_principal_name: 'kerberos_principal',
 activedirectory_kerberos_principal_placeholder : T('Kerberos Principal'),
-activedirectory_kerberos_principal_tooltip : T('Select the keytab created in\
- <a href="--docurl--/directoryservices.html#kerberos-keytabs"\
- target="_blank">Kerberos Keytabs</a>.'),
+activedirectory_kerberos_principal_tooltip : T('Select the location of the principal in the \
+ keytab created in <b>Directory Services > Kerberos Keytabs</b>.'),
 
 computer_account_OU_name: T('createcomputer'),
 computer_account_OU_placeholder: T('Computer Account OU'),
@@ -222,8 +217,6 @@ activedirectory_idmap_change_dialog_message: T('<font color="red">WARNING</font>
  target="_blank">idmap_autorid(8)</a>\, <a\
  href="https://www.freebsd.org/cgi/man.cgi?query=idmap_ad"\
  target="_blank">ad</a>\, <a\
- href="--docurl--/directoryservices.html#id12"\
- target="_blank">fruit</a>\, <a\
  href="https://www.freebsd.org/cgi/man.cgi?query=idmap_ldap"\
  target="_blank">idmap_ldap(8)</a>\, <a\
  href="https://www.freebsd.org/cgi/man.cgi?query=idmap_nss"\

--- a/src/app/helptext/directoryservice/ldap.ts
+++ b/src/app/helptext/directoryservice/ldap.ts
@@ -52,16 +52,13 @@ ldap_anonbind_tooltip : T('Set for the LDAP server to disable authentication and
 
 ldap_kerberos_realm_name : 'kerberos_realm',
 ldap_kerberos_realm_placeholder : T('Kerberos Realm'),
-ldap_kerberos_realm_tooltip: T('Select the realm created using the instructions in <a\
- href="--docurl--/directoryservices.html#kerberos-realms"\
- target="_blank">Kerberos Realms</a>.'),
+ldap_kerberos_realm_tooltip: T('Select an existing realm that was added \
+ in <b>Directory Services > Kerberos Realms</b>.'),
 
 ldap_kerberos_principal_name : 'kerberos_principal',
 ldap_kerberos_principal_placeholder : T('Kerberos Principal'),
-ldap_kerberos_principal_tooltip: T('Select the location of the principal in the keytab\
- created as described in <a\
- href="--docurl--/directoryservices.html#kerberos-keytabs"\
- target="_blank">Kerberos Keytabs</a>.'),
+ldap_kerberos_principal_tooltip: T('Select the location of the principal in the \
+ keytab created in <b>Directory Services > Kerberos Keytabs</b>.'),
 
 ldap_ssl_name : 'ssl',
 ldap_ssl_placeholder : T('Encryption Mode'),

--- a/src/app/helptext/network/interfaces/interfaces-form.ts
+++ b/src/app/helptext/network/interfaces/interfaces-form.ts
@@ -139,14 +139,12 @@ vlan_pcp_options: [
 ],
 
 lagg_protocol_placeholder : T('Lagg Protocol'),
-lagg_protocol_tooltip : T('Select the <a\
- href="--docurl--/network.html--webversion--#link-aggregations"\
- target="_blank">Protocol Type</a>.<br>\
- <i>LACP</i> is the recommended protocol if the network\
- switch is capable of active LACP.<br>\
- <i>Failover</i> is the default protocol choice and\
- should only be used if the network switch does not\
- support active LACP.'),
+lagg_protocol_tooltip : T('Determines the outgoing and incoming traffic ports.<br> \
+ <i>LACP</i> is the recommended protocol if the network switch is capable of \
+ active LACP.<br><i>Failover</i> is the default protocol choice and \
+ should only be used if the network switch does not support active LACP.<br> \
+ See <a href="https://www.freebsd.org/cgi/man.cgi?query=lagg" target="_blank">lagg(4)</a> \
+ for more details.'),
 lagg_protocol_validation : [ Validators.required ],
 lagg_protocol_options: [
     {label:"None", value:"NONE"},

--- a/src/app/helptext/network/laggs/lagg.ts
+++ b/src/app/helptext/network/laggs/lagg.ts
@@ -7,14 +7,12 @@ lagg_interface_placeholder : T('Lagg Interface'),
 lagg_interface_tooltip : T('Description of the lagg interface.'),
 
 lagg_protocol_placeholder : T('Lagg Protocol'),
-lagg_protocol_tooltip : T('Select the <a\
- href="--docurl--/network.html#link-aggregations"\
- target="_blank">Protocol Type</a>.<br>\
- <i>LACP</i> is the recommended protocol if the network\
- switch is capable of active LACP.<br>\
- <i>Failover</i> is the default protocol choice and\
- should only be used if the network switch does not\
- support active LACP.'),
+lagg_protocol_tooltip : T('Determines the outgoing and incoming traffic ports.<br> \
+ <i>LACP</i> is the recommended protocol if the network switch is capable of \
+ active LACP.<br><i>Failover</i> is the default protocol choice and \
+ should only be used if the network switch does not support active LACP.<br> \
+ See <a href="https://www.freebsd.org/cgi/man.cgi?query=lagg" target="_blank">lagg(4)</a> \
+ for more details.'),
 lagg_protocol_validation : [ Validators.required ],
 
 lagg_interfaces_placeholder : T('Lagg Interfaces'),

--- a/src/app/helptext/services/components/service-dc.ts
+++ b/src/app/helptext/services/components/service-dc.ts
@@ -44,9 +44,8 @@ dc_forest_level_options : [
 ],
 
 dc_passwd_placeholder : T('Administrator Password'),
-dc_passwd_tooltip: T('Enter the password to be used for the\
- <a href="--docurl--/directoryservices.html#active-directory"\
- target=”_blank”>Active Directory</a> administrator account.'),
+dc_passwd_tooltip: T('Enter the password to be used for the \
+ Active Directory administrator account.'),
 dc_passwd_validation :
       [ Validators.minLength(8), matchOtherValidator('dc_passwd2') ],
 

--- a/src/app/helptext/services/components/service-ftp.ts
+++ b/src/app/helptext/services/components/service-ftp.ts
@@ -109,15 +109,13 @@ anonuserbw_placeholder : T('Anonymous User Upload Bandwidth'),
 anonuserdlbw_placeholder : T('Anonymous User Download Bandwidth'),
 
 tls_placeholder : T('Enable TLS'),
-tls_tooltip: T('Set to enable encrypted connections. Requires a certificate\
- to be created or imported using\
- <a href="--docurl--/system.html#certificates"\
- target="_blank">Certificates</a>'),
+tls_tooltip: T('Allow encrypted connections. Requires a certificate \
+ created or imported with the <b>System > Certificates</b> menu.'),
 
 tls_policy_placeholder : T('TLS Policy'),
-tls_policy_tooltip: T('The selected policy defines whether the control channel,\
- data channel, both channels, or neither channel of an FTP\
- session must occur over SSL/TLS. The policies are described\
+tls_policy_tooltip: T('Define whether the control channel, \
+ data channel, both channels, or neither channel of an FTP \
+ session must occur over SSL/TLS. The policies are described \
  <a href="http://www.proftpd.org/docs/directives/linked/config_ref_TLSRequired.html"\
  target="_blank">here</a>'),
 

--- a/src/app/helptext/services/components/service-s3.ts
+++ b/src/app/helptext/services/components/service-s3.ts
@@ -5,9 +5,8 @@ import { matchOtherValidator } from '../../../pages/common/entity/entity-form/va
 
 export default {
 bindip_placeholder : T('IP Address'),
-bindip_tooltip: T('Enter the IP address which runs the <a\
- href="--docurl--/services.html#s3" target="_blank">S3\
- service</a>. <i>0.0.0.0</i> tells the server to listen\
+bindip_tooltip: T('Enter the IP address which runs the \
+ S3 service. <i>0.0.0.0</i> tells the server to listen \
  on all addresses.'),
 bindip_options : [
  {label:'0.0.0.0', value: '0.0.0.0'}
@@ -45,9 +44,8 @@ mode_options : [
 ],
 
 certificate_placeholder : T('Certificate'),
-certificate_tooltip : T('Add an <a href="--docurl--/system.html#certificates"\
- target="_blank">SSL certificate</a> to be used for\
- secure S3 connections.'),
+certificate_tooltip : T('Use an SSL certificate that was created or imported in \
+ <b>System > Certificates</b> for secure S3 connections.'),
 
 fieldset_title: T('S3 Configuration Options'),
 

--- a/src/app/helptext/services/components/service-smb.ts
+++ b/src/app/helptext/services/components/service-smb.ts
@@ -26,12 +26,9 @@ cifs_srv_netbiosalias_tooltip: T('Enter any aliases, separated by spaces.\
 cifs_srv_netbiosalias_errmsg: T('Aliases must be 15 characters or less.'),
 
 cifs_srv_workgroup_placeholder: T('Workgroup'),
-cifs_srv_workgroup_tooltip: T('Must match Windows workgroup\
- name. This setting is ignored if the\
- <a href="--docurl--/directoryservices.html#active-directory"\
- target="_blank">Active Directory</a> or <a\
- href="--docurl--/directoryservices.html#ldap"\
- target="_blank">LDAP</a> service is running.'),
+cifs_srv_workgroup_tooltip: T('Must match Windows workgroup \
+ name. This setting is ignored when the \
+ Active Directory or LDAP services are running.'),
 cifs_srv_workgroup_validation : [ Validators.required ],
 
 cifs_srv_description_placeholder: T('Description'),

--- a/src/app/helptext/services/components/service-snmp.ts
+++ b/src/app/helptext/services/components/service-snmp.ts
@@ -9,9 +9,7 @@ location_label : 'Location',
 location_validation : [  ],
 
 contact_placeholder : T('Contact'),
-contact_tooltip: T('Enter an email address to receive messages from the\
- <a href="--docurl--/services.html#snmp"\
- target="_blank">SNMP service</a>.'),
+contact_tooltip: T('E-mail address that will receive SNMP service messages.'),
 contact_validation: [Validators.email],
 
 community_placeholder : T('Community'),

--- a/src/app/helptext/services/components/service-ssh.ts
+++ b/src/app/helptext/services/components/service-ssh.ts
@@ -9,26 +9,22 @@ ssh_tcpport_placeholder : T('TCP Port'),
 ssh_tcpport_tooltip: 'Open a port for SSH connection requests.',
 
 ssh_rootlogin_placeholder : T('Log in as Root with Password'),
-ssh_rootlogin_tooltip: T('<b>Root logins are discouraged.</b> Set to allow root\
- logins. A password must be set for the <i>root</i>\
- user in <a href="--docurl--/accounts.html#users"\
- target="_blank">Users</a>.'),
+ssh_rootlogin_tooltip: T('<b>Root logins are discouraged.</b> Allows root \
+ logins. A password must be set for the <i>root</i> user account.'),
 
 ssh_passwordauth_placeholder : T('Allow Password Authentication'),
-ssh_passwordauth_tooltip: T('Unset to require key-based authentication for\
- all users. This requires <a\
- href="http://the.earth.li/%7Esgtatham/putty/0.55/htmldoc/Chapter8.html"\
- target="_blank">additional setup</a> on both the SSH\
- client and server.'),
+ssh_passwordauth_tooltip: T('Enabling allows using a password to authenticate \
+ the SSH login. Disabling changes authentication to require keys for \
+ all users. This requires \
+ <a href="http://the.earth.li/%7Esgtatham/putty/0.55/htmldoc/Chapter8.html" target="_blank">additional setup</a> \
+ on both the SSH client and server.'),
 
 ssh_kerberosauth_placeholder : T('Allow Kerberos Authentication'),
-ssh_kerberosauth_tooltip: T('Ensure <a\
- href="--docurl--/directoryservices.html#kerberos-realms"\
- target="_blank">Kerberos Realms</a> and <a\
- href="--docurl--/directoryservices.html#kerberos-keytabs"\
- target="_blank">Kerberos Keytabs</a> are configured\
- and the system can communicate with the Kerberos\
- Domain Controller before setting.'),
+ssh_kerberosauth_tooltip: T('Ensure valid entries exist in \
+ <b>Directory Services > Kerberos Realms</b> and \
+ <b>Directory Services > Kerberos Keytabs</b> and the system \
+ can communicate with the Kerberos Domain Controller before \
+ enabling this option.'),
 
 ssh_tcpfwd_placeholder : T('Allow TCP Port Forwarding'),
 ssh_tcpfwd_tooltip: T('Set to allow users to bypass firewall restrictions\

--- a/src/app/helptext/services/components/service-webdav.ts
+++ b/src/app/helptext/services/components/service-webdav.ts
@@ -23,9 +23,8 @@ tcpportssl_tooltip : T('Specify a port for encrypted connections. The\
  a port.'),
 
 certssl_placeholder : T('Webdav SSL Certificate'),
-certssl_tooltip : T('Select the <a href="--docurl--/system.html#certificates"\
- target="_blank">SSL certificate</a> to use for\
- encrypted connections.'),
+certssl_tooltip : T('Select a valid SSL certificate created or imported \
+ in <b>System > Certificates</b> to use for encrypted connections.'),
 
 htauth_placeholder : T('HTTP Authentication'),
 htauth_tooltip : T('<i>Basic Authentication</i> is unencrypted.\

--- a/src/app/helptext/sharing/iscsi/iscsi.ts
+++ b/src/app/helptext/sharing/iscsi/iscsi.ts
@@ -61,13 +61,10 @@ export const helptext_sharing_iscsi = {
   ),
 
   portal_form_placeholder_discovery_authmethod: T("Discovery Authentication Method"),
-  portal_form_tooltip_discovery_authmethod: T(
-    '<a href="--docurl--/sharing.html#block-iscsi"\
- target="_blank">iSCSI</a> supports multiple\
- authentication methods that are used by the target to\
- discover valid devices. <i>None</i> allows anonymous\
- discovery while <i>CHAP</i> and <i>Mutual CHAP</i>\
- require authentication.'
+  portal_form_tooltip_discovery_authmethod: T('iSCSI supports multiple \
+ authentication methods that are used by the target to discover valid \
+ devices. <i>None</i> allows anonymous discovery while <i>CHAP</i> and \
+ <i>Mutual CHAP</i> require authentication.'
   ),
 
   portal_form_placeholder_discovery_authgroup: T("Discovery Authentication Group"),
@@ -145,14 +142,10 @@ export const helptext_sharing_iscsi = {
   globalconf_placeholder_pool_avail_threshold: T(
     "Pool Available Space Threshold (%)"
   ),
-  globalconf_tooltip_pool_avail_threshold: T(
-    'Enter the percentage of free space to remain\
- in the pool. When this percentage is reached,\
- the system issues an alert, but only if zvols are used.\
- See <a href="--docurl--/vaai.html#vaai"\
- target="_blank">VAAI Threshold Warning</a> for more\
- information.'
-  ),
+  globalconf_tooltip_pool_avail_threshold: T('Generate an alert when the \
+   pool has this percent space remaining. This is typically \
+   configured at the pool level when using zvols or at the extent level \
+   for both file and device based extents.'),
 
   globalconf_placeholder_alua: T('Enable iSCSI ALUA'),
   globalconf_tooltip_alua: T(`Allow initiator to discover paths to both\
@@ -212,12 +205,9 @@ export const helptext_sharing_iscsi = {
   ),
 
   extent_placeholder_avail_threshold: T("Available Space Threshold (%)"),
-  extent_tooltip_avail_threshold: T(
-    'Only appears if a <i>File</i> or zvol is selected. When\
- the specified percentage of free space is reached,\
- the system issues an alert.\
- See <a href="--docurl--/vaai.html#vaai"\
- target="_blank">VAAI</a> Threshold Warning.'
+  extent_tooltip_avail_threshold: T('Only appears if a <i>File</i> or \
+ zvol is selected. When the specified percentage of free space is reached,\
+ the system issues an alert.'
   ),
 
   extent_placeholder_comment: T("Description"),

--- a/src/app/helptext/shell/shell.ts
+++ b/src/app/helptext/shell/shell.ts
@@ -7,11 +7,7 @@ export default {
     <b>Netperf</b>, <b>IOzone</b>, <b>arcsat</b>,\
     <b>tw_cli</b>, <br><b>MegaCli</b>,\
     <b>freenas-debug</b>, <b>tmux</b>,\
-    <b>Dmidecode</b>.<br> Refer to the <a\
-    href="--docurl--/cli.html"\
-    target="_blank">Command Line Utilities</a>\
-    chapter in the guide for usage information\
-    and examples.'
+    <b>Dmidecode</b>.'
   ),
 
   dialog_title: T('Copy and Paste'),

--- a/src/app/helptext/storage/import-disk/import-disk.ts
+++ b/src/app/helptext/storage/import-disk/import-disk.ts
@@ -10,10 +10,7 @@ import_disk_volume_tooltip: T('Select the disk to import. The import will copy t
 import_disk_volume_validation : [ Validators.required ],
 
 import_disk_fs_type_placeholder : T('Filesystem type'),
-import_disk_fs_type_tooltip: T('Choose the type of filesystem on the disk. Refer to\
- the guide section on <a\
- href="--docurl--/storage.html#import-disk"\
- target="_blank">importing disks</a> for more details.'),
+import_disk_fs_type_tooltip: T('Choose the type of filesystem on the disk.'),
 import_disk_fs_type_validation : [ Validators.required ],
 
 

--- a/src/app/helptext/storage/snapshots/snapshots.ts
+++ b/src/app/helptext/storage/snapshots/snapshots.ts
@@ -15,10 +15,8 @@ snapshot_add_name_tooltip: T('Unique snapshot name. Cannot be used with \
 
 snapshot_add_naming_schema_placeholder: T('Naming Schema'),
 snapshot_add_naming_schema_tooltip: T('Generate a name for the snapshot \
- from a previously created \
- <a href="--docurl--/tasks.html#periodic-snapshot-tasks" \
- target="_blank">periodic snapshot task</a> naming schema. This allows \
- the snapshot to be replicated. Cannot be used with a <i>Name</i>.'),
+ using the naming schema from a previously created <b>Periodic Snapshot Task</b>. \
+ This allows the snapshot to be replicated. Cannot be used with a <i>Name</i>.'),
 
 snapshot_add_recursive_placeholder: T('Recursive'),
 snapshot_add_recursive_tooltip: T('Set to include child datasets of the \

--- a/src/app/helptext/storage/volumes/datasets/dataset-acl.ts
+++ b/src/app/helptext/storage/volumes/datasets/dataset-acl.ts
@@ -63,10 +63,7 @@ dataset_acl_gid_tooltip: T('The group which controls the dataset. This\
 
 dataset_acl_perms_placeholder: T('Permissions'),
 dataset_acl_perms_tooltip: T('Select permissions to apply to the chosen\
- <i>Who</i>. Choices change depending on the <i>Permissions Type</i>.\
- See the\
- <a href="--docurl--/storage.html#ace-permissions" target="_blank">ACL permissions list</a>\
- for descriptions of each permission.'),
+ <i>Who</i>. Choices change depending on the <i>Permissions Type</i>.'),
 dataset_acl_basic_perms_options: [
                                   {label:'Read', value: 'READ'},
                                   {label:'Modify', value: 'MODIFY'},
@@ -107,9 +104,7 @@ dataset_acl_flags_placeholder: T('Flags'),
 dataset_acl_flags_tooltip: T('How this ACE is applied to newly created\
  directories and files within the dataset. Basic flags enable or disable\
  ACE inheritance. Advanced flags allow further control of how the ACE\
- is applied to files and directories in the dataset. See the\
- <a href="--docurl--/storage.html#ace-inheritance-flags" target="_blank">inheritance flags list</a>\
- for descriptions of Advanced inheritance flags.'),
+ is applied to files and directories in the dataset.'),
 dataset_acl_basic_flags_options: [{label: 'Inherit', value: 'INHERIT'},
                                   {label: 'No Inherit', value: 'NOINHERIT'},
                                   {label: 'Other (Too complicated to be displayed)',

--- a/src/app/helptext/storage/volumes/datasets/dataset-form.ts
+++ b/src/app/helptext/storage/volumes/datasets/dataset-form.ts
@@ -16,10 +16,14 @@ dataset_form_sync_tooltip: T('<i>Standard</i> uses the sync settings that have b
  writes to complete.'),
 
 dataset_form_compression_placeholder: T('Compression level'),
-dataset_form_compression_tooltip: T('For more information about the available compression\
- algorithms, refer to the <a\
- href="--docurl--/storage.html#compression"\
- target="_blank">Compression section</a> of the guide.'),
+dataset_form_compression_tooltip: T('Encode information in less space than the \
+ original data occupies. It is recommended to choose a compression algorithm \
+ that balances disk performance with the amount of saved space.<br> <i>LZ4</i> is \
+ generally recommended as it maximizes performance and dynamically identifies \
+ the best files to compress.<br> <i>GZIP</i> options range from 1 for least \
+ compression, best performance, through 9 for maximum compression with \
+ greatest performance impact.<br> <i>ZLE</i> is a fast algorithm that only \
+ elminates runs of zeroes.'),
 
 dataset_form_atime_placeholder: T('Enable Atime'),
 dataset_form_atime_tooltip: T('Choose <i>ON</i> to update the access time for files\
@@ -68,9 +72,10 @@ dataset_form_reservation_tooltip: T('<i>0</i> is unlimited. A specified value ap
 
 dataset_form_deduplication_label: T('ZFS deduplication'),
 dataset_form_deduplication_placeholder: T('ZFS Deduplication'),
-dataset_form_deduplication_tooltip: T('Please read about <a href="--docurl--/storage.html#deduplication"\
- target="_blank">deduplication</a> before considering\
- changing this setting.'),
+dataset_form_deduplication_tooltip: T('Transparently reuse a single copy of duplicated \
+ data to save space. Deduplication can improve storage capacity, but is RAM intensive. \
+ Compressing data is generally recommended before using deduplication. Deduplicating data is \
+ a one-way process. <b>Deduplicated data cannot be undeduplicated!</b>.'),
 
 dataset_form_readonly_placeholder: T('Read-only'),
 dataset_form_readonly_tooltip: T('Set to prevent the dataset from being modified.'),

--- a/src/app/helptext/storage/volumes/manager/vdev.ts
+++ b/src/app/helptext/storage/volumes/manager/vdev.ts
@@ -1,13 +1,14 @@
 import { T } from '../../../../translate-marker';
 
 export default {
-vdev_diskSizeErrorMsg : T('Mixing disks of different sizes in a VDEV is not allowed.'),
-vdev_type_tooltip : T('Choose a <i>Stripe</i>, <i>Mirror</i>,\
- or <i>Raid-Z</i> configuration for the\
- chosen disk layout. See the <a\
- href="--docurl--/storage.html#pool-manager"\
- target="_blank">Pool Manager</a> section\
- of the guide for more details.'),
+vdev_diskSizeErrorMsg : T('Mixing disks of different sizes in a vdev is not allowed.'),
+vdev_type_tooltip : T('Arrange the disks according to capacity, redundancy, and \
+ performance considerations. More types become available as more disks are added to the vdev.<br> \
+ A <i>Stripe</i> uses the entire capacity of the disks for storage and <b>has no redundancy</b>. \
+ Failed or degraded disks in a stripe can result in data loss!<br> A <i>Mirror</i> requires at \
+ least two disks and mirrors the data from one disk onto each other disk in the vdev, which can \
+ limit the total capacity.<br><i>Raid-Z</i> configurations offer different balances of data \
+ redundancy and total capacity for the selected disks.'),
 vdev_types : {
     'stripe' : T('Stripe'),
     'mirror' : T('Mirror'),

--- a/src/app/helptext/storage/volumes/zvol-form.ts
+++ b/src/app/helptext/storage/volumes/zvol-form.ts
@@ -27,17 +27,21 @@ zvol_sync_tooltip: T('Sets the data write synchronization. <i>Inherit</i>\
  waits for writes to complete.'),
 
 zvol_compression_placeholder: T('Compression level'),
-zvol_compression_tooltip: T('Automatically compress data written to the zvol.\
- Choose a <a href="--docurl--/storage.html#compression"\
- target="_blank">compression algorithm</a>.'),
+zvol_compression_tooltip: T('Encode information in less space than the \
+ original data occupies. It is recommended to choose a compression algorithm \
+ that balances disk performance with the amount of saved space.<br> <i>LZ4</i> is \
+ generally recommended as it maximizes performance and dynamically identifies \
+ the best files to compress.<br> <i>GZIP</i> options range from 1 for least \
+ compression, best performance, through 9 for maximum compression with \
+ greatest performance impact.<br> <i>ZLE</i> is a fast algorithm that only \
+ elminates runs of zeroes.'),
 zvol_compression_validation: [Validators.required],
 
 zvol_deduplication_placeholder: T('ZFS Deduplication'),
-zvol_deduplication_tooltip : T('Activates the process for ZFS to transparently reuse\
- a single copy of duplicated data to save space. The\
- <a href="--docurl--/storage.html#deduplication"\
- target="_blank">Deduplication section</a> of the Guide\
- describes each option.'),
+zvol_deduplication_tooltip : T('Transparently reuse a single copy of duplicated \
+ data to save space. Deduplication can improve storage capacity, but is RAM intensive. \
+ Compressing data is generally recommended before using deduplication. Deduplicating data is \
+ a one-way process. <b>Deduplicated data cannot be undeduplicated!</b>.'),
 zvol_deduplication_validation: [Validators.required],
 
 zvol_sparse_placeholder: T('Sparse'),

--- a/src/app/helptext/system/advanced.ts
+++ b/src/app/helptext/system/advanced.ts
@@ -56,14 +56,10 @@ export const helptext_system_advanced = {
   },
   
   autotune_placeholder: T('Enable Autotune'),
-  autotune_tooltip: T('Enables the autotune script which attempts to optimize\
- the system depending on the installed hardware.\
- <b>Warning:</b> Autotuning is only used as a temporary\
- measure and is not a permanent fix for system hardware\
- issues. See the\
- <a href="--docurl--/system.html#autotune"\
- target="_blank">Autotune section</a> of the guide for\
- more information.'),
+  autotune_tooltip: T('Activates a tuning script which attempts to optimize \
+ the system depending on the installed hardware. <b>Warning:</b> Autotuning \
+ is only used as a temporary measure and is not a permanent fix for system \
+ hardware issues.'),
 
   debugkernel_placeholder: T('Enable Debug Kernel'),
   debugkernel_tooltip: T('Set to boot a debug kernel after the next system\
@@ -91,10 +87,8 @@ export const helptext_system_advanced = {
   cpu_in_percentage_placeholder: T('Report CPU Usage in Percentage'),
   cpu_in_percentage_tooltip: T('Set to display CPU usage as percentages in Reporting.'),
 
-  sed_options_message_paragraph: T('<b>SED (Self-Encrypting Drives) Options</b>'),
-  sed_options_tooltip: T('See the <a href="--docurl--/system.html#self-encrypting-drives"\
- target="_blank"> Self Encrypting Drives</a> section of\
- the user guide for more information.'),
+  sed_options_message_paragraph: T('Self-Encrypting Drive Options'),
+  sed_options_tooltip: T(''),
 
   sed_user_placeholder: T('ATA Security User'),
   sed_user_tooltip: T('User passed to <i>camcontrol security -u</i> to unlock\

--- a/src/app/helptext/system/ca.ts
+++ b/src/app/helptext/system/ca.ts
@@ -32,9 +32,7 @@ matches your certificate usage scenario.'),
     signedby: {
       placeholder: T("Signing Certificate Authority"),
       tooltip: T(
-        'Select a previously imported or created <a\
- href="--docurl--/system.html#cas"\
- target="_blank">CA</a>.'
+        'Select a previously imported or created CA.'
       ),
       validation: [Validators.required]
     },

--- a/src/app/helptext/system/certificates.ts
+++ b/src/app/helptext/system/certificates.ts
@@ -39,8 +39,7 @@ matches your certificate usage scenario.'),
     signedby: {
       placeholder: T("Signing Certificate Authority"),
       tooltip: T(
-        'Select a previously imported or created \
- <a href="--docurl--/system.html#cas" target="_blank">CA</a>.'
+        'Select a previously imported or created CA.'
       ),
       validation: [Validators.required]
     },

--- a/src/app/helptext/system/general.ts
+++ b/src/app/helptext/system/general.ts
@@ -8,10 +8,10 @@ export const helptext_system_general = {
 
   stg_guicertificate: {
     placeholder: T("GUI SSL Certificate"),
-    tooltip: T('The system uses a self-signed \
- <a href="--docurl--/system.html#certificates" target="_blank">certificate</a> \
- to enable encrypted web interface connections. To change the default \
- certificate, select a different created or imported certificate.'
+    tooltip: T('The system uses a self-signed certificate \
+ to enable encrypted web interface connections. To change \
+ the default certificate, select a different certificate \
+ that was created or imported in the <b>Certificates</b> menu.'
     ),
     validation: [Validators.required]
   },

--- a/src/app/helptext/task-calendar/replication/replication.ts
+++ b/src/app/helptext/task-calendar/replication/replication.ts
@@ -20,8 +20,7 @@ export default {
     transport_placeholder: T('Transport'),
     transport_tooltip: T('Method of snapshot transfer:<ul> \
  <li><i>SSH</i> is supported by most systems. It requires a previously \
- created <a href="--docurl--/system.html#ssh-connection" \
- target="_blank">SSH connection</a>.</li> \
+ created connection in <b>System > SSH Connections</b>.</li> \
  <li><i>SSH+NETCAT</i> uses SSH to establish a connection to the \
  destination system, then uses \
  <a href="https://github.com/freenas/py-libzfs" \
@@ -34,9 +33,8 @@ export default {
  and earlier.</li></ul>'),
 
     ssh_credentials_placeholder: T('SSH Connection'),
-    ssh_credentials_tooltip: T('Choose the \
- <a href="--docurl--/system.html#ssh-connection" \
- target="_blank">SSH connection</a>.'),
+    ssh_credentials_tooltip: T('Choose a connection that has been saved in \
+ <b>System > SSH Connections</b>.'),
 
     netcat_active_side_placeholder: T('Netcat Active Side'),
     netcat_active_side_tooltip: T('Establishing a connection requires \
@@ -108,10 +106,9 @@ from the source dataset.'),
 
     periodic_snapshot_tasks_placeholder: T('Periodic Snapshot Tasks'),
     periodic_snapshot_tasks_tooltip: T('Snapshot schedule for this \
- replication task. Choose from configured \
- <a href="--docurl--/tasks.html#periodic-snapshot-tasks" \
- target="_blank">Periodic Snapshot Tasks</a>. This replication task must \
- have the same <b>Recursive</b> and <b>Exclude Child Datasets</b> values \
+ replication task. Choose from previously configured \
+ <b>Periodic Snapshot Tasks</b>. This replication task must have the \
+ same <b>Recursive</b> and <b>Exclude Child Datasets</b> values \
  as the chosen periodic snapshot task. Selecting a periodic snapshot \
  schedule removes the <b>Schedule</b> field.'),
 
@@ -133,10 +130,8 @@ from the source dataset.'),
  When a periodic snapshot is not linked to the replication, enter the \
  naming schema for manually created snapshots. Has the same <i>%Y</i>, \
  <i>%m</i>, <i>%d</i>, <i>%H</i>, and <i>%M</i> string requirements as \
- the <b>Naming Schema</b> in a \
- <a href="--docurl--/tasks.html#periodic-snapshot-tasks" \
- target="_blank">periodic snapshot task. Separate entries by pressing \
- <code>Enter</code>.'),
+ the <b>Naming Schema</b> in a <b>Periodic Snapshot Task</b>. Separate \
+ entries by pressing <code>Enter</code>.'),
 
     auto_placeholder: T('Run Automatically'),
     auto_tooltip: T('Set to either start this replication task \

--- a/src/app/helptext/task-calendar/resync/resync-form.ts
+++ b/src/app/helptext/task-calendar/resync/resync-form.ts
@@ -9,12 +9,10 @@ export default {
     fieldset_options: T('More Options'),
 
     rsync_path_placeholder: T('Path'),
-    rsync_path_tooltip: T('Browse to the path to be copied. The \
-                <a href="--docurl--/intro.html#path-and-name-lengths" \
-                target="_blank">FreeBSD file path limits</a> apply. \
-                Other operating systems can have different limits \
-                which might affect how they can be used as sources \
-                or destinations.'),
+    rsync_path_tooltip: T('Browse to the path to be copied. FreeBSD \
+ file path limits apply. Other operating systems can have different \
+ limits which might affect how they can be used as sources or \
+ destinations.'),
     rsync_path_validation : [ Validators.required ],
 
     rsync_user_placeholder: T('User'),
@@ -35,11 +33,8 @@ export default {
     rsync_remoteport_validation: [rangeValidator(1, 65535), Validators.required],
 
     rsync_mode_placeholder: T('Rsync Mode'),
-    rsync_mode_tooltip: T('Choose <a \
-                href="--docurl--/tasks.html#rsync-module-mode"\
-                target="_blank">rsync module mode</a> or <a \
-                href="--docurl--/tasks.html#rsync-over-ssh-mode"\
-                target="_blank">rsync over SSH mode</a>'),
+    rsync_mode_tooltip: T('Choose to either use a custom-defined remote module \
+ of the rsync server or to use an SSH configuration for the rsync task.'),
 
     rsync_remotemodule_placeholder: T('Remote Module Name'),
     rsync_remotemodule_tooltip: T('At least one module must be defined in <a\

--- a/src/app/helptext/vm/devices/device-add-edit.ts
+++ b/src/app/helptext/vm/devices/device-add-edit.ts
@@ -15,9 +15,7 @@ order_placeholder : T('Device Order'),
 order_tooltip : '',
 
 zvol_path_placeholder : 'Zvol',
-zvol_path_tooltip : 'Browse to an existing <a\
- href="--docurl--/storage.html#adding-zvols"\
- target="_blank">Zvol</a>.',
+zvol_path_tooltip : 'Define the path to an existing zvol for VM use.',
 zvol_path_validation : [Validators.required],
 options:[],
 

--- a/src/app/helptext/vm/vm-cards/vm-cards.ts
+++ b/src/app/helptext/vm/vm-cards/vm-cards.ts
@@ -7,11 +7,7 @@ serial_shell_tooltip : '<b>Ctrl+C</b> kills a foreground process.<br>\
  <b>Netperf</b>, <b>IOzone</b>, <b>arcsat</b>,\
  <b>tw_cli</b>, <br><b>MegaCli</b>,\
  <b>freenas-debug</b>, <b>tmux</b>,\
- <b>Dmidecode</b>.<br> Refer to the <a\
- href="--docurl--/cli.html"\
- target="_blank">Command Line Utilities</a>\
- chapter in the <b>User Guide</b> for usage\
- information and examples.',
+ <b>Dmidecode</b>.',
 
 // VM card edit
 config_name_placeholder: T('Name'),


### PR DESCRIPTION
- Attempt to directly inject more informative text into many help text strings
- Remove fragile documentation links that break with each release
- Cherry-picked commit from 11.3-U3 branch and reworked to apply changes to 12