### PR TITLE
NAS-107442 / 11.3 / NAS-107442 Remove non-existing cols from preferred list (by dkmullen)

### DIFF
--- a/src/app/pages/common/entity/entity-table/entity-table.component.ts
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.ts
@@ -248,6 +248,15 @@ export class EntityTableComponent implements OnInit, AfterViewInit, OnDestroy {
           // If preferred columns have been set for THIS table...
           if (i.title === this.title) {
             this.conf.columns = i.cols;
+            // Remove columns from display and preferred cols if they don't exist in the table
+            let notFound = [];
+            this.conf.columns.forEach(col => {
+              let found = this.filterColumns.find(o => o.prop === col.prop);
+              if (!found) {
+                notFound.push(col.prop);
+              }
+            })
+            this.conf.columns = this.conf.columns.filter(col => !notFound.includes(col.prop));
           }
         });
         if (this.title === 'Users') {

--- a/src/app/pages/common/entity/entity-table/entity-table.component.ts
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.ts
@@ -257,6 +257,7 @@ export class EntityTableComponent implements OnInit, AfterViewInit, OnDestroy {
               }
             })
             this.conf.columns = this.conf.columns.filter(col => !notFound.includes(col.prop));
+            this.selectColumnsToShowOrHide();
           }
         });
         if (this.title === 'Users') {


### PR DESCRIPTION
The issue in the ticket was caused by removal from UI of pools column from disk table. This PR adds a check for missing columns and removes them from display

Original PR: https://github.com/freenas/webui/pull/4618