### PR TITLE
Fix display buttons in french translation

### DIFF
--- a/src/app/pages/preferences/page/forms/custom-theme-manager-form.component.ts
+++ b/src/app/pages/preferences/page/forms/custom-theme-manager-form.component.ts
@@ -14,7 +14,7 @@ import { T } from '../../../../translate-marker';
 
 @Component({
   selector : 'custom-theme-manager-form',
-  template:`<entity-form-embedded fxFlex="100" fxFlex.gt-xs="350px" [target]="target" [data]="values" [conf]="this"></entity-form-embedded>`
+  template:`<entity-form-embedded fxFlex="100" fxFlex.gt-xs="450px" [target]="target" [data]="values" [conf]="this"></entity-form-embedded>`
 })
 export class CustomThemeManagerFormComponent implements OnInit, OnChanges, OnDestroy {
 


### PR DESCRIPTION
I think this fix will resolve the issue below. Indeed with the French translation the buttons below are no longer aligned. With the correction there are.

**Before fix**

![bug](https://user-images.githubusercontent.com/4472695/80797890-42827f00-8ba3-11ea-8457-04bd9c433544.png)

**After fix**

![bug_resolv](https://user-images.githubusercontent.com/4472695/80797920-51693180-8ba3-11ea-85f5-1b7069a2fc49.png)
