### PR TITLE
NAS-107326 Pointing docs link to truenas.com/docs

### DIFF
--- a/src/app/components/common/dialog/about/about-dialog.component.html
+++ b/src/app/components/common/dialog/about/about-dialog.component.html
@@ -15,7 +15,7 @@
 		<div class="line-item">
 			<div fxFlex="10%"><mat-icon class="bullet-icon">assignment</mat-icon></div>
 			<div fxFlex="90%" class="medium-font">{{ helptext.docsA | translate }} 
-				<a href="https://docs.ixsystems.com/" target="_blank" class="external-link">
+				<a href="https://www.truenas.com/docs/" target="_blank" class="external-link">
 					{{ helptext.docsB | translate }}</a> {{ helptext.docsC | translate }}
 			</div>
 		</div>


### PR DESCRIPTION
Here is a fix for https://jira.ixsystems.com/browse/NAS-107326 

Documentation link in About panel should point to https://www.truenas.com/docs/ same as the Guide link in the menu does.