### PR TITLE
NAS-106868 / 12.1 / Nas 106868 

### DIFF
--- a/src/app/helptext/storage/volumes/datasets/dataset-acl.ts
+++ b/src/app/helptext/storage/volumes/datasets/dataset-acl.ts
@@ -152,6 +152,18 @@ dataset_acl_stripacl_tooltip: T("Set to remove all ACLs from the current\
  dataset. ACLs are also recursively stripped from directories and child\
  datasets when those options are set."),
 
+stripACL_dialog: {
+  title: T('Strip ACLs'),
+  message: T('This action removes all ACLs from the current \
+ dataset. ACLs are also recursively stripped from directories and files of the current dataset. \
+ Stripping the ACL resets dataset permissions. This can make data inaccessible until new \
+ permissions are created.'),
+  traverse_checkbox: T('Also strip permissions from child datasets of the current dataset'),
+  warning: T('Removes permissions recursively from all child \
+  datasets of the current dataset. This can make data inaccessible untin new permissions are created.')
+
+},
+
 dataset_acl_stripacl_dialog_warning: T('Warning'),
 dataset_acl_stripacl_dialog_warning_message: T('Stripping the ACL resets\
  dataset permissions. This can make data inaccessible until new\

--- a/src/app/helptext/storage/volumes/datasets/dataset-acl.ts
+++ b/src/app/helptext/storage/volumes/datasets/dataset-acl.ts
@@ -155,12 +155,12 @@ dataset_acl_stripacl_tooltip: T("Set to remove all ACLs from the current\
 stripACL_dialog: {
   title: T('Strip ACLs'),
   message: T('This action removes all ACLs from the current \
- dataset. ACLs are also recursively stripped from directories and files of the current dataset. \
- Stripping the ACL resets dataset permissions. This can make data inaccessible until new \
- permissions are created.'),
-  traverse_checkbox: T('Also strip permissions from child datasets of the current dataset'),
-  warning: T('Removes permissions recursively from all child \
-  datasets of the current dataset. This can make data inaccessible untin new permissions are created.')
+ dataset and any directories or files contained within this \
+ dataset. Stripping the ACL resets dataset permissions. This \
+ can make data inaccessible until new permissions are created.'),
+  traverse_checkbox: T('Remove the ACL and permissions from child datasets of the current dataset'),
+  warning: T('Removes the ACL and permissions recursively \
+ from all child datasets of the current dataset, including all directories and files contained within those child datasets. This can make data inaccessible until new permissions are created.')
 
 },
 

--- a/src/app/helptext/storage/volumes/datasets/dataset-acl.ts
+++ b/src/app/helptext/storage/volumes/datasets/dataset-acl.ts
@@ -202,5 +202,7 @@ posix_tag: {
 posix_default: {
   placeholder: T('Default'),
   tooltip: T('Default')
-}
+},
+
+permissions_editor_button: T('Use Permissions Editor')
 }

--- a/src/app/helptext/storage/volumes/datasets/dataset-permissions.ts
+++ b/src/app/helptext/storage/volumes/datasets/dataset-permissions.ts
@@ -47,5 +47,7 @@ dataset_permissions_dialog_warning_message: T('Changing dataset permission mode 
 heading_dataset_path: T('Dataset Path'),
 heading_owner: T('Owner'),
 heading_access: T('Access'),
-heading_advanced: T('Advanced')
+heading_advanced: T('Advanced'),
+
+acl_manager_button: T('Use ACL Manager')
 }

--- a/src/app/pages/storage/volumes/datasets/dataset-acl/dataset-acl.component.ts
+++ b/src/app/pages/storage/volumes/datasets/dataset-acl/dataset-acl.component.ts
@@ -359,6 +359,7 @@ export class DatasetAclComponent implements OnDestroy {
     this.entityForm = entityEdit;
     this.recursive = entityEdit.formGroup.controls['recursive'];
     this.recursive_subscription = this.recursive.valueChanges.subscribe((value) => {
+      // This is here because valueChanges gets triggered when state is changed to disabled
       if (value === true && value !== this.recursivePreviousValue) {
         this.dialogService.confirm(helptext.dataset_acl_recursive_dialog_warning,
          helptext.dataset_acl_recursive_dialog_warning_message)
@@ -383,6 +384,8 @@ export class DatasetAclComponent implements OnDestroy {
     this.stripacl = entityEdit.formGroup.controls['stripacl'];
     this.stripacl_subscription = this.stripacl.valueChanges.subscribe((value) => {
       if (value === true) {
+        // Store this value here because it changes on response to dialog
+        const isRecursiveChecked = entityEdit.formGroup.controls['recursive'].value;
         this.dialogService.confirm(helptext.dataset_acl_stripacl_dialog_warning,
          helptext.dataset_acl_stripacl_dialog_warning_message)
         .subscribe((res) => {
@@ -390,9 +393,15 @@ export class DatasetAclComponent implements OnDestroy {
             this.stripacl.setValue(false);
           }
           else {
-          this.entityForm.formGroup.controls['recursive'].setValue(true);
-          this.disableRecursive = true;
-          if (entityEdit.formGroup.controls['recursive'].value = true) {}      
+            // If user already checked recursive, just disable it
+            if (isRecursiveChecked) {
+              this.entityForm.setDisabled('recursive', true);    
+            } else {
+              // Otherwise set recursive to true
+              this.entityForm.formGroup.controls['recursive'].setValue(true);
+              // ...and set this boolean to disable recursive after its value changes
+              this.disableRecursive = true;
+            } 
           }
         });
       } else {

--- a/src/app/pages/storage/volumes/datasets/dataset-acl/dataset-acl.component.ts
+++ b/src/app/pages/storage/volumes/datasets/dataset-acl/dataset-acl.component.ts
@@ -43,8 +43,6 @@ export class DatasetAclComponent implements OnDestroy {
   protected defaults: any;
   protected recursive: any;
   protected recursive_subscription: any;
-  protected stripacl: any;
-  protected stripacl_subscription: any;
   private aces: any;
   private aces_fc: any;
   private aces_subscription: any;
@@ -370,7 +368,6 @@ export class DatasetAclComponent implements OnDestroy {
     });
 
     this.ws.call('filesystem.acl_is_trivial', [this.path]).subscribe(acl_is_trivial => {
-      this.entityForm.setDisabled('stripacl', acl_is_trivial);
       this.aclIsTrivial = acl_is_trivial;
     }, (err) => {
       new EntityUtils().handleWSError(this.entityForm, err);
@@ -667,9 +664,7 @@ export class DatasetAclComponent implements OnDestroy {
     this.dialogRef = this.dialog.open(EntityJobComponent, { data: { "title": T("Saving ACLs") }});
     this.dialogRef.componentInstance.setDescription(T("Saving ACLs..."));
     let dacl = body.dacl;
-    if (body.stripacl) {
-      dacl = [];
-    }
+
     await this.userService.getUserByName(body.uid).toPromise().then(userObj => {
       if (userObj && userObj.hasOwnProperty('pw_uid')) {
         body.uid = userObj.pw_uid;
@@ -710,8 +705,7 @@ export class DatasetAclComponent implements OnDestroy {
       [{'path': body.path, 'dacl': dacl,
         'uid': body.uid, 'gid': body.gid,
         'options' : {'recursive': body.recursive,
-        'traverse': body.traverse,
-        'stripacl': body.stripacl
+        'traverse': body.traverse
         }
       }]);
     this.dialogRef.componentInstance.submit();

--- a/src/app/pages/storage/volumes/datasets/dataset-permissions/dataset-permissions.component.ts
+++ b/src/app/pages/storage/volumes/datasets/dataset-permissions/dataset-permissions.component.ts
@@ -133,6 +133,29 @@ export class DatasetPermissionsComponent implements OnDestroy {
       divider: true
     }
   ];
+
+  public custActions: Array<any> = [
+    {
+      id : 'use_acl',
+      name : helptext.acl_manager_button,
+      function : () => {
+        this.ws.call('filesystem.getacl', [this.datasetPath]).subscribe(res => {
+          if(res.acltype === 'POSIX1E') {
+            this.router.navigate(new Array('/').concat([
+              "storage", "pools", "id", this.datasetId.split('/')[0], "dataset",
+              "posix-acl", this.datasetId
+            ]));                    
+          } else {
+            this.router.navigate(new Array('/').concat([
+              "storage", "pools", "id", this.datasetId.split('/')[0], "dataset",
+              "acl", this.datasetId
+            ]));
+          }
+        })
+      }
+    }
+  ];
+
   protected datasetMode: any;
 
   constructor(

--- a/src/app/pages/storage/volumes/datasets/dataset-permissions/dataset-permissions.component.ts
+++ b/src/app/pages/storage/volumes/datasets/dataset-permissions/dataset-permissions.component.ts
@@ -29,6 +29,7 @@ export class DatasetPermissionsComponent implements OnDestroy {
   private entityForm: any;
   protected userField: any;
   protected groupField: any;
+  productType = window.localStorage.getItem('product_type');
 
   public fieldSets: FieldSet[] = [
     {
@@ -166,6 +167,11 @@ export class DatasetPermissionsComponent implements OnDestroy {
     protected mdDialog: MatDialog,
     protected dialog: DialogService,
     protected router: Router) { }
+
+  // Temporarily hide ACL manager in SCALE
+  isCustActionVisible(actionId: string) {
+    return this.productType.includes('SCALE') ? false : true; 
+  }
 
   preInit(entityEdit: any) {
     entityEdit.isNew = true; // remove me when we find a way to get the permissions

--- a/src/app/pages/storage/volumes/datasets/dataset-posix-acl/dataset-posix-acl.component.ts
+++ b/src/app/pages/storage/volumes/datasets/dataset-posix-acl/dataset-posix-acl.component.ts
@@ -21,6 +21,7 @@ import helptext from '../../../../../helptext/storage/volumes/datasets/dataset-a
 import { MatDialog } from '@angular/material/dialog';
 import { EntityJobComponent } from '../../../../common/entity/entity-job/entity-job.component';
 import {EntityUtils} from '../../../../common/entity/utils';
+import { DialogFormConfiguration } from 'app/pages/common/entity/entity-dialog/dialog-form-configuration.interface';
 
 @Component({
   selector: 'app-dataset-posix-acl',
@@ -35,8 +36,6 @@ export class DatasetPosixAclComponent implements OnDestroy {
   protected path: string;
   protected datasetId: string;
   private aclIsTrivial = false;
-  private disableRecursive = false;
-  private recursivePreviousValue: boolean;
   protected userOptions: any[];
   protected groupOptions: any[];
   protected userSearchOptions: [];
@@ -44,8 +43,6 @@ export class DatasetPosixAclComponent implements OnDestroy {
   protected defaults: any;
   protected recursive: any;
   protected recursive_subscription: any;
-  protected stripacl: any;
-  protected stripacl_subscription: any;
   private aces: any;
   private aces_fc: any;
   private aces_subscription: any;
@@ -214,13 +211,6 @@ export class DatasetPosixAclComponent implements OnDestroy {
               value: false,
             }]
           }],
-        },
-        {
-          type: 'checkbox',
-          name: 'stripacl',
-          placeholder: helptext.dataset_acl_stripacl_placeholder,
-          tooltip: helptext.dataset_acl_stripacl_tooltip,
-          value: false,
         }
       ]
     },
@@ -232,12 +222,19 @@ export class DatasetPosixAclComponent implements OnDestroy {
 
   public custActions: Array<any> = [
     {
-      id : 'use_acl',
+      id : 'use_perm_editor',
       name : helptext.permissions_editor_button,
       function : () => {
         this.router.navigate(new Array('/').concat([
           "storage", "pools", "permissions", this.datasetId
         ]));
+      }
+    },
+    {
+      id : 'strip_acl',
+      name : helptext.dataset_acl_stripacl_placeholder,
+      function : () => {
+        this.doStripACL();
       }
     }
   ];
@@ -249,12 +246,13 @@ export class DatasetPosixAclComponent implements OnDestroy {
               protected loader: AppLoaderService, protected dialog: MatDialog) {}
 
   isCustActionVisible(actionId: string) {
-    if (actionId === 'use_acl' && this.aclIsTrivial === true) {
-      return true;
+    if (this.aclIsTrivial) {
+      return actionId === 'use_perm_editor' ? true : false;
+    } else {
+      return actionId === 'strip_acl' ? true : false;
     }
-    return false;
   }
-  
+
   preInit(entityEdit: any) {
     this.sub = this.aroute.params.subscribe(params => {
       this.datasetId = params['path'];
@@ -289,57 +287,22 @@ export class DatasetPosixAclComponent implements OnDestroy {
     this.entityForm = entityEdit;
     this.recursive = entityEdit.formGroup.controls['recursive'];
     this.recursive_subscription = this.recursive.valueChanges.subscribe((value) => {
-      // This is here because valueChanges gets triggered when state is changed to disabled
-      if (value === true && value !== this.recursivePreviousValue) {
+      if (value === true) {
         this.dialogService.confirm(helptext.dataset_acl_recursive_dialog_warning,
          helptext.dataset_acl_recursive_dialog_warning_message)
         .subscribe((res) => {
           if (!res) {
             this.recursive.setValue(false);
-            this.recursivePreviousValue = false;
-          } else {
-            this.recursivePreviousValue = true;
-          }
-          this.entityForm.setDisabled('recursive', this.disableRecursive);    
+          }   
         });
       }
     });
     this.ws.call('filesystem.acl_is_trivial', [this.path]).subscribe(acl_is_trivial => {
-      this.entityForm.setDisabled('stripacl', acl_is_trivial);
       this.aclIsTrivial = acl_is_trivial;
     }, (err) => {
       new EntityUtils().handleWSError(this.entityForm, err);
     });
-    this.stripacl = entityEdit.formGroup.controls['stripacl'];
-    this.stripacl_subscription = this.stripacl.valueChanges.subscribe((value) => {
-      if (value === true) {
-        // Store this value here because it changes on response to dialog
-        const isRecursiveChecked = entityEdit.formGroup.controls['recursive'].value;
-        this.dialogService.confirm(helptext.dataset_acl_stripacl_dialog_warning,
-         helptext.dataset_acl_stripacl_dialog_warning_message)
-        .subscribe((res) => {
-          if (!res) {
-            this.stripacl.setValue(false);
-          }
-          else {
-            // If user already checked recursive, just disable it
-            if (isRecursiveChecked) {
-              this.entityForm.setDisabled('recursive', true);    
-            } else {
-              // Otherwise set recursive to true
-              this.entityForm.formGroup.controls['recursive'].setValue(true);
-              // ...and set this boolean to disable recursive after its value changes
-              this.disableRecursive = true;
-            } 
-          }
-        });
-      } else {
-        this.entityForm.formGroup.controls['recursive'].setValue(false);
-        this.disableRecursive = false;
-        this.entityForm.setDisabled('recursive', this.disableRecursive);   
-        this.recursivePreviousValue = false; 
-      }
-    });
+
     this.aces_fc = _.find(this.fieldConfig, {"name": "aces"});
     this.aces = this.entityForm.formGroup.controls['aces'];
     this.aces_subscription = this.aces.valueChanges.subscribe(res => {
@@ -498,7 +461,6 @@ export class DatasetPosixAclComponent implements OnDestroy {
   ngOnDestroy() {
     this.recursive_subscription.unsubscribe();
     this.aces_subscription.unsubscribe();
-    this.stripacl_subscription.unsubscribe();
   }
 
   beforeSubmit(data) {
@@ -546,9 +508,7 @@ export class DatasetPosixAclComponent implements OnDestroy {
     this.dialogRef = this.dialog.open(EntityJobComponent, { data: { "title": T("Saving ACLs") }});
     this.dialogRef.componentInstance.setDescription(T("Saving ACLs..."));
     let dacl = body.dacl;
-    if (body.stripacl) {
-      dacl = [];
-    }
+
     await this.userService.getUserByName(body.uid).toPromise().then(userObj => {
       if (userObj && userObj.hasOwnProperty('pw_uid')) {
         body.uid = userObj.pw_uid;
@@ -591,8 +551,7 @@ export class DatasetPosixAclComponent implements OnDestroy {
         'uid': body.uid, 'gid': body.gid,
         'acltype' : 'POSIX1E',
         'options' : {'recursive': body.recursive,
-        'traverse': body.traverse,
-        'stripacl': body.stripacl
+        'traverse': body.traverse
         }
       }]);
     this.dialogRef.componentInstance.submit();
@@ -624,6 +583,48 @@ export class DatasetPosixAclComponent implements OnDestroy {
       }
       config.searchOptions = users;
     });
+  }
+
+  doStripACL() {
+    const conf: DialogFormConfiguration = {
+      title: helptext.stripACL_dialog.title,
+      message: helptext.stripACL_dialog.message,
+      fieldConfig: [
+        {
+          type: 'checkbox',
+          name: 'traverse',
+          placeholder: helptext.stripACL_dialog.traverse_checkbox
+        }
+      ],
+      // warning:helptext.stripACL_dialog.warning,
+      saveButtonText: helptext.dataset_acl_stripacl_placeholder,
+      parent: this,
+      customSubmit: (entityDialog) => {
+        entityDialog.dialogRef.close();
+
+        this.dialogRef = this.dialog.open(EntityJobComponent, { data: { "title": T("Stripping ACLs") }});
+        this.dialogRef.componentInstance.setDescription(T("Stripping ACLs..."));
+
+        this.dialogRef.componentInstance.setCall(this.updateCall,
+          [{'path': this.path, 'dacl': [],
+            'options' : {'recursive': true,
+            'traverse': entityDialog.formValue.traverse ? true : false,
+            'stripacl': true
+            }
+          }]);
+        this.dialogRef.componentInstance.submit();
+        this.dialogRef.componentInstance.success.subscribe((res) => {
+          this.entityForm.success = true;
+          this.dialogRef.close();
+          this.router.navigate(new Array('/').concat(
+            this.route_success));
+        });
+        this.dialogRef.componentInstance.failure.subscribe((err) => {
+          new EntityUtils().handleWSError(this.entityForm, err);
+        });
+      }
+    }
+    this.dialogService.dialogFormWide(conf);
   }
 }
 

--- a/src/app/pages/storage/volumes/datasets/dataset-posix-acl/dataset-posix-acl.component.ts
+++ b/src/app/pages/storage/volumes/datasets/dataset-posix-acl/dataset-posix-acl.component.ts
@@ -33,6 +33,10 @@ export class DatasetPosixAclComponent implements OnDestroy {
   protected isEntity = true;
   protected pk: string;
   protected path: string;
+  protected datasetId: string;
+  private aclIsTrivial = false;
+  private disableRecursive = false;
+  private recursivePreviousValue: boolean;
   protected userOptions: any[];
   protected groupOptions: any[];
   protected userSearchOptions: [];
@@ -226,14 +230,34 @@ export class DatasetPosixAclComponent implements OnDestroy {
     },
   ];
 
+  public custActions: Array<any> = [
+    {
+      id : 'use_acl',
+      name : helptext.permissions_editor_button,
+      function : () => {
+        this.router.navigate(new Array('/').concat([
+          "storage", "pools", "permissions", this.datasetId
+        ]));
+      }
+    }
+  ];
+
   constructor(protected router: Router, protected route: ActivatedRoute,
               protected aroute: ActivatedRoute, 
               protected ws: WebSocketService, protected userService: UserService,
               protected storageService: StorageService, protected dialogService: DialogService,
               protected loader: AppLoaderService, protected dialog: MatDialog) {}
 
+  isCustActionVisible(actionId: string) {
+    if (actionId === 'use_acl' && this.aclIsTrivial === true) {
+      return true;
+    }
+    return false;
+  }
+  
   preInit(entityEdit: any) {
     this.sub = this.aroute.params.subscribe(params => {
+      this.datasetId = params['path'];
       this.path = '/mnt/' + params['path'];
       const path_fc = _.find(this.fieldSets[0].config, {name:'path'});
       path_fc.value = this.path;
@@ -265,31 +289,55 @@ export class DatasetPosixAclComponent implements OnDestroy {
     this.entityForm = entityEdit;
     this.recursive = entityEdit.formGroup.controls['recursive'];
     this.recursive_subscription = this.recursive.valueChanges.subscribe((value) => {
-      if (value === true) {
+      // This is here because valueChanges gets triggered when state is changed to disabled
+      if (value === true && value !== this.recursivePreviousValue) {
         this.dialogService.confirm(helptext.dataset_acl_recursive_dialog_warning,
          helptext.dataset_acl_recursive_dialog_warning_message)
         .subscribe((res) => {
           if (!res) {
             this.recursive.setValue(false);
+            this.recursivePreviousValue = false;
+          } else {
+            this.recursivePreviousValue = true;
           }
+          this.entityForm.setDisabled('recursive', this.disableRecursive);    
         });
       }
     });
     this.ws.call('filesystem.acl_is_trivial', [this.path]).subscribe(acl_is_trivial => {
       this.entityForm.setDisabled('stripacl', acl_is_trivial);
+      this.aclIsTrivial = acl_is_trivial;
     }, (err) => {
       new EntityUtils().handleWSError(this.entityForm, err);
     });
     this.stripacl = entityEdit.formGroup.controls['stripacl'];
     this.stripacl_subscription = this.stripacl.valueChanges.subscribe((value) => {
       if (value === true) {
+        // Store this value here because it changes on response to dialog
+        const isRecursiveChecked = entityEdit.formGroup.controls['recursive'].value;
         this.dialogService.confirm(helptext.dataset_acl_stripacl_dialog_warning,
          helptext.dataset_acl_stripacl_dialog_warning_message)
         .subscribe((res) => {
           if (!res) {
             this.stripacl.setValue(false);
           }
+          else {
+            // If user already checked recursive, just disable it
+            if (isRecursiveChecked) {
+              this.entityForm.setDisabled('recursive', true);    
+            } else {
+              // Otherwise set recursive to true
+              this.entityForm.formGroup.controls['recursive'].setValue(true);
+              // ...and set this boolean to disable recursive after its value changes
+              this.disableRecursive = true;
+            } 
+          }
         });
+      } else {
+        this.entityForm.formGroup.controls['recursive'].setValue(false);
+        this.disableRecursive = false;
+        this.entityForm.setDisabled('recursive', this.disableRecursive);   
+        this.recursivePreviousValue = false; 
       }
     });
     this.aces_fc = _.find(this.fieldConfig, {"name": "aces"});


### PR DESCRIPTION
Uses only one menu item, 'Edit Permissions' which takes the user to Permissions editor if ACL is trivial, and to the ACL editor if not. Adds a button for switching from Permissions Editor to ACL and (if ACL is trivial) back again. Makes 'Strip ACL a button with its own submission method