### PR TITLE
NAS-108500 / 21.02 / fix pCloud hostname is not sent when verifying credentials (by AlexKarpov98)

### DIFF
--- a/src/app/pages/credentials/backup-credentials/forms/cloud-credentials-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/forms/cloud-credentials-form.component.ts
@@ -1251,10 +1251,6 @@ export class CloudCredentialsFormComponent {
         }
         value['attributes'] = attributes;
 
-        if (value.provider === 'PCLOUD') {
-          delete value.attributes.hostname;
-        }
-
         if (value.attributes.private_key && value.attributes.private_key === 'NEW') {
           this.makeNewKeyPair(value);
         } else {


### PR DESCRIPTION
pCloud hostname is not sent when verifying credentials

Original PR: https://github.com/freenas/webui/pull/4934