### PR TITLE
NAS-107988 / 20.10 / NAS-107988 reset users/groups when table refreshes

### DIFF
--- a/src/app/helptext/account/user-list.ts
+++ b/src/app/helptext/account/user-list.ts
@@ -23,6 +23,6 @@ deleteDialog: {
     title: T('Delete User '),
     deleteGroup_placeholder: T('Delete user primary group '),
     message: T('Delete User '),
-    saveButtonText: T('DELETE'),
+    saveButtonText: T('Delete'),
 }
 }

--- a/src/app/pages/account/users/user-list/user-list.component.ts
+++ b/src/app/pages/account/users/user-list/user-list.component.ts
@@ -179,6 +179,8 @@ export class UserListComponent {
 
   resourceTransformIncomingRestData(d) {
     let data = Object.assign([], d);
+    this.usr_lst = [];
+    this.grp_lst = [];
     this.usr_lst.push(data);
     this.ws.call('group.query').subscribe((res)=>{
       this.grp_lst.push(res);


### PR DESCRIPTION
Resets user/group lists when when the slide-in menu closes and refreshes the table. This isn't an issue for previous versions because the form navigated to the table causing a complete page reload.