### PR TITLE
Make shark icon smaller

### DIFF
--- a/src/assets/styles/styles.css
+++ b/src/assets/styles/styles.css
@@ -808,12 +808,12 @@ div.hopscotch-bubble .hopscotch-nav-button.prev:hover {
 }
 .branding .app-logo {
     width: auto;
-    height: 40px;
+    height: 35px;
     margin-right: 8px;
 }
 .branding .app-logo-text {
     width: auto;
-    height: 40px;
+    height: 35px;
 }
 .app-user {
     text-align: center;


### PR DESCRIPTION
The shark icon is too big, and right up against the border when collapsed (labels not showing mode). I made it smaller by 5px and it looks so much better.