### PR TITLE
dashboard memory panel: show ECC status only when known

### DIFF
--- a/src/app/core/components/widgets/widgetmemory/widgetmemory.component.html
+++ b/src/app/core/components/widgets/widgetmemory/widgetmemory.component.html
@@ -42,7 +42,7 @@
           <div class="memory-used-caption">
             <span *ngIf="memData">
               {{"total available" | translate}}
-              (<span *ngIf="!ecc">non-</span>ECC)
+              <span *ngIf="ecc">(ECC)</span>
             </span>
           </div>
           <!-- Legend --> 


### PR DESCRIPTION
ecc presents as "ECC" or "non-ECC", but actually
the system actually only knows "ECC" or "IDK, prolly not but maybe".

dmidecode does not seem a reliable source for this information.
It has been shown that ECC can be installed, configured, and enabled,
and yet dmidecode can say that it is not.

This change should only show the "(ECC)" in the panel when it knows
there is ECC, and nothing when it isn't sure, instead of "(non-ECC)".

See:
* https://www.ixsystems.com/community/threads/truenas-web-ui-shows-non-ecc-but-ecc-is-used.84492/
* https://jira.ixsystems.com/projects/NAS/issues/NAS-105991