### PR TITLE
NAS-106204 / 12.0 / NAS-106204 Expose loglevel for AFP

### DIFF
--- a/src/app/helptext/services/components/service-afp.ts
+++ b/src/app/helptext/services/components/service-afp.ts
@@ -38,9 +38,9 @@ afp_srv_chmod_request_tooltip: T('Indicates how to handle Access Control Lists.\
  <b>Simple:</b> is set to chmod() as requested\
  without any extra steps.'),
 afp_srv_chmod_request_options : [
-  {label : 'Ignore', value : 'IGNORE'},
-  {label : 'Preserve', value : 'PRESERVE'},
-  {label : 'Simple', value : 'SIMPLE'},
+  {label : T('Ignore'), value : 'IGNORE'},
+  {label : T('Preserve'), value : 'PRESERVE'},
+  {label : T('Simple'), value : 'SIMPLE'},
 ],
 
 afp_srv_map_acls_placeholder : T('Map ACLs'),
@@ -49,10 +49,22 @@ afp_srv_map_acls_tooltip: T('Select mapping of permissions for\
  (default, Unix-style permissions), <b>None</b>,\
  or <b>Mode</b> (ACLs).'),
 afp_srv_map_acls_options : [
-  {label : 'Rights', value : 'RIGHTS'},
-  {label : 'None', value : 'NONE'},
-  {label : 'Mode', value : 'MODE'},
+  {label : T('Rights'), value : 'RIGHTS'},
+  {label : T('None'), value : 'NONE'},
+  {label : T('Mode'), value : 'MODE'},
 ],
+
+loglevel: {
+  placeholder: T('Log Level'),
+  tooltip: T('Choices are <i>Minimum, Normal, or Debug</i>.'),
+  options: [
+    { label: T('None'), value: 'NONE' },
+    { label: T('Minimum'), value: 'MINIMUM' },
+    { label: T('Normal'), value: 'NORMAL' },
+    { label: T('Full'), value: 'FULL' },
+    { label: T('Debug'), value: 'DEBUG' },
+  ],
+},
 
 afp_srv_bindip_placeholder : T('Bind Interfaces'),
 afp_srv_bindip_tooltip: T('Specify the IP addresses to listen for AFP connections.\

--- a/src/app/helptext/services/components/service-smb.ts
+++ b/src/app/helptext/services/components/service-smb.ts
@@ -39,7 +39,8 @@ cifs_srv_unixcharset_tooltip: T('Default is UTF-8 which supports all characters 
  all languages.'),
 
 cifs_srv_loglevel_placeholder: T('Log Level'),
-cifs_srv_loglevel_tooltip: T('Choices are <i>Minimum, Normal, or Debug</i>.'),
+cifs_srv_loglevel_tooltip: T('Record SMB service messages up to the specified log level. \
+ By default, error and warning level messages are logged.'),
 cifs_srv_loglevel_options: [
   { label: T('None'), value: 'NONE' },
   { label: T('Minimum'), value: 'MINIMUM' },

--- a/src/app/helptext/services/components/service-smb.ts
+++ b/src/app/helptext/services/components/service-smb.ts
@@ -41,11 +41,11 @@ cifs_srv_unixcharset_tooltip: T('Default is UTF-8 which supports all characters 
 cifs_srv_loglevel_placeholder: T('Log Level'),
 cifs_srv_loglevel_tooltip: T('Choices are <i>Minimum, Normal, or Debug</i>.'),
 cifs_srv_loglevel_options: [
-  { label: 'None', value: 'NONE' },
-  { label: 'Minimum', value: 'MINIMUM' },
-  { label: 'Normal', value: 'NORMAL' },
-  { label: 'Full', value: 'FULL' },
-  { label: 'Debug', value: 'DEBUG' },
+  { label: T('None'), value: 'NONE' },
+  { label: T('Minimum'), value: 'MINIMUM' },
+  { label: T('Normal'), value: 'NORMAL' },
+  { label: T('Full'), value: 'FULL' },
+  { label: T('Debug'), value: 'DEBUG' },
 ],
 
 cifs_srv_syslog_placeholder: T('Use Syslog Only'),

--- a/src/app/pages/services/components/service-afp/service-afp.component.ts
+++ b/src/app/pages/services/components/service-afp/service-afp.component.ts
@@ -39,6 +39,7 @@ export class ServiceAFPComponent {
     {
       name: helptext.afp_fieldset_access,
       label: true,
+      width: '49%',
       config: [
         {
           type : 'select',
@@ -75,14 +76,19 @@ export class ServiceAFPComponent {
         }
       ]
     },
-    {
-      name: 'divider',
-      divider: true
-    },
+    { name: 'vertical-spacer', width: '2%'},
     {
       name: helptext.afp_fieldset_other,
       label: true,
+      width: '49%',
       config: [
+        {
+          type: 'select',
+          name: 'loglevel',
+          placeholder: helptext.loglevel.placeholder,
+          tooltip: helptext.loglevel.tooltip,
+          options: helptext.loglevel.options
+        },
         {
           type : 'select',
           name : 'bindip',


### PR DESCRIPTION
The update to mw doesn't appear to be in the build yet.
The tooltip is the same as for log level in Services > SMB. It probably should be checked in both places to make sure it is up-to-date and provides help.