### PR TITLE
NAS-106230 / 12.0 / NAS-106230

### DIFF
--- a/src/app/pages/storage/volumes/volume-status/volume-status.component.css
+++ b/src/app/pages/storage/volumes/volume-status/volume-status.component.css
@@ -5,3 +5,10 @@
 .CellHighlight {
   color: red;
 }
+.time-remaining {
+  margin-left: 5px;
+}
+
+mat-list-item {
+  height: 24px !important;
+}

--- a/src/app/pages/storage/volumes/volume-status/volume-status.component.html
+++ b/src/app/pages/storage/volumes/volume-status/volume-status.component.html
@@ -10,10 +10,24 @@
   <div>
     <mat-list *ngIf="poolScan">
       <mat-list-item><b>{{poolScan.function || 'SCAN'}}</b></mat-list-item>
-      <mat-list-item>Status: {{poolScan.pause != null ? 'PAUSED' : poolScan.state ? poolScan.state : 'None requested'}}</mat-list-item>
-      <mat-list-item *ngIf="poolScan.total_secs_left != null">Time Remaining: {{poolScan.total_secs_left}} Seconds</mat-list-item>
-      <mat-list-item *ngIf="poolScan['errors'] != null">Errors: {{poolScan['errors']}}</mat-list-item>
-      <mat-list-item *ngIf="poolScan.start_time != null">Date: {{getReadableDate(poolScan.start_time)}}</mat-list-item>
+      <mat-list-item>{{'Status' | translate}}: 
+        {{poolScan.pause != null ? 'PAUSED' : poolScan.state ? poolScan.state : 'None requested' | translate}}
+      </mat-list-item>
+      <mat-list-item *ngIf="poolScan.state === 'SCANNING'">
+        {{ 'Completed' | translate }}: {{ poolScan.percentage | number:'2.0-2' }}%
+      </mat-list-item>
+      <mat-list-item *ngIf="poolScan.total_secs_left != null">{{ 'Time Remaining' | translate }}: 
+        <span class="time-remaining" *ngIf="timeRemaining.days > 0">
+          {{ timeRemaining.days }} {{ timeRemaining.days === 1 ? 'day' : 'days' | translate }}, </span>
+        <span class="time-remaining" *ngIf="timeRemaining.hours > 0 || timeRemaining.days > 0"> 
+          {{timeRemaining.hours}} {{ timeRemaining.hours === 1 ? 'hour' : 'hours' | translate }}, </span>
+        <span class="time-remaining" *ngIf="timeRemaining.minutes > 0 || timeRemaining.hours > 0"> 
+          {{timeRemaining.minutes}} {{ timeRemaining.minutes === 1 ? 'minute' : 'minutes' | translate }}, </span>
+        <span class="time-remaining" *ngIf="timeRemaining.seconds || timeRemaining.seconds === 0">
+          {{timeRemaining.seconds}} {{ timeRemaining.seconds === 1 ? 'second' :'seconds' | translate }}</span>
+      </mat-list-item>
+      <mat-list-item *ngIf="poolScan['errors'] != null">{{'Errors' | translate}}: {{poolScan['errors']}}</mat-list-item>
+      <mat-list-item *ngIf="poolScan.start_time != null">{{'Date' | translate}}: {{getReadableDate(poolScan.start_time)}}</mat-list-item>
     </mat-list>
   </div>
   <div class="padding-16">

--- a/src/app/pages/storage/volumes/volume-status/volume-status.component.ts
+++ b/src/app/pages/storage/volumes/volume-status/volume-status.component.ts
@@ -36,6 +36,7 @@ interface poolDiskInfo {
 export class VolumeStatusComponent implements OnInit {
 
   public poolScan: any;
+  public timeRemaining: any = {};
   public treeTableConfig: EntityTreeTable = {
     tableData: [],
     columns: [
@@ -142,6 +143,13 @@ export class VolumeStatusComponent implements OnInit {
       (res) => {
         if (res.fields && res.fields.name == poolName) {
           this.poolScan = res.fields.scan;
+          let seconds = this.poolScan.total_secs_left;
+          this.timeRemaining = {
+            days: Math.floor(seconds / (3600*24)),
+            hours: Math.floor(seconds % (3600*24) / 3600),
+            minutes: Math.floor(seconds % 3600 / 60),
+            seconds: Math.floor(seconds % 60)
+          }
         }
       }
     )


### PR DESCRIPTION
Show pool scrub in seconds, minutes, hours, and days with min, hr, day added only as needed; Distinguish between singular and plural; adjust some styling, fix some translations, also added percentage complete to status page

NOTE that zfs.pool.scan seems to be returning 0 seconds right now