### PR TITLE
NAS-107655 / 20.10 / NAS-107655

### DIFF
--- a/src/app/core/components/widgets/widgetcpu/widgetcpu.component.html
+++ b/src/app/core/components/widgets/widgetcpu/widgetcpu.component.html
@@ -23,7 +23,7 @@
             </div>
         </mat-toolbar-row>
 
-          <div *ngIf="screenType == 'Desktop'" class="cpu-model top">{{cpuModel ? cpuModel : 'gathering info...' | translate}}</div>
+          <div *ngIf="screenType == 'Desktop'" class="cpu-model top">{{cpuModel ? cpuModel : 'Unknown CPU' | translate}}</div>
           
           <!-- Chart -->
           <div [ngClass]="{'mobile': screenType == 'Mobile'}" id="cpu-load-wrapper" fxLayout="row wrap" fxLayoutAlign="space-around center">
@@ -72,7 +72,7 @@
           <div fxFlex="65" class="bottom">
             <div class="list-subheader">  <span class="capitalize">{{"CPU Details" | translate}}</span></div>
             <mat-list>
-              <mat-list-item><span class="label">{{"Model:" | translate}}</span> &nbsp;&nbsp;{{cpuModel ? cpuModel : 'Gathering info...'}}</mat-list-item>
+              <mat-list-item><span class="label">{{"Model:" | translate}}</span> &nbsp;&nbsp;{{cpuModel ? cpuModel : 'Unknown CPU'}}</mat-list-item>
               <mat-list-item><span class="label">{{"Threads:" | translate}}</span> &nbsp;&nbsp;{{coreCount}}</mat-list-item>
             </mat-list>
           </div>

--- a/src/app/core/components/widgets/widgetsysinfo/widgetsysinfo.component.ts
+++ b/src/app/core/components/widgets/widgetsysinfo/widgetsysinfo.component.ts
@@ -188,7 +188,7 @@ export class WidgetSysInfoComponent extends WidgetComponent implements OnInit,On
         this.systemLogo = 'logo.svg';
         this.getFreeNASImage(evt.data.system_product);
         this.isFN = true;
-      } else if(this.product_type == 'Enterprise' && evt.data.license !== null) {
+      } else if(this.product_type.includes('ENTERPRISE') && evt.data.license !== null) {
         this.systemLogo = 'TrueNAS_Logomark_Black.svg';
         this.getTrueNASImage(evt.data.license.model);
         this.isFN = false;

--- a/src/app/core/components/widgets/widgetsysinfo/widgetsysinfo.component.ts
+++ b/src/app/core/components/widgets/widgetsysinfo/widgetsysinfo.component.ts
@@ -184,15 +184,19 @@ export class WidgetSysInfoComponent extends WidgetComponent implements OnInit,On
       } else {
         this.manufacturer = "other";
       }
-      if (this.product_type === 'CORE') {
+      if (this.product_type === 'CORE'){ 
         this.systemLogo = 'logo.svg';
         this.getFreeNASImage(evt.data.system_product);
         this.isFN = true;
-      } else {
+      } else if(this.product_type == 'Enterprise' && evt.data.license !== null) {
         this.systemLogo = 'TrueNAS_Logomark_Black.svg';
         this.getTrueNASImage(evt.data.license.model);
         this.isFN = false;
-      }    
+      } else if(this.product_type == 'SCALE') {
+        this.systemLogo = 'TrueNAS_Logomark_Black.svg';
+        this.getFreeNASImage(evt.data.system_product);
+        this.isFN = false;
+      }
 
       this.parseUptime();
       this.ready = true;


### PR DESCRIPTION
CPU widget should degrade to Unknown if model is null. WidgetSysInfo now has a case for Scale systems in product detection