### PR TITLE
NAS-107884 / 20.10 / NAS-107884

### DIFF
--- a/src/app/helptext/network/interfaces/interfaces-list.ts
+++ b/src/app/helptext/network/interfaces/interfaces-list.ts
@@ -44,5 +44,5 @@ ha_enabled_delete_msg: T("Deleting interfaces while HA is enabled is not allowed
 ha_enabled_text: T("Cannot edit while HA is enabled."),
 go_to_ha: T("Go to HA settings"),
 
-delete_dialog_text: T("Network connectivity will be interrupted. ")
+delete_dialog_text: T("This change can interrupt connectivity and must be tested before making permanent. ")
 }


### PR DESCRIPTION
Update delete_dialog_text to reflect disruptive changes must be tested before saving. Ticket is currently not assigned a Fix Version so let me know if this needs to be back-ported to 12.0.