### PR TITLE
NAS-107876 / 12.0 / Nas 107876 12

### DIFF
--- a/src/app/pages/storage/volumes/volumes-list/volumes-list.component.html
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list.component.html
@@ -20,6 +20,7 @@
             <span *ngIf="row.encrypt > 0">
               {{'(Legacy Encryption)' | translate}}
             </span>
+
           </mat-panel-title>
           <mat-panel-description>
             {{row.status}}&nbsp;
@@ -30,7 +31,8 @@
               <i class="material-icons green-icon" *ngIf="row.healthy; else status;">check_circle</i>
               <ng-template #status>
                 <i class="material-icons orange-icon" *ngIf="row.status==='DEGRADED'">warning</i>
-                <i class="material-icons yellow-icon" *ngIf="row.status==='LOCKED'">lock</i>
+                <i class="material-icons" [class]="row.encrypt===1 && !row.is_decrypted ? 'red-icon' : 'yellow-icon'" 
+                  *ngIf="row.status==='LOCKED'">lock</i>
                 <i class="material-icons blue-icon" *ngIf="row.status==='FAULTED'">help</i>
                 <i class="material-icons red-icon" 
                   *ngIf="row.status!=='DEGRADED' && row.status!=='LOCKED' && row.status!=='FAULTED'"
@@ -42,6 +44,9 @@
               {{row.usedStr}} {{"Used" | translate}} 
               &nbsp;<span style="opacity:0.5;">|</span>&nbsp;
               {{row.availStr}} {{"Free" | translate}}
+            </span>
+            <span *ngIf="row.encrypt===1 && !row.is_decrypted">
+              {{ 'This geli-encrypted pool failed to decrypt.' | translate }}
             </span>
           </mat-panel-description>
         </mat-expansion-panel-header>

--- a/src/app/pages/storage/volumes/volumes-list/volumes-list.component.html
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list.component.html
@@ -31,7 +31,7 @@
               <i class="material-icons green-icon" *ngIf="row.healthy; else status;">check_circle</i>
               <ng-template #status>
                 <i class="material-icons orange-icon" *ngIf="row.status==='DEGRADED'">warning</i>
-                <i class="material-icons" [class]="row.encrypt===1 && !row.is_decrypted ? 'red-icon' : 'yellow-icon'" 
+                <i [ngClass]="['material-icons', row.vol_encrypt===1 && !row.is_decrypted ? 'red-icon' : 'yellow-icon']" 
                   *ngIf="row.status==='LOCKED'">lock</i>
                 <i class="material-icons blue-icon" *ngIf="row.status==='FAULTED'">help</i>
                 <i class="material-icons red-icon" 


### PR DESCRIPTION
When geli-locked pool fails to decrypt, the lock turns red and a message appears.
 Create a test case with:
midclt call datastore.update storage.volume 5 '{"vol_encrypt": 1}'
(5 being the vol number)

The yellow lock is for a pw-protected pool. The red lock is a geli-encrypted pool that failed to decrypt.

![Screenshot from 2020-10-12 12-32-23](https://user-images.githubusercontent.com/9504493/95776698-d4360280-0c92-11eb-9bc3-27d851c84181.png)