### PR TITLE
NAS-106904 / 12.1 / NAS-106904 Update listing of boot options in VM edit form

### DIFF
--- a/src/app/pages/vm/vm-form/vm-form.component.ts
+++ b/src/app/pages/vm/vm-form/vm-form.component.ts
@@ -171,7 +171,7 @@ export class VmFormComponent {
     this.bootloader =_.find(this.fieldConfig, {name : 'bootloader'});
     this.vmService.getBootloaderOptions().subscribe(options => {
       for(const option in options) {
-        this.bootloader.options.push({label : option, value : options[option]})
+        this.bootloader.options.push({label : options[option], value : option})
       }
     });
 


### PR DESCRIPTION
Fixes list of bootloader options on VM edit form. The VNC button issue mentioned in the ticket was addressed in https://github.com/freenas/webui/pull/4427