### PR TITLE
change FreeNAS to TrueNAS on System Support Page

### DIFF
--- a/src/app/helptext/system/support.ts
+++ b/src/app/helptext/system/support.ts
@@ -178,7 +178,7 @@ export const helptext_system_support = {
   },
 
   FN_instructions: T('Search the <a href="https://jira.ixsystems.com/projects/NAS/issues/" \
-   target="_blank">FreeNAS issue tracker</a> \
+   target="_blank">TrueNAS issue tracker</a> \
    to ensure the issue has not already been reported before \
    filing a bug report or feature request. If an issue has \
    already been created, add a comment to the existing issue. \


### PR DESCRIPTION
Right now the UI still states
`Search the FreeNAS issue tracker to ensure the issue has not already been reported before filing a bug report or feature request.`

I changed that to say TrueNAS.