### PR TITLE
Fix support typo in settings

### DIFF
--- a/src/app/helptext/system/support.ts
+++ b/src/app/helptext/system/support.ts
@@ -201,7 +201,7 @@ export const helptext_system_support = {
  TrueNAS Forums</a> - Find answers from other users in the forums.'),
 
   licensing: T('<a href="https://www.ixsystems.com/support/" target="_blank">\
- TrueNAS Liscensing</a> - Learn more about enterprise-grade support.'),
+ TrueNAS Licensing</a> - Learn more about enterprise-grade support.'),
 
   updateTxt: T('Update License'),
   enterTxt: T('Enter License'),


### PR DESCRIPTION
Liscensing -> Licensing on settings-support overview

Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>