### PR TITLE
Update ja.po, README.md

### DIFF
--- a/src/assets/i18n/README.md
+++ b/src/assets/i18n/README.md
@@ -12,7 +12,7 @@ As you update a target language, please make changes to this file, indicating it
 |[French](fr.po "French")|Inomplete|12/18/2019|
 |[German](de.po "German")|Incomplete|02/10/2020|
 |[Italian](it.po "Italian")|Incomplete|02/18/2020|
-|[Japanese](jp.po "Japanese")|Incomplete|01/11/2020|
+|[Japanese](ja.po "Japanese")|Incomplete|07/01/2020|
 |[Polish](pl.po "Polish")|Incomplete|02/19/2020|
 |[Russian](ru.po "Russian")|Incomplete|05/17/2020|
 |[Spanish](es.po "Spanish")|Incomplete|04/25/2020|

--- a/src/assets/i18n/ja.po
+++ b/src/assets/i18n/ja.po
@@ -3136,6 +3136,7 @@ msgid ""
 "<i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to "
 "copy and     <i>Shift+Insert</i> to paste."
 msgstr ""
+"コンテキストメニューのコピーと貼り付け操作はシェルでは無効になっています。コピーと貼り付けのショートカットキーは、Macでは、 <i>Command+C</i> と <i>Command+V</i> を使用します。その他ほとんどのオペレーティングシステムでは、 <i>Ctrl+Insert</i> を使用してコピーし、 <i>Shift+Insert</i> で貼り付けます。"
 
 msgid "Continue"
 msgstr "続ける"
@@ -3176,7 +3177,7 @@ msgid "Copies"
 msgstr ""
 
 msgid "Copy and Paste"
-msgstr ""
+msgstr "コピーと貼り付け"
 
 msgid "Cores"
 msgstr ""


### PR DESCRIPTION
[ja.po]
Add a few translations
[README.md]
Update last update and fix typo (jp.po -> ja.po)

---

1. Is `jp.po` in [README.md](https://github.com/freenas/webui/tree/master/src/assets/i18n#readme) a typo for `ja.po` ? Please check if it's correct.

2. I'd like to work on translating the untranslated parts into Japanese, but I don't know how to incorporate and test (preview) those changes.

    I checked the [README.md in the repository](https://github.com/freenas/webui#readme).
    ```$ ./setup_env.js -i <ip address or FQDN of the server where FreeNAS is running>```
    I entered the IP address of a running FreeNAS and started it with `yarn start`.
    But the web server started with the default `http://localhost:4200` and I can't test (preview) it the way I intended.

To be honest, my English is not very good. Some of the text in this pull request is also with the help of translation tools.
Please let me know if there are any expressions that are difficult to understand in the above content.