### PR TITLE
NAS-107808 / 20.10 / Nas 107808

### DIFF
--- a/src/app/pages/system/general-settings/support/proactive/proactive.component.ts
+++ b/src/app/pages/system/general-settings/support/proactive/proactive.component.ts
@@ -19,31 +19,18 @@ export class ProactiveComponent {
   public contacts: any;
   public controls: any;
   public save_button_enabled: boolean;
-  protected columnsOnForm = 2;
   public title = helptext.proactive.title;
   public fieldConfig: FieldConfig[] = []
   public fieldSets: FieldSet[] = [
   {
-    name: 'title_row',
-    label: false,
-    width: '100%',
-    config:[
-      {
-        type: 'paragraph',
-        name: 'proactive_instructions',
-        paraText: helptext.proactive.instructions
-      },
-    ]
-  },
-  {
     name: 'col1',
     label: false,
-    width: '50%',
     config:[
       {
         type: 'paragraph',
         name: 'proactive_title',
-        paraText: helptext.proactive.primary_contact
+        paraText: helptext.proactive.primary_contact,
+        tooltip: helptext.proactive.instructions
       },
       {
         type: 'input',
@@ -106,7 +93,6 @@ export class ProactiveComponent {
   {
     name: 'col2',
     label: false,
-    width: '50%',
     config:[
       {
         type: 'paragraph',

--- a/src/app/pages/system/general-settings/support/support-licensed/support-form-licensed.component.ts
+++ b/src/app/pages/system/general-settings/support/support-licensed/support-form-licensed.component.ts
@@ -24,14 +24,12 @@ export class SupportFormLicensedComponent {
   public screenshot: any;
   public subs: any;
   public saveSubmitText = helptext.submitBtn;
-  protected columnsOnForm = 2;
   public title = helptext.ticket;
   public custActions: Array<any> = [];
   public fieldConfig: FieldConfig[] = []
   public fieldSets: FieldSet[] = [
     {
       name: 'column1',
-      width: '47%',
       label: false,
       config:[
         {
@@ -96,14 +94,7 @@ export class SupportFormLicensedComponent {
       ]
     },
     {
-      name: 'middle',
-      label: false,
-      width: '5%',
-      config:[]
-    },
-    {
     name: 'col2',
-    width: '47%',
     label: false,
     class: 'lowerme',
     config: [
@@ -121,12 +112,6 @@ export class SupportFormLicensedComponent {
           value: 'inquiry'
         },
         {
-          type : 'checkbox',
-          name : 'attach_debug',
-          placeholder : helptext.attach_debug.placeholder,
-          tooltip : helptext.attach_debug.tooltip,
-        },
-        {
           type : 'input',
           name : 'title',
           placeholder : helptext.title.placeholder,
@@ -142,6 +127,12 @@ export class SupportFormLicensedComponent {
           required: true,
           validation : helptext.body.validation,
           textAreaRows: 8
+        },
+        {
+          type : 'checkbox',
+          name : 'attach_debug',
+          placeholder : helptext.attach_debug.placeholder,
+          tooltip : helptext.attach_debug.tooltip,
         },
         {
           type: 'upload',

--- a/src/app/pages/system/general-settings/support/support-unlicensed/support-form-unlicensed.component.ts
+++ b/src/app/pages/system/general-settings/support/support-unlicensed/support-form-unlicensed.component.ts
@@ -25,6 +25,8 @@ export class SupportFormUnlicensedComponent {
   public saveSubmitText = helptext.submitBtn;
   public isEntity = true;
   public title = helptext.ticket;
+  protected isOneColumnForm = true;
+
   public fieldConfig: FieldConfig[] = []
   public fieldSets: FieldSet[] = [
     {
@@ -84,12 +86,6 @@ export class SupportFormUnlicensedComponent {
           disabled: true,
           isLoading: false
         },
-      ]
-    },
-    {
-    name: 'column2',
-    label: false,
-    config: [
         {
           type : 'checkbox',
           name : 'attach_debug',

--- a/src/app/pages/system/general-settings/support/support.component.html
+++ b/src/app/pages/system/general-settings/support/support.component.html
@@ -63,15 +63,40 @@
           <button id="update-license-btn" (click)="updateLicense()"mat-button color="primary">
             {{ licenseButtonText | translate }}
           </button>
-          <button id="file-ticket-btn" (click)="fileTicket()" mat-button color="default">
+          <button id="file-ticket-btn" (click)="fileTicket()" mat-button color="default" *ngIf="!hasLicense; else elseBlock">
             {{ ticketText | translate }}
           </button>
-          <button id="proactive-support-btn" (click)="openProactive()" mat-button color="default" *ngIf="hasLicense">
-            {{ proactiveText | translate }}
-          </button>
+          <ng-template #elseBlock>
+            <button 
+              mat-button color="default" 
+              [matMenuTriggerFor]="menu" 
+              class="menu-toggle" 
+              ix-auto
+              ix-auto-type="button"
+              ix-auto-identifier="SUPPORT">
+              <span>{{"Get Support" | translate}} <mat-icon class="menu-caret ">arrow_drop_down</mat-icon></span>
+            </button>
+            <mat-menu #menu="matMenu" overlapTrigger="false">
+              <button id="fileTicket"
+                mat-menu-item 
+                (click)="fileTicket()"
+                ix-auto
+                ix-auto-type="button"
+                ix-auto-identifier="{{ticketText}}">
+                <span>{{ticketText | translate}}</span>
+              </button>
+              <button id="proactiveSupport"
+                mat-menu-item 
+                (click)="openProactive()"
+                ix-auto
+                ix-auto-type="button"
+                ix-auto-identifier="{{proactiveText}}">
+                <span>{{proactiveText | translate}}</span>
+              </button>
+            </mat-menu>
+          </ng-template>
+
         </div>
-
-
       </div>
 
     </div>

--- a/src/app/pages/system/general-settings/support/support.component.html
+++ b/src/app/pages/system/general-settings/support/support.component.html
@@ -63,10 +63,7 @@
           <button id="update-license-btn" (click)="updateLicense()"mat-button color="primary">
             {{ licenseButtonText | translate }}
           </button>
-          <button id="file-ticket-btn" (click)="fileTicket()" mat-button color="default" *ngIf="!hasLicense; else elseBlock">
-            {{ ticketText | translate }}
-          </button>
-          <ng-template #elseBlock>
+          <ng-container *ngIf="hasLicense && !isProductImageRack; else elseBlock">
             <button 
               mat-button color="default" 
               [matMenuTriggerFor]="menu" 
@@ -94,6 +91,22 @@
                 <span>{{proactiveText | translate}}</span>
               </button>
             </mat-menu>
+          </ng-container>
+          <ng-template #elseBlock>
+            <button id="file-ticket-btn" (click)="fileTicket()" mat-button color="default"
+              ix-auto
+              ix-auto-type="button"
+              ix-auto-identifier="{{ticketText}}"
+            >
+              {{ ticketText | translate }}
+            </button>
+            <button id="proactive-btn" (click)="openProactive()" mat-button color="default" *ngIf="hasLicense"
+              ix-auto
+              ix-auto-type="button"
+              ix-auto-identifier="{{proactiveText}}"
+            >
+              {{ proactiveText | translate }}
+            </button>
           </ng-template>
 
         </div>

--- a/src/assets/styles/fn-styles.css
+++ b/src/assets/styles/fn-styles.css
@@ -1244,7 +1244,7 @@ div.hopscotch-bubble .hopscotch-nav-button.prev:hover {
     font-size: .7rem;
 }
 .mat-menu-panel.mat-menu-after.mat-menu-below {
-    min-width: 400px !important;
+    min-width: 140px !important;
     }
 .theme-list .mat-menu-item {
     width: 25px;


### PR DESCRIPTION
Sets unlicensed support to one column
Fixes alignment on two-column licensed-support form
Fixes alignment on Proactive support form by moving instructions from header to tooltip
Fixes display problem with three buttons on Support card and vertical image by using dropdown action button
Also undoes min-width setting which attempted to fix width for UPS service driver choices - making a new ticket for displaying those.
(Varying field lengths, misalligned password 'eye' icon are being fixed in another branch)

![Screenshot from 2020-10-08 14-54-27](https://user-images.githubusercontent.com/9504493/95588956-100e6500-0a12-11eb-831f-358e6cec4ac3.png)
![Screenshot from 2020-10-08 14-30-18](https://user-images.githubusercontent.com/9504493/95588985-1bfa2700-0a12-11eb-93aa-84307e5cd7d1.png)
![Screenshot from 2020-10-09 09-05-03](https://user-images.githubusercontent.com/9504493/95589303-8e6b0700-0a12-11eb-9d11-23e0e3a4acd4.png)
![Screenshot from 2020-10-08 14-45-40](https://user-images.githubusercontent.com/9504493/95588997-20bedb00-0a12-11eb-93fe-0164abb06c75.png)
![Screenshot from 2020-10-09 09-01-56](https://user-images.githubusercontent.com/9504493/95589024-2ae0d980-0a12-11eb-94fb-adf0c68448a4.png)
![Screenshot from 2020-10-09 09-07-56](https://user-images.githubusercontent.com/9504493/95589038-303e2400-0a12-11eb-86d8-b58d5e60b420.png)
Still three buttons on licensed rack-mounted server, which is most common case
![Screenshot from 2020-10-09 09-25-24](https://user-images.githubusercontent.com/9504493/95589047-33d1ab00-0a12-11eb-9ed4-7db5dc34c947.png)

