### PR TITLE
NAS-106888 / 12.0 / NAS-106888 Hid Bind when VNC is not available

### DIFF
--- a/src/app/pages/vm/vm-wizard/vm-wizard.component.ts
+++ b/src/app/pages/vm/vm-wizard/vm-wizard.component.ts
@@ -414,10 +414,12 @@ export class VMWizardComponent {
       if(bootloader === "UEFI_CSM"){
         _.find(this.wizardConfig[0].fieldConfig, {name : 'enable_vnc'})['isHidden'] = true;
         _.find(this.wizardConfig[0].fieldConfig, {name : 'wait'})['isHidden'] = true;
+        _.find(this.wizardConfig[0].fieldConfig, {name : 'vnc_bind'}).isHidden = true;
 
       } else {
         _.find(this.wizardConfig[0].fieldConfig, {name : 'enable_vnc'})['isHidden'] = false;
         _.find(this.wizardConfig[0].fieldConfig, {name : 'wait'})['isHidden'] = false;
+        _.find(this.wizardConfig[0].fieldConfig, {name : 'vnc_bind'}).isHidden = false;
 
       }
 


### PR DESCRIPTION
Hides bind on VM wizard when VNC option isn't applicable (12.0 - this is covered already in 12.1 +