### PR TITLE
NAS-106274 / 11.3 / NAS-106274 Allow user/group names to begin with a number

### DIFF
--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -6,7 +6,7 @@ import {WebSocketService} from './ws.service';
 
 @Injectable()
 export class UserService {
-  public static VALIDATOR_NAME = /^[a-zA-Z_][a-zA-Z0-9_\.-]*[$]?$/;
+  public static VALIDATOR_NAME = /^[a-zA-Z0-9_][a-zA-Z0-9_\.-]*[$]?$/;
 
   protected accountUserResource: string = 'account/users/';
   protected accountGroupResource: string = 'account/groups/';


### PR DESCRIPTION
Regex allows username to begin with number, letter or underscore(_); name can contain these plus period (.) and dash(-), and can use $ but only in the last position. Username must be 16 characters or less, and a warning about legacy systems is shown when length exceeds eight characters. Group names use the same regex without the length restrictions.