### PR TITLE
Nas 106868

### DIFF
--- a/src/app/helptext/storage/volumes/datasets/dataset-acl.ts
+++ b/src/app/helptext/storage/volumes/datasets/dataset-acl.ts
@@ -202,5 +202,7 @@ posix_tag: {
 posix_default: {
   placeholder: T('Default'),
   tooltip: T('Default')
-}
+},
+
+permissions_editor_button: T('Use Permissions Editor')
 }

--- a/src/app/helptext/storage/volumes/datasets/dataset-permissions.ts
+++ b/src/app/helptext/storage/volumes/datasets/dataset-permissions.ts
@@ -47,5 +47,7 @@ dataset_permissions_dialog_warning_message: T('Changing dataset permission mode 
 heading_dataset_path: T('Dataset Path'),
 heading_owner: T('Owner'),
 heading_access: T('Access'),
-heading_advanced: T('Advanced')
+heading_advanced: T('Advanced'),
+
+acl_manager_button: T('Use ACL Manager')
 }

--- a/src/app/pages/storage/volumes/datasets/dataset-acl/dataset-acl.component.ts
+++ b/src/app/pages/storage/volumes/datasets/dataset-acl/dataset-acl.component.ts
@@ -359,6 +359,7 @@ export class DatasetAclComponent implements OnDestroy {
     this.entityForm = entityEdit;
     this.recursive = entityEdit.formGroup.controls['recursive'];
     this.recursive_subscription = this.recursive.valueChanges.subscribe((value) => {
+      // This is here because valueChanges gets triggered when state is changed to disabled
       if (value === true && value !== this.recursivePreviousValue) {
         this.dialogService.confirm(helptext.dataset_acl_recursive_dialog_warning,
          helptext.dataset_acl_recursive_dialog_warning_message)
@@ -383,6 +384,8 @@ export class DatasetAclComponent implements OnDestroy {
     this.stripacl = entityEdit.formGroup.controls['stripacl'];
     this.stripacl_subscription = this.stripacl.valueChanges.subscribe((value) => {
       if (value === true) {
+        // Store this value here because it changes on response to dialog
+        const isRecursiveChecked = entityEdit.formGroup.controls['recursive'].value;
         this.dialogService.confirm(helptext.dataset_acl_stripacl_dialog_warning,
          helptext.dataset_acl_stripacl_dialog_warning_message)
         .subscribe((res) => {
@@ -390,9 +393,15 @@ export class DatasetAclComponent implements OnDestroy {
             this.stripacl.setValue(false);
           }
           else {
-          this.entityForm.formGroup.controls['recursive'].setValue(true);
-          this.disableRecursive = true;
-          if (entityEdit.formGroup.controls['recursive'].value = true) {}      
+            // If user already checked recursive, just disable it
+            if (isRecursiveChecked) {
+              this.entityForm.setDisabled('recursive', true);    
+            } else {
+              // Otherwise set recursive to true
+              this.entityForm.formGroup.controls['recursive'].setValue(true);
+              // ...and set this boolean to disable recursive after its value changes
+              this.disableRecursive = true;
+            } 
           }
         });
       } else {

--- a/src/app/pages/storage/volumes/datasets/dataset-permissions/dataset-permissions.component.ts
+++ b/src/app/pages/storage/volumes/datasets/dataset-permissions/dataset-permissions.component.ts
@@ -133,6 +133,29 @@ export class DatasetPermissionsComponent implements OnDestroy {
       divider: true
     }
   ];
+
+  public custActions: Array<any> = [
+    {
+      id : 'use_acl',
+      name : helptext.acl_manager_button,
+      function : () => {
+        this.ws.call('filesystem.getacl', [this.datasetPath]).subscribe(res => {
+          if(res.acltype === 'POSIX1E') {
+            this.router.navigate(new Array('/').concat([
+              "storage", "pools", "id", this.datasetId.split('/')[0], "dataset",
+              "posix-acl", this.datasetId
+            ]));                    
+          } else {
+            this.router.navigate(new Array('/').concat([
+              "storage", "pools", "id", this.datasetId.split('/')[0], "dataset",
+              "acl", this.datasetId
+            ]));
+          }
+        })
+      }
+    }
+  ];
+
   protected datasetMode: any;
 
   constructor(

--- a/src/app/pages/storage/volumes/datasets/dataset-posix-acl/dataset-posix-acl.component.ts
+++ b/src/app/pages/storage/volumes/datasets/dataset-posix-acl/dataset-posix-acl.component.ts
@@ -33,6 +33,10 @@ export class DatasetPosixAclComponent implements OnDestroy {
   protected isEntity = true;
   protected pk: string;
   protected path: string;
+  protected datasetId: string;
+  private aclIsTrivial = false;
+  private disableRecursive = false;
+  private recursivePreviousValue: boolean;
   protected userOptions: any[];
   protected groupOptions: any[];
   protected userSearchOptions: [];
@@ -226,14 +230,34 @@ export class DatasetPosixAclComponent implements OnDestroy {
     },
   ];
 
+  public custActions: Array<any> = [
+    {
+      id : 'use_acl',
+      name : helptext.permissions_editor_button,
+      function : () => {
+        this.router.navigate(new Array('/').concat([
+          "storage", "pools", "permissions", this.datasetId
+        ]));
+      }
+    }
+  ];
+
   constructor(protected router: Router, protected route: ActivatedRoute,
               protected aroute: ActivatedRoute, 
               protected ws: WebSocketService, protected userService: UserService,
               protected storageService: StorageService, protected dialogService: DialogService,
               protected loader: AppLoaderService, protected dialog: MatDialog) {}
 
+  isCustActionVisible(actionId: string) {
+    if (actionId === 'use_acl' && this.aclIsTrivial === true) {
+      return true;
+    }
+    return false;
+  }
+  
   preInit(entityEdit: any) {
     this.sub = this.aroute.params.subscribe(params => {
+      this.datasetId = params['path'];
       this.path = '/mnt/' + params['path'];
       const path_fc = _.find(this.fieldSets[0].config, {name:'path'});
       path_fc.value = this.path;
@@ -265,31 +289,55 @@ export class DatasetPosixAclComponent implements OnDestroy {
     this.entityForm = entityEdit;
     this.recursive = entityEdit.formGroup.controls['recursive'];
     this.recursive_subscription = this.recursive.valueChanges.subscribe((value) => {
-      if (value === true) {
+      // This is here because valueChanges gets triggered when state is changed to disabled
+      if (value === true && value !== this.recursivePreviousValue) {
         this.dialogService.confirm(helptext.dataset_acl_recursive_dialog_warning,
          helptext.dataset_acl_recursive_dialog_warning_message)
         .subscribe((res) => {
           if (!res) {
             this.recursive.setValue(false);
+            this.recursivePreviousValue = false;
+          } else {
+            this.recursivePreviousValue = true;
           }
+          this.entityForm.setDisabled('recursive', this.disableRecursive);    
         });
       }
     });
     this.ws.call('filesystem.acl_is_trivial', [this.path]).subscribe(acl_is_trivial => {
       this.entityForm.setDisabled('stripacl', acl_is_trivial);
+      this.aclIsTrivial = acl_is_trivial;
     }, (err) => {
       new EntityUtils().handleWSError(this.entityForm, err);
     });
     this.stripacl = entityEdit.formGroup.controls['stripacl'];
     this.stripacl_subscription = this.stripacl.valueChanges.subscribe((value) => {
       if (value === true) {
+        // Store this value here because it changes on response to dialog
+        const isRecursiveChecked = entityEdit.formGroup.controls['recursive'].value;
         this.dialogService.confirm(helptext.dataset_acl_stripacl_dialog_warning,
          helptext.dataset_acl_stripacl_dialog_warning_message)
         .subscribe((res) => {
           if (!res) {
             this.stripacl.setValue(false);
           }
+          else {
+            // If user already checked recursive, just disable it
+            if (isRecursiveChecked) {
+              this.entityForm.setDisabled('recursive', true);    
+            } else {
+              // Otherwise set recursive to true
+              this.entityForm.formGroup.controls['recursive'].setValue(true);
+              // ...and set this boolean to disable recursive after its value changes
+              this.disableRecursive = true;
+            } 
+          }
         });
+      } else {
+        this.entityForm.formGroup.controls['recursive'].setValue(false);
+        this.disableRecursive = false;
+        this.entityForm.setDisabled('recursive', this.disableRecursive);   
+        this.recursivePreviousValue = false; 
       }
     });
     this.aces_fc = _.find(this.fieldConfig, {"name": "aces"});


### PR DESCRIPTION
Uses only one menu item, 'Edit Permissions' which takes the user to Permissions editor if ACL is trivial, and to the ACL editor if not. Adds a button for switching from Permissions Editor to ACL and (if ACL is trivial) back again. When Strip ACL is selected, forces Recursive to be selected and disabled.