### PR TITLE
NAS-108500 / 12.0 / fix pCloud hostname is not sent when verifying credentials

### DIFF
--- a/src/app/pages/system/CloudCredentials/cloudcredentials-form/cloudcredentials-form.component.ts
+++ b/src/app/pages/system/CloudCredentials/cloudcredentials-form/cloudcredentials-form.component.ts
@@ -1270,10 +1270,6 @@ export class CloudCredentialsFormComponent {
         }
         value['attributes'] = attributes;
 
-        if (value.provider === 'PCLOUD') {
-          delete value.attributes.hostname;
-        }
-
         if (value.attributes.private_key && value.attributes.private_key === 'NEW') {
           this.makeNewKeyPair(value);
         } else {


### PR DESCRIPTION
pCloud hostname is not sent when verifying credentials