### PR TITLE
NAS-107896 / 12.0 / NAS-107896 Use click instead of routerlink for breadcrumbs

### DIFF
--- a/src/app/components/common/breadcrumb/breadcrumb.component.css
+++ b/src/app/components/common/breadcrumb/breadcrumb.component.css
@@ -24,6 +24,10 @@
   font-size: 1rem;
 }
 
+.clickable {
+  cursor: pointer;
+}
+
 .copyright-txt {
   margin: 0;
   padding: 0;

--- a/src/app/components/common/breadcrumb/breadcrumb.component.html
+++ b/src/app/components/common/breadcrumb/breadcrumb.component.html
@@ -3,7 +3,7 @@
     <li *ngFor="let part of routeParts"
       ix-auto ix-auto-type="option" ix-auto-identifier="{{part.breadcrumb}}">
       <span *ngIf="!part.disabled;else noclick">
-        <a [routerLink]="[part.url]">{{part.breadcrumb | translate}}</a>
+        <a (click)="gotoRoute(part.url)" class="clickable">{{part.breadcrumb | translate}}</a>
       </span>
       <ng-template #noclick>
         <a>{{part.breadcrumb | translate}}</a>

--- a/src/app/components/common/breadcrumb/breadcrumb.component.ts
+++ b/src/app/components/common/breadcrumb/breadcrumb.component.ts
@@ -77,4 +77,7 @@ export class BreadcrumbComponent implements OnInit {
     });
   }
 
+  gotoRoute(url) {
+    this.router.navigateByUrl(url);
+  }
 }


### PR DESCRIPTION
Fixes issue (as in datasets permissions, edit, acls and also zvol edit) where coded urls cause problems. A similar change was implemented recently in 11.3 (below) and this seems to work better

https://github.com/freenas/webui/commit/5f1e0413f4cc01a73cb2ba3fc5971f665f787be5#diff-122221e4e53fbcd8526591888e67e068