### PR TITLE
NAS-108464 / 12.0 / Fix issue with text in Safari

### DIFF
--- a/src/app/core/components/widgets/widgetcpu/widgetcpu.component.css
+++ b/src/app/core/components/widgets/widgetcpu/widgetcpu.component.css
@@ -240,3 +240,7 @@
   font-weight:500;
 }
 
+.no-flicker {
+  -webkit-backface-visibility: hidden;
+  -webkit-transform: rotateY(0deg);
+}

--- a/src/app/core/components/widgets/widgetcpu/widgetcpu.component.html
+++ b/src/app/core/components/widgets/widgetcpu/widgetcpu.component.html
@@ -36,7 +36,7 @@
               <mat-spinner [diameter]="40" style="margin: 0 auto;"></mat-spinner>
             </ng-template>
 
-            <div *ngIf="screenType == 'Desktop'" fxFlex="53" fxFlex.xs="100" id="cpu-load-cores">
+            <div *ngIf="screenType == 'Desktop'" fxFlex="53" fxFlex.xs="100" id="cpu-load-cores" class="no-flicker">
                 <mat-list>
                   <mat-list-item>
                     <span class="label"><strong>{{"Threads" | translate}}:</strong></span> &nbsp;&nbsp;{{coreCount}} {{"threads" | translate}}
@@ -68,7 +68,7 @@
           </div>
 
 
-        <div *ngIf="screenType == 'Mobile'" fxLayout="column" class="mobile" >
+        <div *ngIf="screenType == 'Mobile'" fxLayout="column" class="mobile no-flicker">
           <div fxFlex="65" class="bottom">
             <div class="list-subheader">  <span class="capitalize">{{"CPU Details" | translate}}</span></div>
             <mat-list>
@@ -79,7 +79,7 @@
         </div>
 
 
-        <div *ngIf="screenType == 'Mobile'" fxLayout="column" class="mobile" >
+        <div *ngIf="screenType == 'Mobile'" fxLayout="column" class="mobile no-flicker">
           <div fxFlex="65" class="bottom">
             <div class="list-subheader">  <span class="capitalize">{{"Stats Per Thread" | translate}}</span></div>
             <mat-list>


### PR DESCRIPTION
The issue with stacking text due to `-webkit-transform-style: preserve-3d;` on https://github.com/freenas/webui/blob/f475e51734c9b79eb49649218510b226b0d02769/src%2Fassets%2Fstyles%2Fegret_overrides.css#L197