### PR TITLE
NAS-105950 / 12.0 / NAS-105950 Use new api calls to detect if pools or datasets are locked

### DIFF
--- a/src/app/helptext/sharing/smb/smb.ts
+++ b/src/app/helptext/sharing/smb/smb.ts
@@ -138,6 +138,12 @@ export const helptext_sharing_smb = {
 
     action_share_acl: T('Edit Share ACL'),
     action_edit_acl: T('Edit Filesystem ACL'),
+    action_edit_acl_dialog: {
+      title: T('Error'),
+      message1: T('The pool containing'),
+      message2: T('is locked.')
+   },
+    
 
     dialog_warning: T('Warning'),
     dialog_warning_message: T("Setting default permissions will reset the permissions of this share and any others within its path."),

--- a/src/app/pages/sharing/smb/smb-list/smb-list.component.ts
+++ b/src/app/pages/sharing/smb/smb-list/smb-list.component.ts
@@ -87,8 +87,27 @@ export class SMBListComponent {
         label: helptext_sharing_smb.action_edit_acl,
         onClick: row => {
           const datasetId = rowName;
-          this.router.navigate(
-            ["/"].concat(["storage", "pools", "id", poolName, "dataset", "acl", datasetId]));
+          // If path_is_encrypted is true or an [ENOENT] err returns, pool or ds is locked
+          this.ws.call('filesystem.path_is_encrypted', [row.path]).subscribe(
+            res => {
+            if(res) {
+              this.dialogService.errorReport(helptext_sharing_smb.action_edit_acl_dialog.title, 
+                `${helptext_sharing_smb.action_edit_acl_dialog.message1} ${poolName} 
+                ${helptext_sharing_smb.action_edit_acl_dialog.message2}`)
+            } else {
+              this.router.navigate(
+                ["/"].concat(["storage", "pools", "id", poolName, "dataset", "acl", datasetId]));
+            }
+          }, err => {
+            if (err.reason.includes('[ENOENT]')) { 
+              this.dialogService.errorReport(helptext_sharing_smb.action_edit_acl_dialog.title, 
+                `${helptext_sharing_smb.action_edit_acl_dialog.message1} ${poolName} 
+                ${helptext_sharing_smb.action_edit_acl_dialog.message2}`)
+            } else { // If some other err comes back from filesystem.path_is_encrypted
+              this.dialogService.errorReport(helptext_sharing_smb.action_edit_acl_dialog.title, 
+                err.reason, err.trace.formatted);
+            }
+          })
         }
       },
       {


### PR DESCRIPTION
The [ENOENT] error in the smb table and form, below, was just added to the middleware today, and isn't in the build yet.