### PR TITLE
NAS-107951 / 12.0 / NAS-107951 Make room for all menu items

### DIFF
--- a/src/app/components/common/navigation/navigation.component.ts
+++ b/src/app/components/common/navigation/navigation.component.ts
@@ -85,6 +85,9 @@ export class NavigationComponent extends ViewControllerComponent implements OnIn
           const targetMenu = this.navService.enterpriseFeatures[i];
           _.find(_.find(menuItem, { state: targetMenu.menu }).sub, { state : targetMenu.sub}).disabled = false;
         }
+
+        _.find(_.find(menuItem, { state: 'system' }).sub, { state : 'two-factor'}).disabled = true;
+
       }
  
       this.core.register({

--- a/src/assets/styles/fn-styles.css
+++ b/src/assets/styles/fn-styles.css
@@ -950,7 +950,7 @@ div.hopscotch-bubble .hopscotch-nav-button.prev:hover {
     transition: all .3s cubic-bezier(.35,0,.25,1);
 }
 .sidebar-panel.mat-sidenav .sidebar-list-item.open {
-    max-height: 1000px;
+    max-height: 1100px;
     overflow: visible;
     height: auto;
 }


### PR DESCRIPTION
Allows room for all 22 possible menu items under System, although 21 is probably the max need under current restrictions. Seems to have no ill effect on shorter lists. Should not be an issue with the new menu on SCALE

ALSO: Removes 2FA from the menu if the product type is enterprise