### PR TITLE
NAS-107419 / 20.12 / Nas 107419 (by dkmullen)

### DIFF
--- a/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
@@ -1578,6 +1578,31 @@ export class VolumesListTableConfig implements InputTableConf {
             }
           });
         }
+        if (rowData.encrypted && rowData.key_loaded && rowData.encryption_root === rowData.name) {
+          const fileName = "dataset_" + rowData.name + "_keys.json";
+          const mimetype = 'text/plain';
+          encryption_actions.push({
+            id: rowData.name,
+            name: T('Export Key'),
+            label: T('Export Key'),
+            onClick: (row) => {
+              this.loader.open();
+              this.ws.call('core.download', ['pool.dataset.export_keys', [row.name], fileName]).subscribe(res => {
+                this.loader.close();
+                const url = res[1];
+                this.storageService.streamDownloadFile(this.http, url, fileName, mimetype).subscribe(file => {
+                  if(res !== null && res !== "") {
+                    this.storageService.downloadBlob(file, fileName);
+                  }
+                });
+              }, (e) => {
+                this.loader.close();
+                new EntityUtils().handleWSError(this, e, this.dialogService);
+              });
+            }
+          });
+
+        }
       }
     }
     return encryption_actions;


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x ecd9b091563855caffbb2556c01496643442cf92
    git cherry-pick -x be88b1756cc58e11747cc5995551b39cb5694bdc
    git cherry-pick -x 01d5f4cb622f07a751ccd5458c90083a1cd14492

Adds ability to use a single-dataset key for unlocking

Original PR: https://github.com/freenas/webui/pull/4817