### PR TITLE
NAS-108212 / 12.0 / NAS-108212

### DIFF
--- a/src/app/core/components/widgets/widgetcpu/widgetcpu.component.ts
+++ b/src/app/core/components/widgets/widgetcpu/widgetcpu.component.ts
@@ -365,8 +365,8 @@ export class WidgetCpuComponent extends WidgetComponent implements AfterViewInit
         color = this.stripVar(this.currentTheme[cssVar])
       }
       
-      const bgRGB = this.utils.hexToRGB(this.currentTheme[color]).rgb;
-      const borderRGB = this.utils.hexToRGB(this.currentTheme[color]).rgb;
+      const bgRGB = this.utils.convertToRGB(this.currentTheme[color]).rgb;
+      const borderRGB = this.utils.convertToRGB(this.currentTheme[color]).rgb;
 
       ds.backgroundColor = this.rgbToString(bgRGB, 0.85);
       ds.borderColor = this.rgbToString(bgRGB);
@@ -399,7 +399,7 @@ export class WidgetCpuComponent extends WidgetComponent implements AfterViewInit
     let txtColor = currentTheme.fg2;
 
     // convert to rgb
-    let rgb = this.utils.hexToRGB(txtColor).rgb;
+    let rgb = this.utils.convertToRGB(txtColor).rgb;
 
     // return rgba
     let rgba =  "rgba(" + rgb[0] + "," + rgb[1] + "," + rgb[2] + "," + opacity + ")";


### PR DESCRIPTION
Use the more flexible convertToRGB method. It checks the input value type and will not throw an error when given rgba values.