### PR TITLE
NAS-107326 / 12.0 / Change Documentation link (by Ornias1993)

### DIFF
--- a/src/app/components/common/dialog/about/about-dialog.component.html
+++ b/src/app/components/common/dialog/about/about-dialog.component.html
@@ -15,7 +15,7 @@
 		<div class="line-item">
 			<div fxFlex="10%"><mat-icon class="bullet-icon">assignment</mat-icon></div>
 			<div fxFlex="90%" class="medium-font">{{ helptext.docsA | translate }} 
-				<a href="https://docs.ixsystems.com/" target="_blank" class="external-link">
+				<a href="https://www.truenas.com/docs/" target="_blank" class="external-link">
 					{{ helptext.docsB | translate }}</a> {{ helptext.docsC | translate }}
 			</div>
 		</div>


### PR DESCRIPTION
Although the websites are (currently the same), TrueNAS help should preferably (for consistancy) point to the TrueNAS website.

This sets the Documentation link in the about dialog screen to:
https://www.truenas.com/docs/

Instead of:
https://docs.ixsystems.com/

Notes:
- Needs backport to 12.0

Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>

Original PR: https://github.com/freenas/webui/pull/4571