### PR TITLE
NAS-107330 / 12.1 / Rename arcsat to arcstat

### DIFF
--- a/src/app/helptext/shell/shell.ts
+++ b/src/app/helptext/shell/shell.ts
@@ -4,7 +4,7 @@ export default {
   usage_tooltip: T(
     '<b>Ctrl+C</b> kills a foreground process.<br>\
     Many utilities are built-in:<br> <b>Iperf</b>,\
-    <b>Netperf</b>, <b>IOzone</b>, <b>arcsat</b>,\
+    <b>Netperf</b>, <b>IOzone</b>, <b>arcstat</b>,\
     <b>tw_cli</b>, <br><b>MegaCli</b>,\
     <b>freenas-debug</b>, <b>tmux</b>,\
     <b>Dmidecode</b>.'

--- a/src/app/helptext/vm/vm-cards/vm-cards.ts
+++ b/src/app/helptext/vm/vm-cards/vm-cards.ts
@@ -4,7 +4,7 @@ import {Validators} from '@angular/forms';
 export default {
 serial_shell_tooltip : '<b>Ctrl+C</b> kills a foreground process.<br>\
  Many utilities are built-in:<br><b>Iperf</b>,\
- <b>Netperf</b>, <b>IOzone</b>, <b>arcsat</b>,\
+ <b>Netperf</b>, <b>IOzone</b>, <b>arcstat</b>,\
  <b>tw_cli</b>, <br><b>MegaCli</b>,\
  <b>freenas-debug</b>, <b>tmux</b>,\
  <b>Dmidecode</b>.',


### PR DESCRIPTION
There seems to be a typo in in which arcstat is named arcsat.
This PRfixes said typo

Notes:
- Might want to backport this to 12 and 
- Possibly needs backporting to 11 as well

Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>