### PR TITLE
NAS-106920 / 12.1 / Nas 106920

### DIFF
--- a/src/app/helptext/sharing/afp/afp.ts
+++ b/src/app/helptext/sharing/afp/afp.ts
@@ -172,8 +172,8 @@ export const helptext_sharing_afp = {
     message: T('Beginning in 2013, Apple began using the SMB sharing protocol as the default option \
    for file sharing and ceased development of the AFP sharing protocol. It is recommended to use \
    SMB sharing over AFP unless files will be shared with legacy Apple products.'),
-    button: T('Use AFP'),
-    custBtn: T('Go to SMB Form')
+    button: T('Continue to AFP Setup'),
+    custBtn: T('Create an SMB Share')
   },
 
   formTitle: T('AFP (Apple File Protocol)')

--- a/src/app/helptext/sharing/afp/afp.ts
+++ b/src/app/helptext/sharing/afp/afp.ts
@@ -172,7 +172,7 @@ export const helptext_sharing_afp = {
     message: T('Beginning in 2013, Apple began using the SMB sharing protocol as the default option \
    for file sharing and ceased development of the AFP sharing protocol. It is recommended to use \
    SMB sharing over AFP unless files will be shared with legacy Apple products.'),
-    button: T('Continue to AFP Setup'),
+    button: T('Continue with AFP Setup'),
     custBtn: T('Create an SMB Share')
   },
 

--- a/src/app/helptext/sharing/afp/afp.ts
+++ b/src/app/helptext/sharing/afp/afp.ts
@@ -167,5 +167,15 @@ export const helptext_sharing_afp = {
  by other option fields.'
   ),
 
+  smb_dialog: {
+    title: T('Recommendation'),
+    message: T('You have chosen to create an AFP Share. SMB is the recommended protocol for creating shares. Recent versions of MacOS \
+    and its <i>Time Machine®</i> backup work well with the SMB protocol.\
+    '),
+    button: T('Use AFP'),
+    custBtn: T('Go to SMB Form')
+  },
+
+  formTitle: T('AFP (Apple File Protocol)')
 
 };

--- a/src/app/helptext/sharing/afp/afp.ts
+++ b/src/app/helptext/sharing/afp/afp.ts
@@ -169,9 +169,9 @@ export const helptext_sharing_afp = {
 
   smb_dialog: {
     title: T('Recommendation'),
-    message: T('You have chosen to create an AFP Share. SMB is the recommended protocol for creating shares. Recent versions of MacOS \
-    and its <i>Time Machine®</i> backup work well with the SMB protocol.\
-    '),
+    message: T('Beginning in 2013, Apple began using the SMB sharing protocol as the default option \
+   for file sharing and ceased development of the AFP sharing protocol. It is recommended to use \
+   SMB sharing over AFP unless files will be shared with legacy Apple products.'),
     button: T('Use AFP'),
     custBtn: T('Go to SMB Form')
   },

--- a/src/app/helptext/sharing/smb/smb.ts
+++ b/src/app/helptext/sharing/smb/smb.ts
@@ -224,4 +224,6 @@ export const helptext_sharing_smb = {
  <i>Allowed</i> denies all permissions by default except those that are manually defined.\
  <i>Denied</i> allows all permissions by default except those that are manually defined.'),
 
+ formTitle: T('SMB')
+
 };

--- a/src/app/pages/common/entity/entity-dialog/dialog-form-configuration.interface.ts
+++ b/src/app/pages/common/entity/entity-dialog/dialog-form-configuration.interface.ts
@@ -17,4 +17,5 @@ export interface DialogFormConfiguration {
   afterInit?: any,
   parent?: any,
   confirmCheckbox?: boolean,
+  hideCancel?: boolean
 }

--- a/src/app/pages/common/entity/entity-dialog/entity-dialog.component.html
+++ b/src/app/pages/common/entity/entity-dialog/entity-dialog.component.html
@@ -29,9 +29,9 @@
   ix-auto-type="checkbox"
   ix-auto-identifier="CONFIRM">{{"Confirm" | translate}}</mat-checkbox>
   <span fxFlex></span>
-  <button mat-button class="mat-button mat-accent action-btn" (click)="cancel()" [name]="cancelButtonText + '_button'">{{cancelButtonText | translate}}</button>
+  <button mat-button *ngIf="!conf.hideCancel" class="mat-button mat-accent action-btn" (click)="cancel()" [name]="cancelButtonText + '_button'">{{cancelButtonText | translate}}</button>
   <span *ngFor="let custBtn of conf.custActions">
-    <button id="cust_button_{{custBtn.id}}" mat-button class="mat-button mat-primary action-btn"
+    <button id="cust_button_{{custBtn.id}}" mat-button class="mat-button action-btn"
       *ngIf="!conf.isCustActionVisible || conf.isCustActionVisible(custBtn.id)" type="button"
       [ix-auto]=""
       ix-auto-type="button"

--- a/src/app/pages/sharing/afp/afp-form/afp-form.component.ts
+++ b/src/app/pages/sharing/afp/afp-form/afp-form.component.ts
@@ -4,6 +4,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import globalHelptext from 'app/helptext/global-helptext';
 import { helptext_sharing_afp, shared } from 'app/helptext/sharing';
 import { FieldSets } from 'app/pages/common/entity/entity-form/classes/field-sets';
+import { FieldConfig } from 'app/pages/common/entity/entity-form/models/field-config.interface';
 import { EntityFormComponent } from 'app/pages/common/entity/entity-form/entity-form.component';
 import { forbiddenValues } from 'app/pages/common/entity/entity-form/validators/forbidden-values-validation';
 import { T } from "app/translate-marker";
@@ -31,7 +32,7 @@ export class AFPFormComponent implements OnDestroy {
   public afp_timemachine_subscription: any;
   public title = helptext_sharing_afp.formTitle;
   private namesInUse: string[] = [];
-
+  public fieldConfig: FieldConfig[] = []
   private fieldSets = new FieldSets([
     {
       name: 'recommendation',
@@ -41,7 +42,8 @@ export class AFPFormComponent implements OnDestroy {
         {
           name: 'recommendation',
           type: 'paragraph',
-          paraText: helptext_sharing_afp.smb_dialog.message
+          paraText: helptext_sharing_afp.smb_dialog.message,
+          isHidden: true
         }
       ]
     },
@@ -373,6 +375,7 @@ export class AFPFormComponent implements OnDestroy {
   afterInit(entityForm: any) {
     if (!this.pk) {
       this.openInfoDialog();
+      _.find(this.fieldConfig, {name: 'recommendation'}).isHidden = false;
     }
     this.entityForm = entityForm;
     if (entityForm.isNew) {

--- a/src/app/pages/sharing/afp/afp-form/afp-form.component.ts
+++ b/src/app/pages/sharing/afp/afp-form/afp-form.component.ts
@@ -11,6 +11,7 @@ import * as _ from 'lodash';
 import { combineLatest } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { DialogService, WebSocketService } from '../../../../services/';
+import { DialogFormConfiguration } from 'app/pages/common/entity/entity-dialog/dialog-form-configuration.interface';
 
 @Component({
   selector : 'app-afp-form',
@@ -28,9 +29,22 @@ export class AFPFormComponent implements OnDestroy {
   public afp_timemachine: any;
   public afp_timemachine_quota: any;
   public afp_timemachine_subscription: any;
+  public title = helptext_sharing_afp.formTitle;
   private namesInUse: string[] = [];
 
   private fieldSets = new FieldSets([
+    {
+      name: 'recommendation',
+      class: 'recommendation',
+      label: false,
+      config: [
+        {
+          name: 'recommendation',
+          type: 'paragraph',
+          paraText: helptext_sharing_afp.smb_dialog.message
+        }
+      ]
+    },
     {
       name: helptext_sharing_afp.fieldset_general,
       class: 'general',
@@ -357,6 +371,9 @@ export class AFPFormComponent implements OnDestroy {
   }
 
   afterInit(entityForm: any) {
+    if (!this.pk) {
+      this.openInfoDialog();
+    }
     this.entityForm = entityForm;
     if (entityForm.isNew) {
       entityForm.formGroup.controls['upriv'].setValue(true);
@@ -457,5 +474,21 @@ export class AFPFormComponent implements OnDestroy {
     if (pathControl.value && !nameControl.value) {
       nameControl.setValue(pathControl.value.split('/').pop());
     }
+  }
+
+  openInfoDialog() {
+    const conf: DialogFormConfiguration = {
+      title: helptext_sharing_afp.smb_dialog.title,
+      message: helptext_sharing_afp.smb_dialog.message,
+      fieldConfig: [],
+      saveButtonText: helptext_sharing_afp.smb_dialog.custBtn,
+      cancelButtonText: helptext_sharing_afp.smb_dialog.button,
+      parent: this,
+      customSubmit: (entityDialog) => {
+        entityDialog.dialogRef.close();
+        this.router.navigate(['sharing', 'smb', 'add']);
+      }
+    }
+    this.dialog.dialogFormWide(conf);
   }
 }

--- a/src/app/pages/sharing/afp/afp-form/afp-form.component.ts
+++ b/src/app/pages/sharing/afp/afp-form/afp-form.component.ts
@@ -470,6 +470,16 @@ export class AFPFormComponent implements OnDestroy {
       fieldConfig: [],
       saveButtonText: helptext_sharing_afp.smb_dialog.custBtn,
       cancelButtonText: helptext_sharing_afp.smb_dialog.button,
+      hideCancel: true,
+      custActions: [
+        {
+          name: helptext_sharing_afp.smb_dialog.button,
+          id: 'continue_with_afp',
+          function: () => {
+            this.dialog.closeAllDialogs();
+          }
+        }
+      ],
       parent: this,
       customSubmit: (entityDialog) => {
         entityDialog.dialogRef.close();

--- a/src/app/pages/sharing/afp/afp-form/afp-form.component.ts
+++ b/src/app/pages/sharing/afp/afp-form/afp-form.component.ts
@@ -4,7 +4,6 @@ import { ActivatedRoute, Router } from '@angular/router';
 import globalHelptext from 'app/helptext/global-helptext';
 import { helptext_sharing_afp, shared } from 'app/helptext/sharing';
 import { FieldSets } from 'app/pages/common/entity/entity-form/classes/field-sets';
-import { FieldConfig } from 'app/pages/common/entity/entity-form/models/field-config.interface';
 import { EntityFormComponent } from 'app/pages/common/entity/entity-form/entity-form.component';
 import { forbiddenValues } from 'app/pages/common/entity/entity-form/validators/forbidden-values-validation';
 import { T } from "app/translate-marker";
@@ -32,21 +31,7 @@ export class AFPFormComponent implements OnDestroy {
   public afp_timemachine_subscription: any;
   public title = helptext_sharing_afp.formTitle;
   private namesInUse: string[] = [];
-  public fieldConfig: FieldConfig[] = []
   private fieldSets = new FieldSets([
-    {
-      name: 'recommendation',
-      class: 'recommendation',
-      label: false,
-      config: [
-        {
-          name: 'recommendation',
-          type: 'paragraph',
-          paraText: helptext_sharing_afp.smb_dialog.message,
-          isHidden: true
-        }
-      ]
-    },
     {
       name: helptext_sharing_afp.fieldset_general,
       class: 'general',
@@ -375,7 +360,6 @@ export class AFPFormComponent implements OnDestroy {
   afterInit(entityForm: any) {
     if (!this.pk) {
       this.openInfoDialog();
-      _.find(this.fieldConfig, {name: 'recommendation'}).isHidden = false;
     }
     this.entityForm = entityForm;
     if (entityForm.isNew) {

--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
@@ -27,6 +27,7 @@ export class SMBFormComponent {
   protected isEntity: boolean = true;
   protected isBasicMode: boolean = true;
   public isTimeMachineOn = false;
+  public title = helptext_sharing_smb.formTitle;
   public namesInUse: string[] = [];
   public productType = window.localStorage.getItem('product_type');
   private hostsAllowOnLoad = [];

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -1752,4 +1752,9 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     color: var(--red) !important;
   }
 
+  app-afp-form #recommendation {
+    font-size: larger;
+    margin-bottom: 1.2rem;
+  }
+
  } // end of ix theme

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -1751,11 +1751,6 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
   .entity-table-cell-error {
     color: var(--red) !important;
   }
-
-  app-afp-form #recommendation {
-    font-size: larger;
-    margin-bottom: 1.2rem;
-  }
   
   mat-hint {
     color: var(--yellow) !important;

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -1757,4 +1757,8 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     font-size: 0.7rem;
   }
 
+  #cust_button_continue_with_afp {
+    background: var(--bg1);
+  }
+
  } // end of ix theme


### PR DESCRIPTION
Displays BOTH a dialog AND paragraph warning when user wants to create a NEW AFP share (but not when editing an existing one). We probably want one or the other - need guidance on which; dialog offers an easy way (via a button) to redirect to the SMB share creation form. Also need guidance on the message

![Screenshot from 2020-07-28 18-41-53](https://user-images.githubusercontent.com/9504493/88801660-fcc05d00-d177-11ea-8d04-a9b81cb46698.png)
