### PR TITLE
"AFP" -> "SMB" in SMB helptext

### DIFF
--- a/src/app/helptext/sharing/smb/smb.ts
+++ b/src/app/helptext/sharing/smb/smb.ts
@@ -98,7 +98,7 @@ export const helptext_sharing_smb = {
  with examples can be found \
  <a href="https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#HOSTSALLOW" target="_blank">here</a>. <br><br> \
  If neither *Hosts Allow* or *Hosts Deny* contains \
- an entry, then AFP share access is allowed for any host. <br><br> \
+ an entry, then SMB share access is allowed for any host. <br><br> \
  If there is a *Hosts Allow* list but no *Hosts Deny* list, then only allow \
  hosts on the *Hosts Allow* list. <br><br> \
  If there is a *Hosts Deny* list but no *Hosts Allow* list, then allow all \
@@ -112,7 +112,7 @@ export const helptext_sharing_smb = {
     tooltip_hostsdeny: T('Enter a list of denied hostnames or IP addresses.\
  Separate entries by pressing <code>Enter</code>. \
  If neither *Hosts Allow* or *Hosts Deny* contains \
- an entry, then AFP share access is allowed for any host. <br><br> \
+ an entry, then SMB share access is allowed for any host. <br><br> \
  If there is a *Hosts Allow* list but no *Hosts Deny* list, then only allow \
  hosts on the *Hosts Allow* list. <br><br> \
  If there is a *Hosts Deny* list but no *Hosts Allow* list, then allow all \


### PR DESCRIPTION
This looked like a typo to me