### PR TITLE
NAS-107876 / 11.3 / Nas 107876 v11.3

### DIFF
--- a/src/app/helptext/storage/volumes/volume-list.ts
+++ b/src/app/helptext/storage/volumes/volume-list.ts
@@ -86,5 +86,11 @@ pool_lock_warning_paratext_b: T("</i>.\
 permissions_edit_msg: T('Root dataset permissions cannot be edited.'),
 acl_edit_msg: T('Root dataset ACL cannot be edited.'),
 
-unlock_msg: T('Unlock the pool with either a passphrase or a recovery key.')
+unlock_msg: T('Unlock the pool with either a passphrase or a recovery key.'),
+
+geli_error: {
+    title: T('Error'),
+    message: T('This geli-encrypted pool failed to decrypt.'),
+    button: T('Close')
+}
 }

--- a/src/app/helptext/storage/volumes/volume-list.ts
+++ b/src/app/helptext/storage/volumes/volume-list.ts
@@ -86,11 +86,5 @@ pool_lock_warning_paratext_b: T("</i>.\
 permissions_edit_msg: T('Root dataset permissions cannot be edited.'),
 acl_edit_msg: T('Root dataset ACL cannot be edited.'),
 
-unlock_msg: T('Unlock the pool with either a passphrase or a recovery key.'),
-
-geli_error: {
-    title: T('Error'),
-    message: T('This geli-encrypted pool failed to decrypt.'),
-    button: T('Close')
-}
+unlock_msg: T('Unlock the pool with either a passphrase or a recovery key.')
 }

--- a/src/app/pages/storage/volumes/volumes-list/volumes-list.component.html
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list.component.html
@@ -21,13 +21,17 @@
             <span [style.margin-right.px]="5">
               <i class="material-icons green-icon" *ngIf="row.status==='HEALTHY'">check_circle</i>
               <i class="material-icons orange-icon" *ngIf="row.status==='DEGRADED'">warning</i>
-              <i class="material-icons yellow-icon" *ngIf="row.status==='LOCKED'">lock</i>
+              <i [ngClass]="['material-icons', row.vol_encrypt===1 && !row.is_decrypted ? 'red-icon' : 'yellow-icon']" 
+                *ngIf="row.status==='LOCKED'">lock</i>
               <i class="material-icons blue-icon" *ngIf="row.status==='UNKNOWN'">help</i>
               <i class="material-icons red-icon" 
                 *ngIf="row.status!=='HEALTHY' && row.status!=='DEGRADED' && row.status!=='LOCKED' && row.status!=='UNKNOWN'" 
               >cancel</i>
             </span>
             {{row.status}}<span *ngIf="row.usedStr && row.availStr">{{row.usedStr}} {{"Used" | translate}} / {{row.availStr}} {{"Free" | translate}}</span>
+            <span *ngIf="row.vol_encrypt===1 && !row.is_decrypted" style="margin-left:5px">
+              {{ 'This geli-encrypted pool failed to decrypt.' | translate }}
+            </span>
           </mat-panel-description>
         </mat-expansion-panel-header>
         <div fxLayoutAlign="end start" class="icon-row">
@@ -42,7 +46,7 @@
             >
             <app-entity-table-actions [icon_name]="'lock_outline'" [entity]="actionEncryptedComponent" [row]="row"></app-entity-table-actions>
           </div>
-          <div *ngIf="row.vol_encrypt > 0 && !row.is_decrypted" 
+          <div *ngIf="row.vol_encrypt > 1 && !row.is_decrypted" 
               class="encryption_icon pool-icon" 
               title="Unlock" 
               name="unlock"

--- a/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
@@ -308,116 +308,111 @@ export class VolumesListTableConfig implements InputTableConf {
   }
 
   unlockAction(row1) {
-    if (!row1.is_decrypted && row1.vol_encrypt === 1) {
-      this.dialogService.confirm(helptext.geli_error.title, helptext.geli_error.message, true,
-        helptext.geli_error.button,false,'','','','',true)
-    } else {
-      const self = this;
-      this.storageService.poolUnlockServiceChoices(row1.id).pipe(
-        map(serviceChoices => {
-          return {
-            title: "Unlock " + row1.name,
-            fieldConfig: [
-              {
-                type: 'paragraph',
-                name: 'unlock_msg',
-                paraText: helptext.unlock_msg,
-              },
-              {
-                type : 'input',
-                inputType: 'password',
-                name : 'passphrase',
-                togglePw: true,
-                required: true,
-                placeholder: helptext.unlockDialog_password_placeholder,
-              },
-              {
-                type: 'upload',
-                message: self.messageService,
-                updater: self.key_file_updater,
-                parent: self,
-                hideButton: true, 
-                name: 'key',
-                required: true,
-                placeholder: helptext.unlockDialog_recovery_key_placeholder,
-                tooltip: helptext.unlockDialog_recovery_key_tooltip,
-              },
-              {
-                type: 'select',
-                name: 'services_restart',
-                placeholder: helptext.unlockDialog_services_placeholder,
-                tooltip: helptext.unlockDialog_services_tooltip,
-                multiple: true,
-                value: serviceChoices.map(choice => choice.value),
-                options: serviceChoices
-              }
-            ],
-            afterInit: function(entityDialog) {
-                  self.message_subscription = self.messageService.messageSourceHasNewMessage$.subscribe((message)=>{
-                    entityDialog.formGroup.controls['key'].setValue(message);
-                  });
-                  // these disabled booleans are here to prevent recursion errors, disabling only needs to happen once
-                  let keyDisabled = false;
-                  let passphraseDisabled = false;
-                  entityDialog.formGroup.controls['passphrase'].valueChanges.subscribe((passphrase) => {
-                    if (!passphraseDisabled) {
-                      if (passphrase && passphrase !== '') {
-                        keyDisabled = true;
-                        entityDialog.setDisabled('key', true, true);
-                      } else {
-                        keyDisabled = false;
-                        entityDialog.setDisabled('key', false, false);
-                      }
-                    }
-                  });
-                  entityDialog.formGroup.controls['key'].valueChanges.subscribe((key) => {
-                    if (!keyDisabled) {
-                      if (key && !passphraseDisabled) {
-                        passphraseDisabled = true;
-                        entityDialog.setDisabled('passphrase', true, true);
-                      }
-                    }
-                  });
+    const self = this;
+    this.storageService.poolUnlockServiceChoices(row1.id).pipe(
+      map(serviceChoices => {
+        return {
+          title: "Unlock " + row1.name,
+          fieldConfig: [
+            {
+              type: 'paragraph',
+              name: 'unlock_msg',
+              paraText: helptext.unlock_msg,
             },
-            saveButtonText: T("Unlock"),
-            customSubmit: function (entityDialog) {
-              let done = false;
-              const value = entityDialog.formValue;
-              const params = [row1.id, {passphrase: value.passphrase, services_restart: value.services_restart}]
-              let dialogRef = self.mdDialog.open(EntityJobComponent, {data: {"title":"Unlocking Pool"}, disableClose: true});
-              if(value.key) {
-                params[1]['recoverykey'] = true;
-                const formData: FormData = new FormData();
-                formData.append('data', JSON.stringify({
-                  "method": "pool.unlock",
-                  "params": params
-                }));
-                formData.append('file', self.subs.file);
-                dialogRef.componentInstance.wspost(self.subs.apiEndPoint, formData);
-              } else {
-                dialogRef.componentInstance.setCall('pool.unlock', params);
-                dialogRef.componentInstance.submit();
-              }
-              dialogRef.componentInstance.success.subscribe((res) => {
-                if (!done) {
-                  dialogRef.close(false);
-                  entityDialog.dialogRef.close(true);
-                  self.parentVolumesListComponent.repaintMe();
-                  self.dialogService.Info(T("Unlock"), row1.name + T(" has been unlocked."), '300px', "info", true);
-                  done = true;
-                }
-              });
-              dialogRef.componentInstance.failure.subscribe((res) => {
-                dialogRef.close(false);
-                new EntityUtils().handleWSError(self, res ,self.dialogService);
-              });
+            {
+              type : 'input',
+              inputType: 'password',
+              name : 'passphrase',
+              togglePw: true,
+              required: true,
+              placeholder: helptext.unlockDialog_password_placeholder,
+            },
+            {
+              type: 'upload',
+              message: self.messageService,
+              updater: self.key_file_updater,
+              parent: self,
+              hideButton: true, 
+              name: 'key',
+              required: true,
+              placeholder: helptext.unlockDialog_recovery_key_placeholder,
+              tooltip: helptext.unlockDialog_recovery_key_tooltip,
+            },
+            {
+              type: 'select',
+              name: 'services_restart',
+              placeholder: helptext.unlockDialog_services_placeholder,
+              tooltip: helptext.unlockDialog_services_tooltip,
+              multiple: true,
+              value: serviceChoices.map(choice => choice.value),
+              options: serviceChoices
             }
-          };
-        }),
-        switchMap(conf => this.dialogService.dialogForm(conf))
-      ).subscribe(() => {})
-    }
-
+          ],
+          afterInit: function(entityDialog) {
+                self.message_subscription = self.messageService.messageSourceHasNewMessage$.subscribe((message)=>{
+                  entityDialog.formGroup.controls['key'].setValue(message);
+                });
+                // these disabled booleans are here to prevent recursion errors, disabling only needs to happen once
+                let keyDisabled = false;
+                let passphraseDisabled = false;
+                entityDialog.formGroup.controls['passphrase'].valueChanges.subscribe((passphrase) => {
+                  if (!passphraseDisabled) {
+                    if (passphrase && passphrase !== '') {
+                      keyDisabled = true;
+                      entityDialog.setDisabled('key', true, true);
+                    } else {
+                      keyDisabled = false;
+                      entityDialog.setDisabled('key', false, false);
+                    }
+                  }
+                });
+                entityDialog.formGroup.controls['key'].valueChanges.subscribe((key) => {
+                  if (!keyDisabled) {
+                    if (key && !passphraseDisabled) {
+                      passphraseDisabled = true;
+                      entityDialog.setDisabled('passphrase', true, true);
+                    }
+                  }
+                });
+          },
+          saveButtonText: T("Unlock"),
+          customSubmit: function (entityDialog) {
+            let done = false;
+            const value = entityDialog.formValue;
+            const params = [row1.id, {passphrase: value.passphrase, services_restart: value.services_restart}]
+            let dialogRef = self.mdDialog.open(EntityJobComponent, {data: {"title":"Unlocking Pool"}, disableClose: true});
+            if(value.key) {
+              params[1]['recoverykey'] = true;
+              const formData: FormData = new FormData();
+              formData.append('data', JSON.stringify({
+                "method": "pool.unlock",
+                "params": params
+              }));
+              formData.append('file', self.subs.file);
+              dialogRef.componentInstance.wspost(self.subs.apiEndPoint, formData);
+            } else {
+              dialogRef.componentInstance.setCall('pool.unlock', params);
+              dialogRef.componentInstance.submit();
+            }
+            dialogRef.componentInstance.success.subscribe((res) => {
+              if (!done) {
+                dialogRef.close(false);
+                entityDialog.dialogRef.close(true);
+                self.parentVolumesListComponent.repaintMe();
+                self.dialogService.Info(T("Unlock"), row1.name + T(" has been unlocked."), '300px', "info", true);
+                done = true;
+              }
+            });
+            dialogRef.componentInstance.failure.subscribe((res) => {
+              dialogRef.close(false);
+              new EntityUtils().handleWSError(self, res ,self.dialogService);
+            });
+          }
+        };
+      }),
+      switchMap(conf => this.dialogService.dialogForm(conf))
+    ).subscribe(() => {})
+    
   }
 
   getPoolData(poolId: number) {


### PR DESCRIPTION
When geli-locked pool fails to decrypt, the lock turns red and a message appears, and the lock icon that opens the unlock dialog is not shown. Create a test case with:
midclt call datastore.update storage.volume 5 '{"vol_encrypt": 1}' 
(5 being the vol number)

The yellow lock is for a pw-protected pool, and has the icon on the right for unlocking. The red lock is a geli-encrypted pool that failed to decrypt.
![image](https://user-images.githubusercontent.com/9504493/95776078-9f757b80-0c91-11eb-9c55-9fe6c02f5009.png)
