### PR TITLE
NAS-106099 / 12.0 / update hosts allow/deny helptext.

### DIFF
--- a/src/app/helptext/sharing/afp/afp.ts
+++ b/src/app/helptext/sharing/afp/afp.ts
@@ -147,7 +147,7 @@ export const helptext_sharing_afp = {
  If there is a host not on the *Allow Hosts* and not on the *Deny Hosts* list, \
  then allow it."),
 
-  tooltip_hostsdeny: T("Deny hostnames or IP addresses to connect to the share. \
+  tooltip_hostsdeny: T("Deny hostnames or IP addresses access to the share. \
   Click <i>ADD</i> to add multiple entries. <br><br> \
   If neither *Allow Hosts* or *Deny Hosts* contains \
   an entry, then AFP share access is allowed for any host. <br><br> \

--- a/src/app/helptext/sharing/afp/afp.ts
+++ b/src/app/helptext/sharing/afp/afp.ts
@@ -134,16 +134,31 @@ export const helptext_sharing_afp = {
  (anyone can read, write, and execute)."
   ),
 
-  placeholder_hostsallow: T("Hosts Allow"),
-  tooltip_hostsallow: T(
-    "Comma-, space-, or tab-delimited list of allowed\
- hostnames or IP addresses."
-  ),
+  tooltip_hostsallow: T( "Allow hostnames or IP addresses to connect to the \
+ share. Click <i>ADD</i> to add multiple entries. <br><br> \
+ If neither *Allow Hosts* or *Deny Hosts* contains \
+ an entry, then AFP share access is allowed for any host. <br><br> \
+ If there is a *Allow Hosts* list but no *Deny Hosts* list, then only allow \
+ hosts on the *Allow Hosts* list. <br><br> \
+ If there is a *Deny Hosts* list but no *Allow Hosts* list, then allow all \
+ hosts that are not on the *Deny Hosts* list. <br><br> \
+ If there is both a *Allow Hosts* and *Deny Hosts* list, then allow all hosts \
+ that are on the *Allow Hosts* list. <br><br> \
+ If there is a host not on the *Allow Hosts* and not on the *Deny Hosts* list, \
+ then allow it."),
 
-  tooltip_hostsdeny: T(
-    "Comma-, space-, tab-delimited list of denied\
- hostnames or IP addresses."
-  ),
+  tooltip_hostsdeny: T("Deny hostnames or IP addresses to connect to the share. \
+  Click <i>ADD</i> to add multiple entries. <br><br> \
+  If neither *Allow Hosts* or *Deny Hosts* contains \
+  an entry, then AFP share access is allowed for any host. <br><br> \
+  If there is a *Allow Hosts* list but no *Deny Hosts* list, then only allow \
+  hosts on the *Allow Hosts* list. <br><br> \
+  If there is a *Deny Hosts* list but no *Allow Hosts* list, then allow all \
+  hosts that are not on the *Deny Hosts* list. <br><br> \
+  If there is both a *Allow Hosts* and *Deny Hosts* list, then allow all hosts \
+  that are on the *Allow Hosts* list. <br><br> \
+  If there is a host not on the *Allow Hosts* and not on the *Deny Hosts* list, \
+  then allow it."),
 
   tooltip_auxparams: T(
     'Additional\

--- a/src/app/helptext/sharing/smb/smb.ts
+++ b/src/app/helptext/sharing/smb/smb.ts
@@ -93,11 +93,31 @@ export const helptext_sharing_smb = {
     tooltip_hostsallow: T('Enter a list of allowed hostnames or IP addresses.\
  Separate entries by pressing <code>Enter</code>. A more detailed description \
  with examples can be found \
- <a href="https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#HOSTSALLOW">here</a>.'),
+ <a href="https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#HOSTSALLOW">here</a>. <br><br> \
+ If neither *Hosts Allow* or *Hosts Deny* contains \
+ an entry, then AFP share access is allowed for any host. <br><br> \
+ If there is a *Hosts Allow* list but no *Hosts Deny* list, then only allow \
+ hosts on the *Hosts Allow* list. <br><br> \
+ If there is a *Hosts Deny* list but no *Hosts Allow* list, then allow all \
+ hosts that are not on the *Hosts Deny* list. <br><br> \
+ If there is both a *Hosts Allow* and *Hosts Deny* list, then allow all hosts \
+ that are on the *Hosts Allow* list. <br><br> \
+ If there is a host not on the *Hosts Allow* and not on the *Hosts Deny* list, \
+ then allow it.'),
 
     placeholder_hostsdeny: T('Hosts Deny'),
     tooltip_hostsdeny: T('Enter a list of denied hostnames or IP addresses.\
- Separate entries by pressing <code>Enter</code>.'),
+ Separate entries by pressing <code>Enter</code>. \
+ If neither *Hosts Allow* or *Hosts Deny* contains \
+ an entry, then AFP share access is allowed for any host. <br><br> \
+ If there is a *Hosts Allow* list but no *Hosts Deny* list, then only allow \
+ hosts on the *Hosts Allow* list. <br><br> \
+ If there is a *Hosts Deny* list but no *Hosts Allow* list, then allow all \
+ hosts that are not on the *Hosts Deny* list. <br><br> \
+ If there is both a *Hosts Allow* and *Hosts Deny* list, then allow all hosts \
+ that are on the *Hosts Allow* list. <br><br> \
+ If there is a host not on the *Hosts Allow* and not on the *Hosts Deny* list, \
+ then allow it.'),
 
     placeholder_shadowcopy: T('Enable Shadow Copies'),
     tooltip_shadowcopy: T('Export ZFS snapshots as\


### PR DESCRIPTION
Updated AFP and SMB hosts allow/deny helptext. Also, I removed some erroneous code for a placeholder no longer being used.