### PR TITLE
NAS-108211 / 12.0 / NAS-108211

### DIFF
--- a/src/app/core/classes/hardware/m50.ts
+++ b/src/app/core/classes/hardware/m50.ts
@@ -5,7 +5,7 @@ import { ChassisView } from './chassis-view';
 
 export class M50 extends Chassis {
 
-  constructor(){
+  constructor(rearChassis: boolean = false){
     super();
     this.model = "m50";
 
@@ -15,21 +15,21 @@ export class M50 extends Chassis {
     this.front.driveTrayBackgroundPath = "assets/images/hardware/m50/m50_960w_drivetray_bg.png" 
     this.front.driveTrayHandlePath = "assets/images/hardware/m50/m50_960w_drivetray_handle.png"
     this.front.totalDriveTrays = 24;
-    this.front.slotRange = { start: 5, end: 28 };
 
-    this.rear = new ChassisView();
-    this.rear.driveTrays.scale = {x: 0.88, y: 0.88};
-    this.rear.driveTraysOffsetX = -16;
-    this.rear.driveTraysOffsetY = -65;
-    this.rear.container = new PIXI.Container();
-    this.rear.chassisPath = "assets/images/hardware/m50/m50_rear_960w.png";
-    this.rear.driveTrayBackgroundPath = "assets/images/hardware/m50/m50_960w_drivetray_bg.png" 
-    this.rear.driveTrayHandlePath = "assets/images/hardware/m50/m50_960w_drivetray_handle.png"
-    this.rear.columns = 1;
-    this.rear.rows = 4;
-
-    this.rear.totalDriveTrays = 4;
-    this.rear.slotRange = { start: 1, end: 4 };
+    if(rearChassis){
+      this.rear = new ChassisView();
+      this.rear.driveTrays.scale = {x: 0.88, y: 0.88};
+      this.rear.driveTraysOffsetX = -16;
+      this.rear.driveTraysOffsetY = -65;
+      this.rear.container = new PIXI.Container();
+      this.rear.chassisPath = "assets/images/hardware/m50/m50_rear_960w.png";
+      this.rear.driveTrayBackgroundPath = "assets/images/hardware/m50/m50_960w_drivetray_bg.png" 
+      this.rear.driveTrayHandlePath = "assets/images/hardware/m50/m50_960w_drivetray_handle.png"
+      this.rear.columns = 1;
+      this.rear.rows = 4;
+  
+      this.rear.totalDriveTrays = 4;
+    }
   }
 
 }

--- a/src/app/core/classes/system-profiler.ts
+++ b/src/app/core/classes/system-profiler.ts
@@ -317,4 +317,5 @@ export class SystemProfiler {
   getEnclosureLabel(key){
     return this.enclosures[key].label == this.enclosures[key].name ? this.enclosures[key].label : this.enclosures[key].model;
   }
+
 }

--- a/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks-mini.component.ts
+++ b/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks-mini.component.ts
@@ -43,6 +43,8 @@ export class EnclosureDisksMiniComponent extends EnclosureDisksComponent {
     super(el, core, sanitizer, mediaObserver, cdr, dialogService)
     this.pixiWidth = 960 * 0.6; // PIXI needs an explicit number. Make sure the template flex width matches this
     this.pixiHeight = 480;
+
+    this.startDiskTempListener();
   }
 
   createExtractedEnclosure(profile){

--- a/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks.component.ts
+++ b/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks.component.ts
@@ -581,7 +581,6 @@ export class EnclosureDisksComponent implements AfterContentInit, OnChanges, OnD
   }
 
   setCurrentView(opt: string){
-    //console.log("setCurrentView(" + opt + ")");
     if(this.currentView){ this.exitingView = this.currentView; }
     // pools || status || expanders || details
 

--- a/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks.component.ts
+++ b/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks.component.ts
@@ -966,7 +966,7 @@ export class EnclosureDisksComponent implements AfterContentInit, OnChanges, OnD
       }));
 
       // Convert color to rgb value
-      let cc = this.hexToRGB(this.theme.cyan);
+      let cc = this.themeUtils.convertToRGB(this.theme.cyan);
       const animation = keyframes({
         values: [
           { borderWidth: 0, borderColor: 'rgb(' + cc.rgb[0] +', ' + cc.rgb[1] +', ' + cc.rgb[2] +')' },
@@ -978,30 +978,6 @@ export class EnclosureDisksComponent implements AfterContentInit, OnChanges, OnD
 
       this.identifyBtnRef = { animation: animation, originalState: startShadow, styler: elementBorder};
 
-    }
-  }
-
-  hexToRGB(str) {
-    var spl = str.split('#');
-    var hex = spl[1];
-    if(hex.length == 3){
-      hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
-    }
-
-    var value = '';
-    var rgb = [];
-    for(let i = 0; i < 6; i++){
-      let mod = i % 2;
-      let even = 0;
-      value += hex[i];
-      if(mod !== even){
-        rgb.push(parseInt(value, 16))
-        value = '';
-      }
-    }
-    return {
-      hex:hex,
-      rgb:rgb
     }
   }
 

--- a/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks.component.ts
+++ b/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks.component.ts
@@ -152,7 +152,6 @@ export class EnclosureDisksComponent implements AfterContentInit, OnChanges, OnD
   ){
     
     this.themeUtils = new ThemeUtils();
-
     core.register({observerClass: this, eventName: 'DisksChanged'}).subscribe((evt:CoreEvent) => {
       // REACT TO EVENT PROVIDED BY DISK.QUERY
     });
@@ -191,6 +190,29 @@ export class EnclosureDisksComponent implements AfterContentInit, OnChanges, OnD
 
   clearDisk(){
     this.setCurrentView(this.defaultView);
+  }
+
+  protected startDiskTempListener(){
+
+    this.core.register({observerClass: this, eventName: 'DiskTemperatures'}).subscribe((evt:CoreEvent) => {
+      if(!this.chassis || !this.chassis[this.view] || !this.chassis[this.view].driveTrayObjects){ return; }
+      
+      let clone: Temperature = Object.assign({}, evt.data);
+      clone.values = {};
+      clone.keys = [];
+      
+      this.chassis[this.view].driveTrayObjects.forEach((dt, index) => {
+      const disk = this.findDiskBySlotNumber(parseInt(dt.id));
+      if(disk){
+        clone.keys.push(disk.name);
+        clone.values[disk.name] = evt.data.values[disk.name];
+      }
+      });
+      
+      this.temperatures = clone;
+    });
+    this.core.emit({name:"DiskTemperaturesSubscribe", sender:this});
+
   }
 
   ngAfterContentInit() {


### PR DESCRIPTION
Fixes too many concurrent calls error on enclosure UI. This was caused by the DiskTemperatures subscription living in the base class. This is a feature only on the MINI line but the service was being activated on the rack mount models too.

The rear drive bays on the M50 were referencing the drives that belong to the front. Rear drive bay detection has been reworked and rear drives now correctly reference the disks that belong to that chassis.